### PR TITLE
Allow for Pred to be used with safe, ifElse, unless, when and filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ While the `composeB` can be used to create a composition of two functions, there
 #### `curry : ((a, b, c) -> d) -> a -> b -> c -> d`
 Pass this function a function and it will return you a function that can be called in any form that you require until all arguments have been provided. For example if you pass a function: `f : (a, b, c) -> d` you get back a function that can be called in any combination, such as: `f(x, y, z)`, `f(x)(y)(z)`, `f(x, y)(z)`, or even `f(x)(y, z)`. This is great for doing partial application on functions for maximum reusability.
 
-#### `ifElse : (a -> Boolean) -> (a -> b) -> (a -> c) -> a -> b | c`
+#### `ifElse : ((a -> Boolean) | Pred) -> (a -> b) -> (a -> c) -> a -> b | c`
 Whenever you need to modify a value based some condition and want a functional way to do it without some imperative `if` statement, then reach for `ifElse`. This function take a predicate (some function that returns a Boolean) and two functions. The first is what is executed when the predicate is true, the second on a false condition. This will return a function ready to take a value to run through the predicate. After the value is evaluated, it will be ran through it's corresponding function, returning the result as the final result. This function comes in really handy when creating lifting functions for Sum Types (like `Either` or `Maybe`).
 
 #### `inspect : a -> String`
@@ -151,14 +151,14 @@ There comes a time where the values you have in a `List` or an `Array` are not i
 #### `pipe : ((a -> b), (b -> c), ..., (y -> z)) -> a -> z`
 If you find yourself not able to come to terms with doing the typical right-to-left, then `crocks` provides a means to accommodate you. This function does the same thing as `compose`, the only difference is it allows you define your flows in a left-to-right manner.
 
-#### `safe : (a -> Boolean) -> a -> Maybe a`
+#### `safe : ((a -> Boolean) | Pred) -> a -> Maybe a`
 When using a `Maybe`, it is a common practice to lift into a `Just` or a `Nothing` depending on a condition on the value to be lifted.  It is so common that it warrants a function, and that function is called `safe`. Provide a predicate (a function that returns a Boolean) and a value to be lifted. The value will be evaluated against the predicate, and will lift it into a `Just` if true and a `Nothing` if false.
 
 
-#### `unless : (a -> Boolean) -> (a -> b) -> a -> a | b`
+#### `unless : ((a -> Boolean) | Pred) -> (a -> b) -> a -> a | b`
 There may come a time when you need to adjust a value when a condition is false, that is where `unless` can come into play. Just provide a predicate function (a function that returns a Boolean) and a function to apply your desired modification. This will get you back a function that when you pass it a value, it will evaluate it and if false, will run your value through the provided function. Either the original or modified value will be returned depending on the result of the predicate. Check out `when` for a negated version of this function.
 
-#### `when : (a -> Boolean) -> (a -> b) -> a -> b | a`
+#### `when : ((a -> Boolean) | Pred) -> (a -> b) -> a -> b | a`
 There may come a time when you need to adjust a value when a condition is true, that is where `when` can come into play. Just provide a predicate function (a function that returns a Boolean) and a function to apply your desired modification. This will get you back a function that when you pass it a value, it will evaluate it and if true, will run your value through the provided function. Either the original or modified value will be returned depending on the result of the predicate. Check out `unless` for a negated version of this function.
 
 #### Point-free Functions
@@ -203,7 +203,7 @@ These functions provide a very clean way to build out very simple functions and 
 | `either` | `(a -> c) -> (b -> c) -> m a b -> c` |
 | `evalWith` | `a -> m -> b` |
 | `execWith` | `a -> m -> b` |
-| `filter` | `(a -> Boolean) -> m a -> m a` |
+| `filter` | `((a -> Boolean) | Pred) -> m a -> m a` |
 | `first` | `(a -> b) -> m (a, c) -> m (b, c)` |
 | `fst` | `m a b -> a` |
 | `head` | `m a -> Maybe a` |

--- a/crocks/List.js
+++ b/crocks/List.js
@@ -121,10 +121,14 @@ function List(xs) {
     return xs.reduce(fn, i)
   }
 
