### PR TITLE
Allow `traverse` and `sequence` to accept arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import curry from 'crocks/helpers/curry'
 import map from 'crocks/pointfree/map'
 
 // you can of course do the same with require statements:
-const Maybe = require('crocks/crocks/Maybe')
+const All = require('crocks/monoids/All')
 ...
 ```
 
@@ -109,7 +109,7 @@ Provides a means to describe a composition between two functions. it takes two f
 This is a very handy dandy function, used a lot. Pass it any value and it will give you back a function that will return that same value no matter what you pass it.
 
 #### `flip : (a -> b -> c) -> b -> a -> c`
-This little function just takes a function and returns a function that takes the first two parameters in reverse. Once can compose flip calls down the line to flip all, or some of the other parameters if there are more than two. Mix and match to your :heart:s desire.
+This little function just takes a function and returns a function that takes the first two parameters in reverse. One can compose flip calls down the line to flip all, or some of the other parameters if there are more than two. Mix and match to your :heart:'s desire.
 
 #### `identity :  a -> a`
 This function and `constant` are the workhorses of writing code with this library. It quite simply is just a function that when you pass it something, it returns that thing right back to you. So simple, I will leave it as an exercise to reason about why this is so powerful and important.
@@ -151,7 +151,7 @@ These two functions are very handy for combining an entire `List` or `Array` of 
 There comes a time where the values you have in a `List` or an `Array` are not in the type that is needed for the `Monoid` you want to combine with. These two functions can be used to `map` some transforming function from a given type into the type needed for the `Monoid`. In essence, this function will run each value through the function before it lifts the value into the `Monoid`, before `concat` is applied. The difference between the two is that `mconcatMap` returns the result inside the `Monoid` used to combine them. Where `mreduceMap` returns the bare value itself.
 
 #### `not : ((a -> Boolean) | Pred) -> a -> Boolean`
-When you need to negate a predicate function or a `Pred`, but want a new predicate function that does the negation, then `not` is going to get you what you need. Using `not` will allow you to stay as declarative as possible. Just pass `not` your predicate function or `Pred` and it will give you back a predicate function ready for insertion into your flow. All predicate based functions in `crocks` take either a `Pred` or predicate function, so it should be easy to swap between the two.
+When you need to negate a predicate function or a `Pred`, but want a new predicate function that does the negation, then `not` is going to get you what you need. Using `not` will allow you to stay as declarative as possible. Just pass `not` your predicate function or a `Pred`, and it will give you back a predicate function ready for insertion into your flow. All predicate based functions in `crocks` take either a `Pred` or predicate function, so it should be easy to swap between the two.
 
 #### `pipe : ((a -> b), (b -> c), ..., (y -> z)) -> a -> z`
 If you find yourself not able to come to terms with doing the typical right-to-left, then `crocks` provides a means to accommodate you. This function does the same thing as `compose`, the only difference is it allows you define your flows in a left-to-right manner.
@@ -246,11 +246,11 @@ These functions provide a very clean way to build out very simple functions and 
 | `run` | `m a -> b` |
 | `runWith` | `a -> m -> b` |
 | `second` | `(b -> c) -> m (a, b) -> m (a, c)` |
-| `sequence` | `Apply f => (b -> f b) -> m (f a) -> f (m a)` |
+| `sequence` | `Applicative f => (b -> f b) -> m (f a) -> f (m a)` |
 | `snd` | `m a b -> b` |
 | `swap` | `m a b -> m b a` |
 | `tail` | `m a -> Maybe (m a)` |
-| `traverse` | `Apply f => (c -> f c) -> (a -> f b) -> m (f a) -> f (m b)` |
+| `traverse` | `Applicative f => (c -> f c) -> (a -> f b) -> m (f a) -> f (m b)` |
 | `value` | `m a -> a` |
 
 ##### Datatypes
@@ -281,9 +281,9 @@ These functions provide a very clean way to build out very simple functions and 
 | `run` | `IO` |
 | `runWith` | `Arrow`, `Pred`, `Reader`, `Star`, `State` |
 | `second` | `Arrow` |
-| `sequence` | `Either`, `Identity`, `List`, `Maybe` |
+| `sequence` | `Array`, `Either`, `Identity`, `List`, `Maybe` |
 | `snd` | `Pair` |
 | `swap` | `Pair` |
 | `tail` | `Array`, `List`, `String` |
-| `traverse` | `Either`, `Identity`, `List`, `Maybe` |
+| `traverse` | `Array`, `Either`, `Identity`, `List`, `Maybe` |
 | `value` | `Arrow`, `Const`, `Either`, `Identity`, `List`, `Pair`, `Pred`, `Unit`, `Writer` |

--- a/pointfree/sequence.js
+++ b/pointfree/sequence.js
@@ -3,17 +3,35 @@
 
 const curry = require('../helpers/curry')
 
+const isApplicative = require('../predicates/isApplicative')
+const isArray = require('../predicates/isArray')
 const isFunction = require('../predicates/isFunction')
+
+const concat = require('./concat')
+
+function runSequence(acc, x) {
+  if(!isApplicative(x)) {
+    throw new TypeError('sequence: Must wrap Applicatives')
+  }
+
+  return x
+    .map(v => concat([ v ]))
+    .ap(acc)
+}
 
 function sequence(af, m) {
   if(!isFunction(af)) {
     throw new TypeError('sequence: Applicative function required for first argument')
   }
-  else if(!(m && isFunction(m.sequence))) {
-    throw new TypeError('sequence: Traversable required for second argument')
+  else if((m && isFunction(m.sequence))) {
+    return m.sequence(af)
   }
-
-  return m.sequence(af)
+  else if((isArray(m))) {
+    return m.reduce(runSequence, af([]))
+  }
+  else {
+    throw new TypeError('sequence: Traversable or Array required for second argument')
+  }
 }
 
 module.exports = curry(sequence)

--- a/pointfree/sequence.spec.js
+++ b/pointfree/sequence.spec.js
@@ -5,17 +5,19 @@ const helpers = require('../test/helpers')
 const bindFunc = helpers.bindFunc
 const noop = helpers.noop
 
+const isArray = require('../predicates/isArray')
 const isFunction = require('../predicates/isFunction')
 
 const constant = require('../combinators/constant')
+
+const MockCrock = require('../test/MockCrock')
 
 const sequence = require('./sequence')
 
 test('sequence pointfree', t => {
   const seq = bindFunc(sequence)
 
-  const x = 'super cool'
-  const m = { sequence: sinon.spy(constant(x)) }
+  const m = { sequence: constant(23) }
 
   t.ok(isFunction(seq), 'is a function')
 
@@ -41,12 +43,31 @@ test('sequence pointfree', t => {
   t.throws(seq(noop, {}), 'throws if second arg is an object')
 
   t.doesNotThrow(seq(noop, m), 'allows a function and Traverable')
+  t.doesNotThrow(seq(noop, []), 'allows a function and an Array')
+
+  t.end()
+})
+
+test('sequence with Traversable', t => {
+  const x = 'gnarly dude'
+  const m = { sequence: sinon.spy(constant(x)) }
 
   const f = sinon.spy()
   const res = sequence(f, m)
 
   t.ok(m.sequence.calledWith(f), 'calls sequence on Traversable, passing the function')
   t.equal(res, x, 'returns the result of sequence on Traversable')
+
+  t.end()
+})
+
+test('sequence with Array', t => {
+  const outer = sequence(MockCrock.of, [ MockCrock(12), MockCrock(23) ])
+  const inner = outer.value()
+
+  t.equal(outer.type(), 'MockCrock', 'outer container is a MockCrock')
+  t.ok(isArray(inner), 'inner container is an Array')
+  t.equal((inner.length), 2, 'inner array maintains structure')
 
   t.end()
 })

--- a/pointfree/traverse.spec.js
+++ b/pointfree/traverse.spec.js
@@ -5,9 +5,12 @@ const helpers = require('../test/helpers')
 const bindFunc = helpers.bindFunc
 const noop = helpers.noop
 
+const isArray = require('../predicates/isArray')
 const isFunction = require('../predicates/isFunction')
 
 const constant = require('../combinators/constant')
+
+const MockCrock = require('../test/MockCrock')
 
 const traverse = require('./traverse')
 
@@ -49,10 +52,17 @@ test('traverse pointfree', t => {
   t.throws(trav(noop, noop, 'string'), 'throws if third arg is a truthy string')
   t.throws(trav(noop, noop, false), 'throws if third arg is false')
   t.throws(trav(noop, noop, true), 'throws if third arg is true')
-  t.throws(trav(noop, noop, []), 'throws if third arg is an array')
   t.throws(trav(noop, noop, {}), 'throws if third arg is an object')
 
   t.doesNotThrow(trav(noop, noop, m), 'allows two functions and a Traverable')
+  t.doesNotThrow(trav(noop, noop, []), 'allows two functions and an Array ')
+
+  t.end()
+})
+
+test('traverse with Traversable', t => {
+  const x = 'super sweet'
+  const m = { traverse: sinon.spy(constant(x)) }
 
   const f = sinon.spy()
   const g = sinon.spy()
@@ -60,6 +70,19 @@ test('traverse pointfree', t => {
 
   t.ok(m.traverse.calledWith(f, g), 'calls traverse on Traversable, passing the functions')
   t.equal(res, x, 'returns the result of traverse on Traversable')
+
+  t.end()
+})
+
+test('traverse with Array', t => {
+  const f = sinon.spy(x => MockCrock(x + 2))
+
+  const outer = traverse(MockCrock.of, f, [ 12, 23 ])
+  const inner = outer.value()
+
+  t.equal(outer.type(), 'MockCrock', 'outer container is a MockCrock')
+  t.ok(isArray(inner), 'inner container is an Array')
+  t.same((inner), [ 14, 25 ], 'mapping/lifting function applied to every element')
 
   t.end()
 })


### PR DESCRIPTION
## We have the technology
![](http://thevine.irvinecompany.com/wp-content/uploads/2015/11/6millondollarman.jpg)

This PR addresses [issue#1](https://github.com/evilsoft/crocks/issues/1).
It allows both the `sequence` and `traverse` point-free functions to work on Arrays.