### PR TITLE
Add JSHint and Hook up Travis

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+test
+*.spec.js

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "asi": true,
+  "esversion": 6,
+  "laxbreak": true
+}

--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,10 @@ node_modules
 test
 *.spec.js
 
+.travis.yml
+.jshintignore
+.jshintrc
+
 .node-version
 *.log
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - '7'
+  - '6'
+  - '5'
+  - '4.2'
+install:
+  - npm install
+script:
+  - npm test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/evilsoft/crocks.svg?branch=master)](https://travis-ci.org/evilsoft/crocks)
+
 # crocks.js
 `crocks` is a collection of popular *Algebraic Data Types (ADTs)* that are all the rage in functional programming. You have heard of things like `Maybe` and `Either` and heck maybe even `IO`, that is what these are. The main goal of `crocks` is to curate and provide not only a common interface between each type (where possible of course), but also all of the helper functions needed to hit the ground running.
 

--- a/crocks/Unit.js
+++ b/crocks/Unit.js
@@ -18,16 +18,14 @@ const _empty =
   Unit
 
 function Unit() {
-  const x = undefined
-
   const equals =
-    m => isType(type(), m) && x === m.value()
+    m => isType(type(), m) && undefined === m.value()
 
   const inspect =
     constant(`()`)
 
   const value =
-    constant(x)
+    constant(undefined)
 
   const type =
     _type

--- a/helpers/once.js
+++ b/helpers/once.js
@@ -12,11 +12,12 @@ function once(fn) {
   }
 
   return function() {
-    if(called) { return result }
+    if(!called) {
+      called = true
+      result = fn.apply(null, arguments)
+    }
 
-    called = true
-    return result =
-      fn.apply(null, arguments)
+    return result
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
     "preversion": "npm run build",
     "build:publish": "npm test && npm run build && npm publish",
     "build": "npm test && webpack && uglifyjs dist/crocks.js -c \"warnings=false\" -m -o dist/crocks.min.js",
-    "spec": "nodemon -q -e js -x 'npm test -s | tap-spec'",
-    "test": "tape combinators/*.spec.js crocks/*.spec.js helpers/*.spec.js internal/*.spec.js monoids/*.spec.js pointfree/*.spec.js ./predicates/*.spec.js ./*.spec.js"
+    "lint": "jshint .",
+    "lint:dev": "jshint --reporter=node_modules/jshint-stylish .",
+    "spec": "tape combinators/*.spec.js crocks/*.spec.js helpers/*.spec.js internal/*.spec.js monoids/*.spec.js pointfree/*.spec.js ./predicates/*.spec.js ./*.spec.js",
+    "spec:dev": "nodemon -q -e js -x 'npm run spec -s | tap-spec'",
+    "test": "npm run lint && npm run spec"
   },
   "repository": {
     "type": "git",
@@ -35,6 +38,8 @@
     "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
     "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
     "babel-plugin-transform-es2015-template-literals": "^6.8.0",
+    "jshint": "^2.9.4",
+    "jshint-stylish": "^2.2.1",
     "nodemon": "^1.9.2",
     "sinon": "^1.17.4",
     "tap-spec": "^4.1.1",


### PR DESCRIPTION
## The :eyes: are always watching
![](http://rlv.zcache.com/all_seeing_eye_dog_round_pendant_necklace-ra62738b3081b4e15b55d46f49f2def58_fkoez_8byvr_324.jpg)

This PR addresses [Issue#22](https://github.com/evilsoft/crocks/issues/22).

* Adds Travis integration to repo
* updates `.npmignore` to keep dev config out of npm package
* Sets up `jshint` for dat `crocks` style (need to set up a style guide for contributors)
* Adds the Travis badge to the README
* :wrench:  some of the npm scripts to work with the linting addition.
* :wrench: some linting errors that came back :taco: :tada: 