### PR TITLE
Add Inital Transformation Functions

### DIFF
--- a/crocks.js
+++ b/crocks.js
@@ -115,7 +115,14 @@ const predicates = {
   isNumber: require('./predicates/isNumber'),
   isObject: require('./predicates/isObject'),
   isSemigroup: require('./predicates/isSemigroup'),
-  isString: require('./predicates/isString'),
+  isString: require('./predicates/isString')
+}
+
+const transforms = {
+  eitherToAsync: require('./transforms/eitherToAsync'),
+  eitherToMaybe: require('./transforms/eitherToMaybe'),
+  maybeToAsync: require('./transforms/maybeToAsync'),
+  maybeToEither: require('./transforms/maybeToEither')
 }
 
 module.exports = Object.assign(
@@ -125,5 +132,6 @@ module.exports = Object.assign(
   helpers,
   monoids,
   pointFree,
-  predicates
+  predicates,
+  transforms
 )

--- a/crocks.spec.js
+++ b/crocks.spec.js
@@ -108,6 +108,11 @@ const isObject = require('./predicates/isObject')
 const isSemigroup = require('./predicates/isSemigroup')
 const isString = require('./predicates/isString')
 
+const eitherToAsync = require('./transforms/eitherToAsync')
+const eitherToMaybe = require('./transforms/eitherToMaybe')
+const maybeToAsync = require('./transforms/maybeToAsync')
+const maybeToEither  = require('./transforms/maybeToEither')
+
 test('entry', t => {
   t.equal(crocks.toString(), '[object Object]', 'is an object')
 
@@ -216,6 +221,11 @@ test('entry', t => {
   t.equal(crocks.isObject, isObject, 'provides the isObject function')
   t.equal(crocks.isSemigroup, isSemigroup, 'provides the isSemigroup function')
   t.equal(crocks.isString, isString, 'provides the isString function')
+
+  t.equal(crocks.eitherToAsync, eitherToAsync, 'provides the eitherToAsync function')
+  t.equal(crocks.eitherToMaybe, eitherToMaybe, 'provides the eitherToMaybe function')
+  t.equal(crocks.maybeToAsync, maybeToAsync, 'provides the maybeToAsync function')
+  t.equal(crocks.maybeToEither, maybeToEither, 'provides the maybeToEither function')
 
   t.end()
 })

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm test && webpack && uglifyjs dist/crocks.js -c \"warnings=false\" -m -o dist/crocks.min.js",
     "lint": "jshint .",
     "lint:dev": "jshint --reporter=node_modules/jshint-stylish .",
-    "spec": "tape combinators/*.spec.js crocks/*.spec.js helpers/*.spec.js internal/*.spec.js monoids/*.spec.js pointfree/*.spec.js ./predicates/*.spec.js ./*.spec.js",
+    "spec": "tape combinators/*.spec.js crocks/*.spec.js helpers/*.spec.js internal/*.spec.js monoids/*.spec.js pointfree/*.spec.js ./predicates/*.spec.js ./transforms/*.spec.js ./*.spec.js",
     "spec:dev": "nodemon -q -e js -x 'npm run spec -s | tap-spec'",
     "test": "npm run lint && nyc npm run spec",
     "coverage": "nyc report --reporter=text-lcov | coveralls"

--- a/transforms/eitherToAsync.js
+++ b/transforms/eitherToAsync.js
@@ -1,0 +1,36 @@
+/** @license ISC License (c) copyright 2017 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const curry = require('../helpers/curry')
+
+const isFunction = require('../predicates/isFunction')
+const isType = require('../internal/isType')
+
+const Either = require('../crocks/Either')
+const Async = require('../crocks/Async')
+
+const applyTransform = either =>
+  either.either(Async.rejected, Async.of)
+
+// eitherToAsync : Either e a -> Async e a
+// eitherToAsync : (a -> Either e b) -> a -> Async e b
+function eitherToAsync(either) {
+  if(isType(Either.type(), either)) {
+    return applyTransform(either)
+  }
+  else if(isFunction(either)) {
+    return function(x) {
+      const m = either(x)
+
+      if(!isType(Either.type(), m)) {
+        throw new TypeError('eitherToAsync: Either returing function required')
+      }
+
+      return applyTransform(m)
+    }
+  }
+
+  throw new TypeError('eitherToAsync: Either or Either returing function required')
+}
+
+module.exports = curry(eitherToAsync)

--- a/transforms/eitherToAsync.spec.js
+++ b/transforms/eitherToAsync.spec.js
@@ -1,0 +1,97 @@
+const test = require('tape')
+const sinon = require('sinon')
+const helpers = require('../test/helpers')
+
+const bindFunc = helpers.bindFunc
+const noop = helpers.noop
+
+const identity = require('../combinators/identity')
+
+const isFunction = require('../predicates/isFunction')
+const isType = require('../internal/isType')
+
+const Either = require('../crocks/Either')
+const Async = require('../crocks/Async')
+
+const eitherToAsync = require('./eitherToAsync')
+
+test('eitherToAsync transform', t => {
+  const f = bindFunc(eitherToAsync)
+
+  t.ok(isFunction(eitherToAsync), 'is a function')
+
+  t.throws(f(undefined), TypeError, 'throws if arg is undefined')
+  t.throws(f(null), TypeError, 'throws if arg is null')
+  t.throws(f(0), TypeError, 'throws if arg is a falsey number')
+  t.throws(f(1), TypeError, 'throws if arg is a truthy number')
+  t.throws(f(''), TypeError, 'throws if arg is a falsey string')
+  t.throws(f('string'), TypeError, 'throws if arg is a truthy string')
+  t.throws(f(false), TypeError, 'throws if arg is false')
+  t.throws(f(true), TypeError, 'throws if arg is true')
+  t.throws(f([]), TypeError, 'throws if arg is an array')
+  t.throws(f({}), TypeError, 'throws if arg is an object')
+
+  t.end()
+})
+
+test('eitherToAsync with Either', t => {
+  const some = 'something'
+  const none = 'nothing'
+
+  const good = eitherToAsync(Either.Right(some))
+  const bad = eitherToAsync(Either.Left(none))
+
+  t.ok(isType(Async.type(), good), 'returns an Async when Right')
+  t.ok(isType(Async.type(), bad), 'returns an Async when Left')
+
+  const res = sinon.spy(noop)
+  const rej = sinon.spy(noop)
+
+  good.fork(rej, res)
+  bad.fork(rej, res)
+
+  t.ok(res.calledWith(some), 'Right maps to a Resolved')
+  t.ok(rej.calledWith(none), 'Left maps to a Rejected')
+
+  t.end()
+})
+
+test('eitherToAsync with Either returning function', t => {
+  const some = 'something'
+  const none = 'nothing'
+
+  t.ok(isFunction(eitherToAsync(Either.of)), 'returns a function')
+
+  const f = bindFunc(eitherToAsync(identity))
+
+  t.throws(f(undefined), TypeError, 'throws if function returns undefined')
+  t.throws(f(null), TypeError, 'throws if function returns null')
+  t.throws(f(0), TypeError, 'throws if function returns a falsey number')
+  t.throws(f(1), TypeError, 'throws if function returns a truthy number')
+  t.throws(f(''), TypeError, 'throws if function returns a falsey string')
+  t.throws(f('string'), TypeError, 'throws if function returns a truthy string')
+  t.throws(f(false), TypeError, 'throws if function returns false')
+  t.throws(f(true), TypeError, 'throws if function returns true')
+  t.throws(f([]), TypeError, 'throws if function returns an array')
+  t.throws(f({}), TypeError, 'throws if function returns an object')
+
+  const lift =
+    x => x !== undefined ? Either.Right(x) : Either.Left(none)
+
+  const good = eitherToAsync(lift, some)
+  const bad = eitherToAsync(lift, undefined)
+
+  t.ok(isType(Async.type(), good), 'returns an Async when Right')
+  t.ok(isType(Async.type(), bad), 'returns an Async when Left')
+
+  const res = sinon.spy(noop)
+  const rej = sinon.spy(noop)
+
+  good.fork(rej, res)
+  bad.fork(rej, res)
+
+  t.ok(res.calledWith(some), 'Right maps to a Resolved')
+  t.ok(rej.calledWith(none), 'Left maps to a Rejected with option')
+
+  t.end()
+})

--- a/transforms/eitherToMaybe.js
+++ b/transforms/eitherToMaybe.js
@@ -1,0 +1,36 @@
+/** @license ISC License (c) copyright 2017 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const curry = require('../helpers/curry')
+
+const isFunction = require('../predicates/isFunction')
+const isType = require('../internal/isType')
+
+const Either = require('../crocks/Either')
+const Maybe = require('../crocks/Maybe')
+
+const applyTransform = either =>
+  either.either(Maybe.Nothing, Maybe.Just)
+
+// eitherToMaybe : Either b a -> Maybe a
+// eitherToMaybe : (a -> Either c b) -> a -> Maybe b
+function eitherToMaybe(either) {
+  if(isType(Either.type(), either)) {
+    return applyTransform(either)
+  }
+  else if(isFunction(either)) {
+    return function(x) {
+      const m = either(x)
+
+      if(!isType(Either.type(), m)) {
+        throw new TypeError('eitherToMaybe: Either returing function required')
+      }
+
+      return applyTransform(m)
+    }
+  }
+
+  throw new TypeError('eitherToMaybe: Either or Either returing function required')
+}
+
+module.exports = curry(eitherToMaybe)

--- a/transforms/eitherToMaybe.spec.js
+++ b/transforms/eitherToMaybe.spec.js
@@ -1,0 +1,83 @@
+const test = require('tape')
+const helpers = require('../test/helpers')
+
+const bindFunc = helpers.bindFunc
+
+const identity = require('../combinators/identity')
+
+const isFunction = require('../predicates/isFunction')
+const isType = require('../internal/isType')
+
+const Either = require('../crocks/Either')
+const Maybe = require('../crocks/Maybe')
+
+const eitherToMaybe = require('./eitherToMaybe')
+
+test('eitherToMaybe transform', t => {
+  const f = bindFunc(eitherToMaybe)
+
+  t.ok(isFunction(eitherToMaybe), 'is a function')
+
+  t.throws(f(undefined), TypeError, 'throws if arg is undefined')
+  t.throws(f(null), TypeError, 'throws if arg is null')
+  t.throws(f(0), TypeError, 'throws if arg is a falsey number')
+  t.throws(f(1), TypeError, 'throws if arg is a truthy number')
+  t.throws(f(''), TypeError, 'throws if arg is a falsey string')
+  t.throws(f('string'), TypeError, 'throws if arg is a truthy string')
+  t.throws(f(false), TypeError, 'throws if arg is false')
+  t.throws(f(true), TypeError, 'throws if arg is true')
+  t.throws(f([]), TypeError, 'throws if arg is an array')
+  t.throws(f({}), TypeError, 'throws if arg is an object')
+
+  t.end()
+})
+
+test('eitherToMaybe with Either', t => {
+  const some = 'something'
+  const none = 'nothing'
+
+  const good = eitherToMaybe(Either.Right(some))
+  const bad = eitherToMaybe(Either.Left(none))
+
+  t.ok(isType(Maybe.type(), good), 'returns a Maybe when Right')
+  t.ok(isType(Maybe.type(), bad), 'returns a Maybe when Left')
+
+  t.equals(good.option(none), some, 'Right maps to a Just')
+  t.equals(bad.option(none), none, 'Left maps to a Nothing')
+
+  t.end()
+})
+
+test('eitherToMaybe with Either returning function', t => {
+  const some = 'something'
+  const none = 'nothing'
+
+  t.ok(isFunction(eitherToMaybe(Maybe.of)), 'returns a function')
+
+  const f = bindFunc(eitherToMaybe(identity))
+
+  t.throws(f(undefined), TypeError, 'throws if function returns undefined')
+  t.throws(f(null), TypeError, 'throws if function returns null')
+  t.throws(f(0), TypeError, 'throws if function returns a falsey number')
+  t.throws(f(1), TypeError, 'throws if function returns a truthy number')
+  t.throws(f(''), TypeError, 'throws if function returns a falsey string')
+  t.throws(f('string'), TypeError, 'throws if function returns a truthy string')
+  t.throws(f(false), TypeError, 'throws if function returns false')
+  t.throws(f(true), TypeError, 'throws if function returns true')
+  t.throws(f([]), TypeError, 'throws if function returns an array')
+  t.throws(f({}), TypeError, 'throws if function returns an object')
+
+  const lift =
+    x => x !== undefined ? Either.Right(x) : Either.Left(none)
+
+  const good = eitherToMaybe(lift, some)
+  const bad = eitherToMaybe(lift, undefined)
+
+  t.ok(isType(Maybe.type(), good), 'returns a Maybe with a Right')
+  t.ok(isType(Maybe.type(), bad), 'returns a Maybe with a Left')
+
+  t.equals(good.option(none), some, 'Right maps to a Just')
+  t.equals(bad.option(none), none, 'Left maps to a Nothing')
+
+  t.end()
+})

--- a/transforms/maybeToAsync.js
+++ b/transforms/maybeToAsync.js
@@ -1,0 +1,40 @@
+/** @license ISC License (c) copyright 2017 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const curry = require('../helpers/curry')
+const constant = require('../combinators/constant')
+
+const isFunction = require('../predicates/isFunction')
+const isType = require('../internal/isType')
+
+const Maybe = require('../crocks/Maybe')
+const Async = require('../crocks/Async')
+
+const applyTransform = (left, maybe) =>
+  maybe.either(
+    constant(Async.rejected(left)),
+    Async.of
+  )
+
+// maybeToAsync : e -> Maybe a -> Async e a
+// maybeToAsync : e -> (a -> Maybe b) -> a -> Async e b
+function maybeToAsync(left, maybe) {
+  if(isType(Maybe.type(), maybe)) {
+    return applyTransform(left, maybe)
+  }
+  else if(isFunction(maybe)) {
+    return function(x) {
+      const m = maybe(x)
+
+      if(!isType(Maybe.type(), m)) {
+        throw new TypeError('maybeToAsync: Maybe returing function required for second argument')
+      }
+
+      return applyTransform(left, m)
+    }
+  }
+
+  throw new TypeError('maybeToAsync: Maybe or Maybe returing function required for second argument')
+}
+
+module.exports = curry(maybeToAsync)

--- a/transforms/maybeToAsync.spec.js
+++ b/transforms/maybeToAsync.spec.js
@@ -1,0 +1,100 @@
+const test = require('tape')
+const sinon = require('sinon')
+const helpers = require('../test/helpers')
+
+const bindFunc = helpers.bindFunc
+const noop = helpers.noop
+
+const identity = require('../combinators/identity')
+
+const isFunction = require('../predicates/isFunction')
+const isType = require('../internal/isType')
+
+const Maybe = require('../crocks/Maybe')
+const Async = require('../crocks/Async')
+
+const maybeToAsync = require('./maybeToAsync')
+
+test('maybeToAsync transform', t => {
+  const f = bindFunc(maybeToAsync)
+
+  const x = 23
+  const m = Maybe.of(x)
+
+  t.ok(isFunction(maybeToAsync), 'is a function')
+
+  t.throws(f(x, undefined), TypeError, 'throws if second arg is undefined')
+  t.throws(f(x, null), TypeError, 'throws if second arg is null')
+  t.throws(f(x, 0), TypeError, 'throws if second arg is a falsey number')
+  t.throws(f(x, 1), TypeError, 'throws if second arg is a truthy number')
+  t.throws(f(x, ''), TypeError, 'throws if second arg is a falsey string')
+  t.throws(f(x, 'string'), TypeError, 'throws if second arg is a truthy string')
+  t.throws(f(x, false), TypeError, 'throws if second arg is false')
+  t.throws(f(x, true), TypeError, 'throws if second arg is true')
+  t.throws(f(x, []), TypeError, 'throws if second arg is an array')
+  t.throws(f(x, {}), TypeError, 'throws if second arg is an object')
+
+  t.end()
+})
+
+test('maybeToAsync with Maybe', t => {
+  const some = 'something'
+  const none = 'nothing'
+
+  const good = maybeToAsync(none, Maybe.Just(some))
+  const bad = maybeToAsync(none, Maybe.Nothing())
+
+  t.ok(isType(Async.type(), good), 'returns an Async with a Just')
+  t.ok(isType(Async.type(), bad), 'returns an Async with a Nothing')
+
+  const res = sinon.spy(noop)
+  const rej = sinon.spy(noop)
+
+  good.fork(rej, res)
+  bad.fork(rej, res)
+
+  t.ok(res.calledWith(some), 'Just maps to a Resolved')
+  t.ok(rej.calledWith(none), 'Nothing maps to a Rejected with option')
+
+  t.end()
+})
+
+test('maybeToAsync with Maybe returning function', t => {
+  const some = 'something'
+  const none = 'nothing'
+
+  t.ok(isFunction(maybeToAsync(none, Maybe.of)), 'returns a function')
+
+  const f = bindFunc(maybeToAsync(none, identity))
+
+  t.throws(f(undefined), TypeError, 'throws if function returns undefined')
+  t.throws(f(null), TypeError, 'throws if function returns null')
+  t.throws(f(0), TypeError, 'throws if function returns a falsey number')
+  t.throws(f(1), TypeError, 'throws if function returns a truthy number')
+  t.throws(f(''), TypeError, 'throws if function returns a falsey string')
+  t.throws(f('string'), TypeError, 'throws if function returns a truthy string')
+  t.throws(f(false), TypeError, 'throws if function returns false')
+  t.throws(f(true), TypeError, 'throws if function returns true')
+  t.throws(f([]), TypeError, 'throws if function returns an array')
+  t.throws(f({}), TypeError, 'throws if function returns an object')
+
+  const lift =
+    x => x !== undefined ? Maybe.Just(x) : Maybe.Nothing()
+
+  const good = maybeToAsync(none, lift, some)
+  const bad = maybeToAsync(none, lift, undefined)
+
+  t.ok(isType(Async.type(), good), 'returns an Async with a Just')
+  t.ok(isType(Async.type(), bad), 'returns an Async with a Nothing')
+
+  const res = sinon.spy(noop)
+  const rej = sinon.spy(noop)
+
+  good.fork(rej, res)
+  bad.fork(rej, res)
+
+  t.ok(res.calledWith(some), 'Just maps to a Resolved')
+  t.ok(rej.calledWith(none), 'Nothing maps to a Rejected with option')
+
+  t.end()
+})

--- a/transforms/maybeToEither.js
+++ b/transforms/maybeToEither.js
@@ -1,0 +1,40 @@
+/** @license ISC License (c) copyright 2017 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const curry = require('../helpers/curry')
+const constant = require('../combinators/constant')
+
+const isFunction = require('../predicates/isFunction')
+const isType = require('../internal/isType')
+
+const Maybe = require('../crocks/Maybe')
+const Either = require('../crocks/Either')
+
+const applyTransform = (left, maybe) =>
+  maybe.either(
+    constant(Either.Left(left)),
+    Either.Right
+  )
+
+// maybeToEither : b -> Maybe a -> Either b a
+// maybeToEither : c -> (a -> Maybe b) -> a -> Either c b
+function maybeToEither(left, maybe) {
+  if(isType(Maybe.type(), maybe)) {
+    return applyTransform(left, maybe)
+  }
+  else if(isFunction(maybe)) {
+    return function(x) {
+      const m = maybe(x)
+
+      if(!isType(Maybe.type(), m)) {
+        throw new TypeError('maybeToEither: Maybe returing function required for second argument')
+      }
+
+      return applyTransform(left, m)
+    }
+  }
+
+  throw new TypeError('maybeToEither: Maybe or Maybe returing function required for second argument')
+}
+
+module.exports = curry(maybeToEither)

--- a/transforms/maybeToEither.spec.js
+++ b/transforms/maybeToEither.spec.js
@@ -1,0 +1,85 @@
+const test = require('tape')
+const helpers = require('../test/helpers')
+
+const bindFunc = helpers.bindFunc
+
+const identity = require('../combinators/identity')
+
+const isFunction = require('../predicates/isFunction')
+const isType = require('../internal/isType')
+
+const Maybe = require('../crocks/Maybe')
+const Either = require('../crocks/Either')
+
+const maybeToEither = require('./maybeToEither')
+
+test('maybeToEither transform', t => {
+  const f = bindFunc(maybeToEither)
+  const x = 23
+  const m = Maybe.of(x)
+
+  t.ok(isFunction(maybeToEither), 'is a function')
+
+  t.throws(f(x, undefined), TypeError, 'throws if second arg is undefined')
+  t.throws(f(x, null), TypeError, 'throws if second arg is null')
+  t.throws(f(x, 0), TypeError, 'throws if second arg is a falsey number')
+  t.throws(f(x, 1), TypeError, 'throws if second arg is a truthy number')
+  t.throws(f(x, ''), TypeError, 'throws if second arg is a falsey string')
+  t.throws(f(x, 'string'), TypeError, 'throws if second arg is a truthy string')
+  t.throws(f(x, false), TypeError, 'throws if second arg is false')
+  t.throws(f(x, true), TypeError, 'throws if second arg is true')
+  t.throws(f(x, []), TypeError, 'throws if second arg is an array')
+  t.throws(f(x, {}), TypeError, 'throws if second arg is an object')
+
+  t.end()
+})
+
+test('maybeToEither with Maybe', t => {
+  const some = 'something'
+  const none = 'nothing'
+
+  const good = maybeToEither(none, Maybe.Just(some))
+  const bad = maybeToEither(none, Maybe.Nothing())
+
+  t.ok(isType(Either.type(), good), 'returns an Either with a Just')
+  t.ok(isType(Either.type(), bad), 'returns an Either with a Nothing')
+
+  t.equals(good.either(identity, identity), some, 'Just maps to a Right')
+  t.equals(bad.either(identity, identity), none, 'Nothing maps to a Left with option value')
+
+  t.end()
+})
+
+test('maybeToEither with Maybe returning function', t => {
+  const some = 'something'
+  const none = 'nothing'
+
+  t.ok(isFunction(maybeToEither(none, Maybe.of)), 'returns a function')
+
+  const f = bindFunc(maybeToEither(none, identity))
+
+  t.throws(f(undefined), TypeError, 'throws if function returns undefined')
+  t.throws(f(null), TypeError, 'throws if function returns null')
+  t.throws(f(0), TypeError, 'throws if function returns a falsey number')
+  t.throws(f(1), TypeError, 'throws if function returns a truthy number')
+  t.throws(f(''), TypeError, 'throws if function returns a falsey string')
+  t.throws(f('string'), TypeError, 'throws if function returns a truthy string')
+  t.throws(f(false), TypeError, 'throws if function returns false')
+  t.throws(f(true), TypeError, 'throws if function returns true')
+  t.throws(f([]), TypeError, 'throws if function returns an array')
+  t.throws(f({}), TypeError, 'throws if function returns an object')
+
+  const lift =
+    x => x !== undefined ? Maybe.Just(x) : Maybe.Nothing()
+
+  const good = maybeToEither(none, lift, some)
+  const bad = maybeToEither(none, lift, undefined)
+
+  t.ok(isType(Either.type(), good), 'returns an Either with a Just')
+  t.ok(isType(Either.type(), bad), 'returns an Either with a Nothing')
+
+  t.equals(good.either(identity, identity), some, 'Just maps to a Right')
+  t.equals(bad.either(identity, identity), none, 'Nothing maps to a Left with option value')
+
+  t.end()
+})


### PR DESCRIPTION
## Robits  in Disguise

![](http://www.beyondhe.com.au/media/media/cache/594/SH1029-transformers-robots-in-disguise-2000x1125.jpg)

This PR addresses [issue#47](https://github.com/evilsoft/crocks/issues/47) and adds all the initial natural transofrmation functions. Really only covers the two main Sum Types `Maybe` and `Either` back and forth and to `Async`. Once `Validation` is added, will add an additional set of functions to account for those transformations.
