### PR TITLE
Add and configure coveralls for code coverage reporing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules
 .node-version
 dist/
 
+.coveralls.yml
+.nyc_output/
+
 *.log
 
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,9 @@ test
 .jshintignore
 .jshintrc
 
+.coveralls.yml
+.nyc_output/
+
 .node-version
 *.log
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: node_js
+
 node_js:
   - '7'
   - '6'
   - '5'
   - '4.2'
+
 install:
   - npm install
+
 script:
   - npm test
+
+after_success:
+  - npm run coverage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/evilsoft/crocks.svg?branch=master)](https://travis-ci.org/evilsoft/crocks)
+[![Build Status](https://travis-ci.org/evilsoft/crocks.svg?branch=master)](https://travis-ci.org/evilsoft/crocks) [![Coverage Status](https://coveralls.io/repos/github/evilsoft/crocks/badge.svg?branch=master)](https://coveralls.io/github/evilsoft/crocks?branch=master)
 
 # crocks.js
 `crocks` is a collection of popular *Algebraic Data Types (ADTs)* that are all the rage in functional programming. You have heard of things like `Maybe` and `Either` and heck maybe even `IO`, that is what these are. The main goal of `crocks` is to curate and provide not only a common interface between each type (where possible of course), but also all of the helper functions needed to hit the ground running.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:dev": "jshint --reporter=node_modules/jshint-stylish .",
     "spec": "tape combinators/*.spec.js crocks/*.spec.js helpers/*.spec.js internal/*.spec.js monoids/*.spec.js pointfree/*.spec.js ./predicates/*.spec.js ./*.spec.js",
     "spec:dev": "nodemon -q -e js -x 'npm run spec -s | tap-spec'",
-    "test": "npm run lint && npm run spec"
+    "test": "npm run lint && nyc npm run spec",
+    "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {
     "type": "git",
@@ -38,9 +39,11 @@
     "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
     "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
     "babel-plugin-transform-es2015-template-literals": "^6.8.0",
+    "coveralls": "^2.11.15",
     "jshint": "^2.9.4",
     "jshint-stylish": "^2.2.1",
     "nodemon": "^1.9.2",
+    "nyc": "^10.1.2",
     "sinon": "^1.17.4",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0",


### PR DESCRIPTION
## When you need to paint, wear dem coveralls
![](http://www.mig-welding.co.uk/paint-safety/paint-overalls.jpg)

This PR addresses [issue#35](https://github.com/evilsoft/crocks/issues/35) and gets coveralls added in there complete with a cutesy badge of scary (spice).
