### PR TITLE
Move inspect into internal from helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ const { Maybe, compose, curry, map } = crocks
 // I feel ya, try this:
 
 import Maybe from 'crocks/crocks/Maybe'
-import compose from 'crocks/funcs/compose'
-import curry from 'crocks/funcs/curry'
+import compose from 'crocks/helpers/compose'
+import curry from 'crocks/helpers/curry'
 import map from 'crocks/pointfree/map'
 
 // you can of course do the same with require statements:
@@ -52,7 +52,7 @@ There are (5) classifications of "things" included in this library:
 
 * Combinators (`crocks/combinators`): A collection of functions that are used for working with other functions. These do things like compose (2) functions together, or flip arguments on a function. They typically either take a function, return a function or a bit a both. These are considered the glue that holds the mighty house of `Crocks` together and a valuable aid in writing reusable code.
 
-* Helper Functions (`crocks/funcs`): All other support functions that are either convenient versions of combinators or not even combinators at all cover this group.
+* Helper Functions (`crocks/helpers`): All other support functions that are either convenient versions of combinators or not even combinators at all cover this group.
 
 * Point-free Functions (`crocks/pointfree`): Wanna use these ADTs in a way that you never have to reference the actual data being worked on? Well here is where you will find all of these functions to do that. For every algebra available on both the `Crocks` and `Monoids` there is a function here.
 
@@ -101,7 +101,7 @@ All `Monoids` provide `empty` and `type` function on their Constructors as well 
 Seems really silly, but is quite useful for a lot of things. It takes a function and a value and then returns the result of that function with the argument applied.
 
 #### `composeB : (b -> c) -> (a -> b) -> a -> c`
-Provides a means to describe a composition between two functions. it takes two functions and an value. Given `composeB(f, g)`, which is read `f` after `g`, it will return a function that will take value `a` and apply it to `g`, passing the result as an argument to `f`, and will finally return the result of `f`. (This allows only two functions, if you want to avoid things like: `composeB(composeB(f, g), composeB(h, i))` then check out `crocks/funcs/compose`.)
+Provides a means to describe a composition between two functions. it takes two functions and an value. Given `composeB(f, g)`, which is read `f` after `g`, it will return a function that will take value `a` and apply it to `g`, passing the result as an argument to `f`, and will finally return the result of `f`. (This allows only two functions, if you want to avoid things like: `composeB(composeB(f, g), composeB(h, i))` then check out `crocks/helpers/compose`.)
 
 #### `constant : a -> b -> a`
 This is a very handy dandy function, used a lot. Pass it any value and it will give you back a function that will return that same value no matter what you pass it.

--- a/crocks/Arrow.js
+++ b/crocks/Arrow.js
@@ -3,8 +3,8 @@
 
 const isFunction = require('../internal/isFunction')
 const isType = require('../internal/isType')
+const _inspect = require('../internal/inspect')
 
-const _inspect = require('../helpers/inspect')
 const compose = require('../helpers/compose')
 
 const identity = require('../combinators/identity')

--- a/crocks/Const.js
+++ b/crocks/Const.js
@@ -4,7 +4,7 @@
 const isFunction = require('../internal/isFunction')
 const isType = require('../internal/isType')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/crocks/Either.js
+++ b/crocks/Either.js
@@ -5,13 +5,12 @@ const isApplicative = require('../internal/isApplicative')
 const isFunction = require('../internal/isFunction')
 const isType = require('../internal/isType')
 
+const _inspect = require('../internal/inspect')
 const defineUnion = require('../internal/defineUnion')
 
 const constant = require('../combinators/constant')
 const composeB = require('../combinators/composeB')
 const identity = require('../combinators/identity')
-
-const _inspect = require('../helpers/inspect')
 
 const _either = defineUnion({ Left: [ 'a' ], Right: [ 'b' ] })
 

--- a/crocks/IO.js
+++ b/crocks/IO.js
@@ -4,7 +4,7 @@
 const isFunction = require('../internal/isFunction')
 const isType = require('../internal/isType')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const composeB = require('../combinators/composeB')
 const constant = require('../combinators/constant')

--- a/crocks/Identity.js
+++ b/crocks/Identity.js
@@ -5,7 +5,7 @@ const isFunction = require('../internal/isFunction')
 const isType = require('../internal/isType')
 const isApplicative = require('../internal/isApplicative')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 const composeB = require('../combinators/composeB')

--- a/crocks/List.js
+++ b/crocks/List.js
@@ -6,9 +6,10 @@ const isArray = require('../internal/isArray')
 const isType = require('../internal/isType')
 const isApplicative = require('../internal/isApplicative')
 
+const _inspect = require('../internal/inspect')
+
 const constant = require('../combinators/constant')
 
-const _inspect = require('../helpers/inspect')
 const _concat = require('../pointfree/concat')
 
 const Maybe = require('./Maybe')

--- a/crocks/Maybe.js
+++ b/crocks/Maybe.js
@@ -5,13 +5,12 @@ const isApplicative = require('../internal/isApplicative')
 const isFunction = require('../internal/isFunction')
 const isType = require('../internal/isType')
 
+const _inspect = require('../internal/inspect')
 const defineUnion = require('../internal/defineUnion')
 