-  function filter(fn) {
-    if(!isFunction(fn)) {
-      throw new TypeError('List.filter: Function required')
+  function filter(pred) {
+    if(!(isFunction(pred) || isType('Pred', pred))) {
+      throw new TypeError('List.filter: Pred or predicate function required')
     }
+
+    const fn = isFunction(pred)
+      ? pred
+      : pred.runWith
 
     return reduce(
       (x, y) => fn(y) ? x.concat(x.of(y)) : x,

--- a/crocks/List.spec.js
+++ b/crocks/List.spec.js
@@ -14,6 +14,7 @@ const isFunction = require('../internal/isFunction')
 
 const MockCrock = require('../test/MockCrock')
 const Maybe     = require('./Maybe')
+const Pred      = require('./Pred')
 
 const List = require('./List')
 
@@ -258,6 +259,7 @@ test('List filter errors', t => {
   t.throws(filter({}), TypeError, 'throws with an object')
 
   t.doesNotThrow(filter(noop), 'allows a function')
+  t.doesNotThrow(filter(Pred(noop)), 'allows a Pred')
 
   t.end()
 })
@@ -268,8 +270,14 @@ test('List filter functionality', t => {
   const bigNum = x => typeof x === 'number' && x > 10
   const justStrings = x => typeof x === 'string'
 
-  t.same(m.filter(bigNum).value(), [ 34 ], 'filters for bigNums')
-  t.same(m.filter(justStrings).value(), [ 'string' ], 'filters for strings')
+  const bigNumPred = Pred(bigNum)
+  const justStringsPred = Pred(justStrings)
+
+  t.same(m.filter(bigNum).value(), [ 34 ], 'filters for bigNums with function')
+  t.same(m.filter(justStrings).value(), [ 'string' ], 'filters for strings with function')
+
+  t.same(m.filter(bigNumPred).value(), [ 34 ], 'filters for bigNums with Pred')
+  t.same(m.filter(justStringsPred).value(), [ 'string' ], 'filters for strings with Pred')
 
   t.end()
 })

--- a/funcs/ifElse.js
+++ b/funcs/ifElse.js
@@ -2,18 +2,23 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const isFunction = require('../internal/isFunction')
+const isType = require('../internal/isType')
 const curry = require('./curry')
 
 function ifElse(pred, f, g) {
-  if(!isFunction(pred)) {
-    throw new TypeError('ifElse: Predicate function required for first argument')
+  if(!(isFunction(pred) || isType('Pred', pred))) {
+    throw new TypeError('ifElse: Pred or predicate function required for first argument')
   }
 
   if(!isFunction(f) || !isFunction(g)) {
     throw new TypeError('ifElse: Functions required for second and third arguments')
   }
 
-  return x => !!pred(x) ? f(x) : g(x)
+  const func = isFunction(pred)
+    ? pred
+    : pred.runWith
+
+  return x => !!func(x) ? f(x) : g(x)
 }
 
 module.exports = curry(ifElse)

--- a/funcs/ifElse.spec.js
+++ b/funcs/ifElse.spec.js
@@ -9,6 +9,8 @@ const isFunction = require('../internal/isFunction')
 const identity = require('../combinators/identity')
 const constant = require('../combinators/constant')
 
+const Pred = require('../crocks/Pred')
+
 const ifElse = require('./ifElse')
 
 test('ifElse', t => {
@@ -49,6 +51,12 @@ test('ifElse', t => {
   t.throws(f(noop, noop, {}), 'throws with an object in third argument')
   t.throws(f(noop, noop, []), 'throws with an array in third argument')
 
+  const func = x => !!x
+  const pred = Pred(func)
+
+  t.doesNotThrow(f(func, noop, noop), 'allows a predicate function in first argument')
+  t.doesNotThrow(f(pred, noop, noop), 'allows a Pred in first argument')
+
   const g = ifElse(noop, noop, noop)
   const h = ifElse(constant(true), identity, noop, 11)
 
@@ -58,10 +66,31 @@ test('ifElse', t => {
   t.end()
 })
 
-test('ifElse functionality', t => {
+test('ifElse predicate function', t => {
   const tPath = sinon.spy(identity)
   const fPath = sinon.spy(constant(10))
   const pred = x => x >= 10
+
+  const f = ifElse(pred, tPath, fPath)
+
+  const tResult = f(11)
+
+  t.ok(tPath.calledOnce, 'true function called when true')
+  t.ok(tPath.returned(tResult), 'returns the result of the true function when true')
+
+  const fResult = f(5)
+
+  t.ok(fPath.calledOnce, 'false function called when false')
+  t.ok(tPath.calledOnce, 'true function not called when false')
+  t.ok(fPath.returned(fResult), 'returns the result of the false function when false')
+
+  t.end()
+})
+
+test('ifElse Pred', t => {
+  const tPath = sinon.spy(identity)
+  const fPath = sinon.spy(constant(10))
+  const pred = Pred(x => x >= 10)
 
   const f = ifElse(pred, tPath, fPath)
 

--- a/funcs/safe.js
+++ b/funcs/safe.js
@@ -2,7 +2,9 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const isFunction = require('../internal/isFunction')
+const isType = require('../internal/isType')
 const curry = require('./curry')
+const ifElse = require('./ifElse')
 
 const Maybe = require('../crocks/Maybe')
 
@@ -10,11 +12,14 @@ const Nothing = Maybe.Nothing
 const Just = Maybe.Just
 
 function safe(pred) {
-  if(!isFunction(pred)) {
-    throw new TypeError('safe: Predicate function required for first argument')
+  if(!(isFunction(pred) || isType('Pred', pred))) {
+    throw new TypeError('safe: Pred or predicate function required for first argument')
   }
+  const fn = isFunction(pred)
+    ? pred
+    : pred.runWith
 
-  return x => !!pred(x) ? Just(x) : Nothing()
+  return ifElse(fn, Just, Nothing)
 }
 
 module.exports = curry(safe)

--- a/funcs/safe.spec.js
+++ b/funcs/safe.spec.js
@@ -8,6 +8,8 @@ const isFunction = require('../internal/isFunction')
 
 const constant = require('../combinators/constant')
 
+const Pred = require('../crocks/Pred')
+
 const safe = require('./safe')
 
 test('safe', t => {
@@ -27,16 +29,31 @@ test('safe', t => {
   t.throws(f([]), 'throws with an array in first argument')
 
   t.doesNotThrow(f(noop), 'allows a function in first argument')
+  t.doesNotThrow(f(Pred(noop)), 'allows a Pred in first argument')
 
   t.end()
 })
 
-test('safe functionality', t => {
+test('safe predicate function', t => {
   const pred = x => !!x
 
   const f = safe(pred)
 
   const fResult = f(false).option('nothing')
+  const tResult = f('just').option('nothing')
+
+  t.equals(fResult, 'nothing', 'returns a Nothing when false')
+  t.equals(tResult, 'just', 'returns a Just when true')
+
+  t.end()
+})
+
+test('safe Pred', t => {
+  const pred = Pred(x => !!x)
+
+  const f = safe(pred)
+
+  const fResult = f(0).option('nothing')
   const tResult = f('just').option('nothing')
 
   t.equals(fResult, 'nothing', 'returns a Nothing when false')

--- a/funcs/unless.js
+++ b/funcs/unless.js
@@ -2,18 +2,23 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const isFunction = require('../internal/isFunction')
+const isType = require('../internal/isType')
 const curry = require('./curry')
 
 function unless(pred, f) {
-  if(!isFunction(pred)) {
-    throw new TypeError('unless: Predicate function required for first argument')
+  if(!(isFunction(pred) || isType('Pred', pred))) {
+    throw new TypeError('unless: Pred or predicate function required for first argument')
   }
 
   if(!isFunction(f)) {
     throw new TypeError('unless: Function required for second argument')
   }
 
-  return x => !pred(x) ? f(x) : x
+  const func = isFunction(pred)
+    ? pred
+    : pred.runWith
+
+  return x => !func(x) ? f(x) : x
 }
 
 module.exports = curry(unless)

--- a/funcs/unless.spec.js
+++ b/funcs/unless.spec.js
@@ -8,6 +8,8 @@ const isFunction = require('../internal/isFunction')
 
 const constant = require('../combinators/constant')
 
+const Pred = require('../crocks/Pred')
+
 const unless = require('./unless')
 
 test('unless', t => {
@@ -37,6 +39,12 @@ test('unless', t => {
   t.throws(f(noop, {}), 'throws with an object in second argument')
   t.throws(f(noop, []), 'throws with an array in second argument')
 
+  const func = x => !!x
+  const pred = Pred(func)
+
+  t.doesNotThrow(f(func, noop), 'allows a predicate function in first argument')
+  t.doesNotThrow(f(pred, noop), 'allows a Pred in first argument')
+
   const g = unless(noop, noop)
   const h = unless(constant(false), x => x * 2, 11)
 
@@ -46,9 +54,28 @@ test('unless', t => {
   t.end()
 })
 
-test('unless functionality', t => {
+test('unless predicate function', t => {
   const func = sinon.spy(constant('called'))
   const pred = x => !!x
+
+  const f = unless(pred, func)
+
+  const fResult = f(false)
+
+  t.ok(func.calledOnce, 'function called when false')
+  t.ok(func.returned(fResult), 'returns the result of the function when false')
+
+  const tResult = f(true)
+
+  t.ok(func.calledOnce, 'function not called when true')
+  t.equal(tResult, true, 'just returns value when true')
+
+  t.end()
+})
+
+test('unless Pred', t => {
+  const func = sinon.spy(constant('called'))
+  const pred = Pred(x => !!x)
 
   const f = unless(pred, func)
 

--- a/funcs/when.js
+++ b/funcs/when.js
@@ -2,18 +2,23 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const isFunction = require('../internal/isFunction')
+const isType = require('../internal/isType')
 const curry = require('./curry')
 
 function when(pred, f) {
-  if(!isFunction(pred)) {
-    throw new TypeError('when: Predicate function required for first argument')
+  if(!(isFunction(pred) || isType('Pred', pred))) {
+    throw new TypeError('when: Pred or predicate function required for first argument')
   }
 
   if(!isFunction(f)) {
     throw new TypeError('when: Function required for second argument')
   }
 
-  return x => !!pred(x) ? f(x) : x
+  const func = isFunction(pred)
+    ? pred
+    : pred.runWith
+
+  return x => !!func(x) ? f(x) : x
 }
 
 module.exports = curry(when)

--- a/funcs/when.spec.js
+++ b/funcs/when.spec.js
@@ -6,6 +6,8 @@ const noop = helpers.noop
 const bindFunc = helpers.bindFunc
 const isFunction = require('../internal/isFunction')
 
+const Pred = require('../crocks/Pred')
+
 const constant = require('../combinators/constant')
 
 const when = require('./when')
@@ -37,6 +39,12 @@ test('when', t => {
   t.throws(f(noop, {}), 'throws with an object in second argument')
   t.throws(f(noop, []), 'throws with an array in second argument')
 
+  const func = x => !!x
+  const pred = Pred(func)
+
+  t.doesNotThrow(f(func, noop), 'allows a predicate function in first argument')
+  t.doesNotThrow(f(pred, noop), 'allows a Pred in first argument')
+
   const g = when(noop, noop)
   const h = when(constant(true), x => x * 2, 11)
 
@@ -46,9 +54,28 @@ test('when', t => {
   t.end()
 })
 
-test('when functionality', t => {
+test('when predicate function', t => {
   const func = sinon.spy(constant('called'))
   const pred = x => !!x
+
+  const f = when(pred, func)
+
+  const tResult = f(true)
+
+  t.ok(func.calledOnce, 'function called when true')
+  t.ok(func.returned(tResult), 'returns the result of the function when true')
+
+  const fResult = f(false)
+
+  t.ok(func.calledOnce, 'function not called when false')
+  t.equal(fResult, false, 'just returns value when false')
+
+  t.end()
+})
+
+test('when Pred', t => {
+  const func = sinon.spy(constant('called'))
+  const pred = Pred(x => !!x)
 
   const f = when(pred, func)
 

--- a/pointfree/filter.js
+++ b/pointfree/filter.js
@@ -3,13 +3,19 @@
 
 const curry = require('../funcs/curry')
 const isFunction = require('../internal/isFunction')
+const isType = require('../internal/isType')
 
 // filter :: Foldable f => (a -> Boolean) -> f a -> f a
-function filter(fn, m) {
-  if(!isFunction(fn)) {
-    throw new TypeError('filter: Function required for first argument')
+function filter(pred, m) {
+  if(!(isFunction(pred) || isType('Pred', pred))) {
+    throw new TypeError('filter: Pred or predicate function required for first argument')
   }
   else if(m && isFunction(m.filter)) {
+
+    const fn = isFunction(pred)
+      ? pred
+      : pred.runWith
+
     return m.filter(fn)
   }
   else {

--- a/pointfree/filter.spec.js
+++ b/pointfree/filter.spec.js
@@ -8,6 +8,8 @@ const isFunction = require('../internal/isFunction')
 
 const identity = require('../combinators/identity')
 
+const Pred = require('../crocks/Pred')
+
 const filter = require('./filter')
 
 test('filter pointfree', t => {
@@ -39,6 +41,9 @@ test('filter pointfree', t => {
 
   t.doesNotThrow(m(noop, f), 'allows a function and Foldable container')
   t.doesNotThrow(m(noop, []), 'allows a function and an array (also Foldable)')
+
+  t.doesNotThrow(m(Pred(noop), f), 'allows a Pred and Foldable container')
+  t.doesNotThrow(m(Pred(noop), []), 'allows a Pred and an array (also Foldable)')
 
   t.end()
 })


### PR DESCRIPTION
## Rex Man...I mean... Predicate Day
![](http://sd.keepcalm-o-matic.co.uk/i/keep-calm-its-predicate-day.png)

Well now that we have dat handy dandy `Pred` I guess we should put it to work. Updated the following predicate based functions to accept and run a given `Pred`:

* `filter` & `List.filter`
* `ifElse`
* `safe`
* `unless`
* `when`