### PR TITLE
:corn:sistant errors and add chain errors to IO and Reader

### DIFF
--- a/crocks/Async.js
+++ b/crocks/Async.js
@@ -97,7 +97,7 @@ function Async(fn) {
 
   function fork(reject, resolve) {
     if(!isFunction(reject) || !isFunction(resolve)) {
-      throw new TypeError('Async.fork: reject and resolve functions required')
+      throw new TypeError('Async.fork: Reject and resolve functions required')
     }
 
     fn(reject, resolve)

--- a/crocks/Either.js
+++ b/crocks/Either.js
@@ -99,7 +99,7 @@ function Either(u) {
 
   function map(fn) {
     if(!isFunction(fn)) {
-      throw new TypeError('Either.map: function required')
+      throw new TypeError('Either.map: Function required')
     }
 
     return either(Either.Left, composeB(Either.Right, fn))
@@ -129,13 +129,13 @@ function Either(u) {
 
   function chain(fn) {
     if(!isFunction(fn)) {
-      throw new TypeError('Either.chain: function required')
+      throw new TypeError('Either.chain: Function required')
     }
 
     const m = either(Either.Left, fn)
 
     if(!isSameType(Either, m)) {
-      throw new TypeError('Either.chain: function must return an Either')
+      throw new TypeError('Either.chain: Function must return an Either')
     }
 
     return m

--- a/crocks/IO.js
+++ b/crocks/IO.js
@@ -50,7 +50,15 @@ function IO(run) {
       throw new TypeError('IO.chain: Function required')
     }
 
-    return IO(_ => fn(run()).run())
+    return IO(function() {
+      const m = fn(run())
+
+      if(!isSameType(IO, m)) {
+        throw new TypeError('IO.chain: Function must return an IO')
+      }
+
+      return m.run()
+    })
   }
 
   return {

--- a/crocks/IO.spec.js
+++ b/crocks/IO.spec.js
@@ -187,11 +187,23 @@ test('IO chain errors', t => {
   t.throws(chain('string'), TypeError, 'throws with truthy string')
   t.throws(chain(false), TypeError, 'throws with false')
   t.throws(chain(true), TypeError, 'throws with true')
-  t.throws(chain(null), TypeError, 'throws with null')
   t.throws(chain([]), TypeError, 'throws with an array')
   t.throws(chain({}), TypeError, 'throws with an object')
 
-  t.doesNotThrow(chain(noop), 'does not throw when passed a function')
+  const badRtn =
+    bindFunc(x => IO(identity).chain(constant(x)).run())
+
+  t.throws(badRtn(undefined), TypeError, 'throws when function returns undefined')
+  t.throws(badRtn(null), TypeError, 'throws when function returns null')
+  t.throws(badRtn(0), TypeError, 'throws when function returns a falsey number')
+  t.throws(badRtn(1), TypeError, 'throws when function returns a truthy number')
+  t.throws(badRtn(''), TypeError, 'throws when function returns a falsey string')
+  t.throws(badRtn('string'), TypeError, 'throws when function returns a truthy string')
+  t.throws(badRtn(false), TypeError, 'throws when function returns false')
+  t.throws(badRtn(true), TypeError, 'throws when function returns true')
+  t.throws(badRtn([]), TypeError, 'throws when function returns an array')
+  t.throws(badRtn({}), TypeError, 'throws when function returns an object')
+  t.throws(badRtn(noop), TypeError, 'throws when function returns a function')
 
   t.end()
 })

--- a/crocks/Identity.js
+++ b/crocks/Identity.js
@@ -64,7 +64,7 @@ function Identity(x) {
     const m = fn(x)
 
     if(!isSameType(Identity, m)) {
-      throw new TypeError('Identity.chain: function must return an Identity')
+      throw new TypeError('Identity.chain: Function must return an Identity')
     }
 
     return m

--- a/crocks/Maybe.js
+++ b/crocks/Maybe.js
@@ -110,7 +110,7 @@ function Maybe(u) {
     const m = either(Maybe.Nothing, fn)
 
     if(!isSameType(Maybe, m)) {
-      throw new TypeError('Maybe.chain: function must return a Maybe')
+      throw new TypeError('Maybe.chain: Function must return a Maybe')
     }
 
     return m

--- a/crocks/Pair.js
+++ b/crocks/Pair.js
@@ -123,7 +123,7 @@ function Pair(l, r) {
     const m = fn(snd())
 
     if(!(isSameType(Pair, m))) {
-      throw new TypeError('Pair.chain: function must return a Pair')
+      throw new TypeError('Pair.chain: Function must return a Pair')
     }
     else if(!isSemigroup(m.fst())) {
       throw new TypeError('Pair.chain: Semigroup required for first value of chained function result')

--- a/crocks/Reader.js
+++ b/crocks/Reader.js
@@ -57,7 +57,15 @@ function Reader(runWith) {
       throw new TypeError('Reader.chain: Function required')
     }
 
-    return Reader(e => fn(runWith(e)).runWith(e))
+    return Reader(function(e) {
+      const m = fn(runWith(e))
+
+      if(!isSameType(Reader, m)) {
+        throw new TypeError('Reader.chain: Function must return a Reader')
+      }
+
+      return m.runWith(e)
+    })
   }
 
   return {

--- a/crocks/Reader.spec.js
+++ b/crocks/Reader.spec.js
@@ -234,7 +234,20 @@ test('Reader chain errors', t => {
   t.throws(chain([]), TypeError, 'throws with an array')
   t.throws(chain({}), TypeError, 'throws with an object')
 
-  t.doesNotThrow(chain(noop), 'allows a function')
+  const badRtn =
+    bindFunc(x => Reader(identity).chain(identity).runWith(x))
+
+  t.throws(badRtn(undefined), TypeError, 'throws when function returns undefined')
+  t.throws(badRtn(null), TypeError, 'throws when function returns null')
+  t.throws(badRtn(0), TypeError, 'throws when function returns a falsey number')
+  t.throws(badRtn(1), TypeError, 'throws when function returns a truthy number')
+  t.throws(badRtn(''), TypeError, 'throws when function returns a falsey string')
+  t.throws(badRtn('string'), TypeError, 'throws when function returns a truthy string')
+  t.throws(badRtn(false), TypeError, 'throws when function returns false')
+  t.throws(badRtn(true), TypeError, 'throws when function returns true')
+  t.throws(badRtn([]), TypeError, 'throws when function returns an array')
+  t.throws(badRtn({}), TypeError, 'throws when function returns an object')
+  t.throws(badRtn(noop), TypeError, 'throws when function returns a function')
 
   t.end()
 })

--- a/crocks/Writer.js
+++ b/crocks/Writer.js
@@ -74,8 +74,8 @@ function _Writer(Monoid) {
 
       const w = fn(value())
 
-      if(!(w && isSameType(Writer, w))) {
-        throw new TypeError('Writer.chain: function must return a Writer')
+      if(!isSameType(Writer, w)) {
+        throw new TypeError('Writer.chain: Function must return a Writer')
       }
 
       return Writer(log().concat(w.log()).value(), w.value())

--- a/pointfree/concat.js
+++ b/pointfree/concat.js
@@ -8,7 +8,7 @@ const isString = require('../predicates/isString')
 
 function concat(x, m) {
   if(!isSemigroup(m)) {
-    throw new TypeError('concat: Semi-group required for second argument')
+    throw new TypeError('concat: Semigroup required for second argument')
   }
 
   if(isString(m)) {

--- a/pointfree/either.js
+++ b/pointfree/either.js
@@ -7,7 +7,7 @@ const isFunction = require('../predicates/isFunction')
 
 function either(lf, rf, m) {
   if(!isFunction(lf) || !isFunction(rf)) {
-    throw new TypeError('either: first two arguments must be functions')
+    throw new TypeError('either: First two arguments must be functions')
   }
   else if(!(m && isFunction(m.either))) {
     throw new TypeError('either: Last argument must be an Either or Maybe')


### PR DESCRIPTION
## Lazy people...Lazy Data Types
![](http://www.raptureready1.com/vlazy_people.gif)

This PR addresses [issue#49](https://github.com/evilsoft/crocks/issues/49)
Seems I was as Lazy as some of my earlier Lazy types. I failed to add Error handling for `chain` on both `IO` and `Reader`. I never checked if the value returned by the function was indeed the same type, so any errors were happening when run, with no indication of what the heck happened. 

This PR fixes that.

Also noticed some in:corn:sistancies with some of the error messages not being Capitalized. :wrench: that too!!