+const composeB = require('../combinators/composeB')
 const constant = require('../combinators/constant')
 const identity = require('../combinators/identity')
-const composeB = require('../combinators/composeB')
-
-const _inspect = require('../helpers/inspect')
 
 const _maybe = defineUnion({ Nothing: [], Just: [ 'a' ] })
 

--- a/crocks/Pair.js
+++ b/crocks/Pair.js
@@ -5,7 +5,7 @@ const isType = require('../internal/isType')
 const isFunction = require('../internal/isFunction')
 const isSemigroup = require('../internal/isSemigroup')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/crocks/Pred.js
+++ b/crocks/Pred.js
@@ -4,7 +4,7 @@
 const isFunction = require('../internal/isFunction')
 const isType = require('../internal/isType')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 const composeB = require('../combinators/composeB')

--- a/crocks/Reader.js
+++ b/crocks/Reader.js
@@ -4,7 +4,7 @@
 const isFunction = require('../internal/isFunction')
 const isType = require('../internal/isType')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const composeB = require('../combinators/composeB')
 const constant = require('../combinators/constant')

--- a/crocks/Star.js
+++ b/crocks/Star.js
@@ -4,7 +4,7 @@
 const isFunction = require('../internal/isFunction')
 const isFunctor = require('../internal/isFunctor')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 const compose = require('../helpers/compose')

--- a/crocks/State.js
+++ b/crocks/State.js
@@ -4,7 +4,7 @@
 const isFunction = require('../internal/isFunction')
 const isType = require('../internal/isType')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/crocks/Unit.js
+++ b/crocks/Unit.js
@@ -4,7 +4,7 @@
 const isFunction = require('../internal/isFunction')
 const isType = require('../internal/isType')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/crocks/Writer.js
+++ b/crocks/Writer.js
@@ -5,7 +5,7 @@ const isType = require('../internal/isType')
 const isFunction = require('../internal/isFunction')
 const isMonoid = require('../internal/isMonoid')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/internal/inspect.js
+++ b/internal/inspect.js
@@ -1,10 +1,10 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const isArray = require('../internal/isArray')
-const isObject = require('../internal/isObject')
-const isString = require('../internal/isString')
-const isFunction = require('../internal/isFunction')
+const isArray = require('./isArray')
+const isObject = require('./isObject')
+const isString = require('./isString')
+const isFunction = require('./isFunction')
 
 function arrayInspect(xs) {
   return xs.length

--- a/internal/inspect.spec.js
+++ b/internal/inspect.spec.js
@@ -3,7 +3,7 @@ const helpers = require('../test/helpers')
 
 const noop = helpers.noop
 const constant = require('../combinators/constant')
-const isFunction = require('../internal/isFunction')
+const isFunction = require('./isFunction')
 
 const inspect = require('./inspect')
 

--- a/monoids/All.js
+++ b/monoids/All.js
@@ -5,7 +5,7 @@ const isType = require('../internal/isType')
 const isFunction = require('../internal/isFunction')
 const isNil = require('../internal/isNil')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/monoids/Any.js
+++ b/monoids/Any.js
@@ -5,7 +5,7 @@ const isType = require('../internal/isType')
 const isFunction = require('../internal/isFunction')
 const isNil = require('../internal/isNil')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/monoids/Assign.js
+++ b/monoids/Assign.js
@@ -6,7 +6,7 @@ const isObject = require('../internal/isObject')
 const isFunction = require('../internal/isFunction')
 const isNil = require('../internal/isNil')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/monoids/Max.js
+++ b/monoids/Max.js
@@ -5,7 +5,7 @@ const isType = require('../internal/isType')
 const isNumber = require('../internal/isNumber')
 const isNil = require('../internal/isNil')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/monoids/Min.js
+++ b/monoids/Min.js
@@ -5,7 +5,7 @@ const isType = require('../internal/isType')
 const isNumber = require('../internal/isNumber')
 const isNil = require('../internal/isNil')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/monoids/Prod.js
+++ b/monoids/Prod.js
@@ -6,7 +6,7 @@ const isNumber = require('../internal/isNumber')
 const isFunction = require('../internal/isFunction')
 const isNil = require('../internal/isNil')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/monoids/Sum.js
+++ b/monoids/Sum.js
@@ -6,7 +6,7 @@ const isNumber = require('../internal/isNumber')
 const isFunction = require('../internal/isFunction')
 const isNil = require('../internal/isNil')
 
-const _inspect = require('../helpers/inspect')
+const _inspect = require('../internal/inspect')
 
 const constant = require('../combinators/constant')
 

--- a/test/LastMonoid.js
+++ b/test/LastMonoid.js
@@ -1,6 +1,7 @@
 const identity = require('../combinators/identity')
 const constant = require('../combinators/constant')
-const _inspect = require('../helpers/inspect')
+
+const _inspect = require('../internal/inspect')
 
 const _type = constant('Last')
 


### PR DESCRIPTION
## Some internal medicine
![](https://s-media-cache-ak0.pinimg.com/564x/dc/07/36/dc0736846202bcace90a873b2421854d.jpg)

This PR is the last required portion to address [issue#17](https://github.com/evilsoft/crocks/issues/17). 

As `inspect` is no longer available on the Public API, seems odd to keep it inside of `helpers`. This PR moves it to the `internal` folder in the project.