### PR TITLE
Remove extraction functions from `Either` and `Maybe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ All `Crocks` are Constructor functions of the given type, with `Writer` being an
 | `Arrow` | `empty` | `both`, `concat`, `contramap`, `empty`, `first`, `map`, `promap`, `runWith`, `second`, `value` |
 | `Async` | `all`, `fromNode`, `fromPromise`, `of`, `rejected` | `ap`, `bimap`, `chain`, `coalesce`, `fork`, `map`, `of`, `swap`, `toPromise` |
 | `Const` | -- | `ap`, `chain`, `concat`, `equals`, `map`, `value` |
-| `Either` | `Left`, `Right`, `of`| `ap`, `bimap`, `chain`, `coalesce`, `either`, `equals`, `map`, `of`, `sequence`, `swap`, `traverse`, `value` |
+| `Either` | `Left`, `Right`, `of`| `ap`, `bimap`, `chain`, `coalesce`, `either`, `equals`, `map`, `of`, `sequence`, `swap`, `traverse` |
 | `Identity` | `of` | `ap`, `chain`, `equals`, `map`, `of`, `sequence`, `traverse`, `value` |
 | `IO` | `of` | `ap`, `chain`, `map`, `of`, `run` |
 | `List` |  `empty`, `of` | `ap`, `chain`, `concat`, `cons`, `empty`, `equals`, `filter`, `head`, `map`, `of`, `reduce`, `sequence`, `tail`, `traverse`, `value` |
-| `Maybe` | `Nothing`, `Just`, `of` | `ap`, `chain`, `coalesce`, `equals`, `either`, `map`, `maybe`, `of`, `option`, `sequence`, `traverse` |
+| `Maybe` | `Nothing`, `Just`, `of` | `ap`, `chain`, `coalesce`, `equals`, `either`, `map`, `of`, `option`, `sequence`, `traverse` |
 | `Pair` | `of` | `ap`, `bimap`, `chain`, `concat`, `equals`, `fst`, `map`, `merge`, `of`, `snd`, `swap`, `value` |
 | `Pred`[*] | `empty` | `concat`, `contramap`, `empty`, `runWith`, `value` |
 | `Reader` | `ask`, `of`| `ap`, `chain`, `map`, `of`, `runWith` |
@@ -141,7 +141,7 @@ While the `composeB` can be used to create a composition of two functions, there
 Pass this function a function and it will return you a function that can be called in any form that you require until all arguments have been provided. For example if you pass a function: `f : (a, b, c) -> d` you get back a function that can be called in any combination, such as: `f(x, y, z)`, `f(x)(y)(z)`, `f(x, y)(z)`, or even `f(x)(y, z)`. This is great for doing partial application on functions for maximum re-usability.
 
 #### `curryN : Number -> ((a, b, ...) -> z) -> a -> b -> ... -> z`
-When dealing with variable argument functions, there are times when you may want to curry a specific number of arguments. Just pass this function the number of arguments you want to curry as well as the function, and it will not call the wrapped function until all arguments have been passed. This function will ONLY pass the number of arguments that you specified, any remaining arguments are discarded. This is great for limiting the arity of a given function when additional parameters are defaulted or not needed. This function will not auto curry functions returning functions like `curry` does, use with `curry` if you need to do some fancy setup for your wrapped function's api.
+When dealing with variable argument functions, there are times when you may want to curry a specific number of arguments. Just pass this function the number of arguments you want to curry as well as the function, and it will not call the wrapped function until all arguments have been passed. This function will ONLY pass the number of arguments that you specified, any remaining arguments are discarded. This is great for limiting the arity of a given function when additional parameters are defaulted or not needed. This function will not auto curry functions returning functions like `curry` does, use with `curry` if you need to do some fancy setup for your wrapped function's API.
 
 #### `fanout : (a -> b) -> (a -> c) -> (a -> Pair b c)`
 #### `fanout : Arrow a b -> Arrow a c -> Arrow a (Pair b c)`
@@ -190,7 +190,7 @@ The functions in this section are used to represent logical branching in a decla
 #### `and : ((a -> Boolean) | Pred) -> ((a -> Boolean) | Pred) -> a -> Boolean`
 Say you have two predicate functions or `Pred`s and would like to combine them into one predicate over conjunction, well you came to the right place, `and` accepts either predicate functions or `Pred`s and will return you a function ready to take a value. Once that value is passed, it will run it through both of the predicates and return the result of combining it over a `logical and`. This is super helpful combined with `or` for putting together reusable, complex predicates. As they follow the general form of `(a -> Boolean)` they are easily combined with other logic functions.
 
-#### `ifElse : ((a -> Boolean) | Pred) -> (a -> b) -> (a -> c) -> a -> b | c`
+#### `ifElse : ((a -> Boolean) | Pred) -> (* -> a) -> (* -> a) -> * -> a`
 Whenever you need to modify a value based some condition and want a functional way to do it without some imperative `if` statement, then reach for `ifElse`. This function take a predicate (some function that returns a Boolean) and two functions. The first is what is executed when the predicate is true, the second on a false condition. This will return a function ready to take a value to run through the predicate. After the value is evaluated, it will be ran through it's corresponding function, returning the result as the final result. This function comes in really handy when creating lifting functions for Sum Types (like `Either` or `Maybe`).
 
 #### `not : ((a -> Boolean) | Pred) -> a -> Boolean`
@@ -199,10 +199,10 @@ When you need to negate a predicate function or a `Pred`, but want a new predica
 #### `or : ((a -> Boolean) | Pred) -> ((a -> Boolean) | Pred) -> a -> Boolean`
 Say you have two predicate functions or `Pred`s and would like to combine them into one predicate over disjunction, look no further, `or` accepts either predicate functions or `Pred`s and will return you a function ready to take a value. Once that value is passed, it will run it through both of the predicates and return the result of combining it over a `logical or`. This is super helpful combined with `and` for putting together reusable, complex predicates. As they follow the general form of `(a -> Boolean)` they are easily combined with other logic functions.
 
-#### `unless : ((a -> Boolean) | Pred) -> (a -> b) -> a -> a | b`
+#### `unless : ((a -> Boolean) | Pred) -> (* -> a) -> * -> a`
 There may come a time when you need to adjust a value when a condition is false, that is where `unless` can come into play. Just provide a predicate function (a function that returns a Boolean) and a function to apply your desired modification. This will get you back a function that when you pass it a value, it will evaluate it and if false, will run your value through the provided function. Either the original or modified value will be returned depending on the result of the predicate. Check out `when` for a negated version of this function.
 
-#### `when : ((a -> Boolean) | Pred) -> (a -> b) -> a -> b | a`
+#### `when : ((a -> Boolean) | Pred) -> (* -> a) -> * -> a`
 There may come a time when you need to adjust a value when a condition is true, that is where `when` can come into play. Just provide a predicate function (a function that returns a Boolean) and a function to apply your desired modification. This will get you back a function that when you pass it a value, it will evaluate it and if true, will run your value through the provided function. Either the original or modified value will be returned depending on the result of the predicate. Check out `unless` for a negated version of this function.
 
 ### Predicate Functions
@@ -236,23 +236,24 @@ While it can seem natural to work with all these containers in a fluent fashion,
 ```javascript
 const crocks = require('crocks')
 
-const { compose, map } = crocks // map is the point-free function
+const {
+  compose, map, safe, isInteger
+} = crocks // map is the point-free function
 
-const { Maybe } = crocks
-const { Nothing, Just } = Maybe
-
+// isEven : Integer -> Boolean
 const isEven =
-  x => !(x % 2)
+  x => (x % 2) === 0
 
+// maybeInt : a -> Maybe Integer
 const maybeInt =
-  x => !Number.isInteger(x)
-    ? Nothing() : Just(x)
+  safe(isInteger)
 
-function fluentIsEven(data) {
-  return maybeInt(data)
+// fluentIsEven : a -> Maybe Boolean
+const fluentIsEven = data =>
+  maybeInt(data)
     .map(isEven)
-}
 
+// pointfreeIsEven : a -> Maybe Boolean
 const pointfreeIsEven =
   compose(map(isEven), maybeInt)
 ```
@@ -279,7 +280,6 @@ These functions provide a very clean way to build out very simple functions and 
 | `head` | `m a -> Maybe a` |
 | `log` | `m a b -> a` |
 | `map` | `(a -> b) -> m a -> m b` |
-| `maybe` | `a -> m a -> a` |
 | `merge` | `(a -> b -> c) -> m a b -> c` |
 | `option` | `a -> m a -> a` |
 | `promap` | `(c -> a) -> (b -> d) -> m a b -> m c d` |
@@ -315,7 +315,6 @@ These functions provide a very clean way to build out very simple functions and 
 | `head` | `Array`, `List` |
 | `log` | `Writer` |
 | `map` | `Async`, `Array`, `Arrow`, `Const`, `Either`, `Function`, `Identity`, `IO`, `List`, `Maybe`, `Pair`, `Reader`, `Star`, `State`, `Unit`, `Writer` |
-| `maybe` | `Maybe` |
 | `merge` | `Pair` |
 | `option` | `Either`, `Maybe` |
 | `promap` | `Arrow`, `Star` |
@@ -329,7 +328,7 @@ These functions provide a very clean way to build out very simple functions and 
 | `swap` | `Async`, `Either`, `Pair` |
 | `tail` | `Array`, `List`, `String` |
 | `traverse` | `Array`, `Either`, `Identity`, `List`, `Maybe` |
-| `value` | `Arrow`, `Const`, `Either`, `Identity`, `List`, `Pair`, `Pred`, `Unit`, `Writer` |
+| `value` | `Arrow`, `Const`, `Identity`, `List`, `Pair`, `Pred`, `Unit`, `Writer` |
 
 ### Transformation Functions
 Transformation functions are mostly used to reduce unwanted nesting of similar types. Take for example the following structure:

--- a/crocks/Either.js
+++ b/crocks/Either.js
@@ -48,14 +48,11 @@ function Either(u) {
   const type =
     _type
 
-  const value =
-    constant(either(identity, identity))
-
   const equals =
     m => isSameType(Either, m) && either(
-      constant(m.either(constant(true), constant(false))),
-      constant(m.either(constant(false), constant(true)))
-    ) && value() === m.value()
+      x => m.either(y => y === x, constant(false)),
+      x => m.either(constant(false), y => y === x)
+    )
 
   const of =
     _of
@@ -170,7 +167,7 @@ function Either(u) {
   }
 
   return {
-    inspect, either, value, type,
+    inspect, either, type,
     swap, coalesce, equals, map, bimap,
     ap, of, chain, sequence, traverse
   }

--- a/crocks/Either.spec.js
+++ b/crocks/Either.spec.js
@@ -67,13 +67,6 @@ test('Either type', t => {
   t.end()
 })
 
-test('Either value', t => {
-  t.equal(Either.Left(23).value(), 23, 'value returns the left when isLeft')
-  t.equal(Either.Right(98).value(), 98, 'value returns the right when isRight')
-
-  t.end()
-})
-
 test('Either either', t => {
   const l = Either.Left('left')
   const r = Either.Right('right')
@@ -268,11 +261,11 @@ test('Either map functionality', t => {
   const r = Either.Right(0).map(rspy)
 
   t.equal(l.type(), 'Either', 'returns an Either Type')
-  t.equal(l.value(), 0, 'returns the original Left value')
+  t.equal(l.either(identity, constant(1)), 0, 'returns the original Left value')
   t.notOk(lspy.called, 'mapped function is never called when Left')
 
   t.equal(r.type(), 'Either', 'returns a Either type')
-  t.equal(r.value(), 0, 'returns a Right Either with the same value when mapped with identity')
+  t.equal(r.either(constant(1), identity), 0, 'returns a Right Either with the same value when mapped with identity')
   t.ok(rspy.called, 'mapped function is called when Right')
 
   t.end()
@@ -282,14 +275,26 @@ test('Either map properties (Functor)', t => {
   const f = x => x + 2
   const g = x => x * 2
 
-  t.ok(isFunction(Either.Left(0).map), 'left provides a map function')
-  t.ok(isFunction(Either.Right(0).map), 'right provides a map function')
+  const Right = Either.Right
+  const Left = Either.Left
 
-  t.equal(Either.Right(30).map(identity).value(), 30, 'Right identity')
-  t.equal(Either.Right(10).map(x => f(g(x))).value(), Either.Right(10).map(g).map(f).value(), 'Right composition')
+  t.ok(isFunction(Left(0).map), 'left provides a map function')
+  t.ok(isFunction(Right(0).map), 'right provides a map function')
 
-  t.equal(Either.Left(45).map(identity).value(), 45, 'Left identity')
-  t.equal(Either.Left(10).map(x => f(g(x))).value(), Either.Left(10).map(g).map(f).value(), 'Left composition')
+  t.equal(Right(30).map(identity).either(constant(0), identity), 30, 'Right identity')
+
+  t.equal(
+    Right(10).map(composeB(f, g)).either(constant(0), identity),
+    Right(10).map(g).map(f).either(constant(0), identity),
+    'Right composition'
+  )
+
+  t.equal(Left(45).map(identity).either(identity, constant(0)), 45, 'Left identity')
+  t.equal(
+    Left(10).map(composeB(f, g)).either(identity, constant(0)),
+    Left(10).map(g).map(f).either(identity, constant(0)),
+    'Left composition'
+  )
 
   t.end()
 })
@@ -356,7 +361,8 @@ test('Either ap errors', t => {
 })
 
 test('Either ap properties (Apply)', t => {
-  const m = Either.Right(identity)
+  const Right = Either.Right
+  const m = Right(identity)
 
   const a = m.map(composeB).ap(m).ap(m)
   const b = m.ap(m.ap(m))
@@ -364,7 +370,11 @@ test('Either ap properties (Apply)', t => {
   t.ok(isFunction(m.ap), 'provides an ap function')
   t.ok(isFunction(m.map), 'implements the Functor spec')
 
-  t.equal(a.ap(Either.Right(3)).value(), b.ap(Either.Right(3)).value(), 'composition Right')
+  t.equal(
+    a.ap(Right(3)).either(constant(0), identity),
+    b.ap(Right(3)).either(constant(0), identity),
+    'composition Right'
+  )
 
   t.end()
 })
@@ -378,21 +388,32 @@ test('Either of', t => {
 })
 
 test('Either of properties (Applicative)', t => {
-  const r = Either.Right(identity)
-  const l = Either.Left('left')
+  const Right = Either.Right
+  const Left = Either.Left
+
+  const r = Right(identity)
+  const l = Left('left')
 
   t.ok(isFunction(r.of), 'Right provides an of function')
   t.ok(isFunction(l.of), 'Left provides an of function')
   t.ok(isFunction(r.ap), 'Right implements the Apply spec')
   t.ok(isFunction(l.ap), 'Left implements the Apply spec')
 
-  t.equal(r.ap(Either.Right(3)).value(), 3, 'identity Right')
-  t.equal(r.ap(Either.of(3)).value(), Either.of(identity(3)).value(), 'homomorphism Right')
+  t.equal(r.ap(Right(3)).either(constant(0), identity), 3, 'identity Right')
+  t.equal(
+    r.ap(Either.of(3)).either(constant(0), identity),
+    Either.of(3).either(constant(0), identity),
+    'homomorphism Right'
+  )
 
   const a = x => r.ap(Either.of(x))
   const b = x => Either.of(reverseApply(x)).ap(r)
 
-  t.equal(a(3).value(), b(3).value(), 'interchange Right')
+  t.equal(
+    a(3).either(constant(0),identity),
+    b(3).either(constant(0),identity),
+    'interchange Right'
+  )
 
   t.end()
 })
@@ -430,34 +451,51 @@ test('Either chain errors', t => {
 })
 
 test('Either chain properties (Chain)', t => {
-  t.ok(isFunction(Either.Right(0).chain), 'Right provides a chain function')
-  t.ok(isFunction(Either.Right(0).ap), 'Right implements the Apply spec')
+  const Right = Either.Right
+  const Left = Either.Left
 
-  t.ok(isFunction(Either.Left(0).chain), 'Left provides a chain function')
-  t.ok(isFunction(Either.Left(0).ap), 'Leftimplements the Apply spec')
+  t.ok(isFunction(Right(0).chain), 'Right provides a chain function')
+  t.ok(isFunction(Right(0).ap), 'Right implements the Apply spec')
 
-  const f = x => Either.Right(x + 2)
-  const g = x => Either.Right(x + 10)
+  t.ok(isFunction(Left(0).chain), 'Left provides a chain function')
+  t.ok(isFunction(Left(0).ap), 'Leftimplements the Apply spec')
 
-  const a = x => Either.Right(x).chain(f).chain(g)
-  const b = x => Either.Right(x).chain(y => f(y).chain(g))
+  const f = x => Right(x + 2)
+  const g = x => Right(x + 10)
 
-  t.equal(a(10).value(), b(10).value(), 'assosiativity Right')
+  const a = x => Right(x).chain(f).chain(g)
+  const b = x => Right(x).chain(y => f(y).chain(g))
+
+  t.equal(
+    a(10).either(constant(0), identity),
+    b(10).either(constant(0), identity),
+    'assosiativity Right'
+  )
 
   t.end()
 })
 
 test('Either chain properties (Monad)', t => {
-  t.ok(isFunction(Either.Right(0).chain), 'Right implements the Chain spec')
-  t.ok(isFunction(Either.Right(0).of), 'Right implements the Applicative spec')
+  const Right = Either.Right
 
-  const f = x => Either.Right(x)
+  t.ok(isFunction(Right(0).chain), 'Right implements the Chain spec')
+  t.ok(isFunction(Right(0).of), 'Right implements the Applicative spec')
 
-  t.equal(Either.of(3).chain(f).value(), f(3).value(), 'left identity Right')
+  const f = x => Right(x)
 
-  const m = x => Either.Right(x)
+  t.equal(
+    Either.of(3).chain(f).either(constant(0), identity),
+    f(3).either(constant(0), identity),
+    'left identity Right'
+  )
 
-  t.equal(m(3).chain(Either.of).value(), m(3).value(), 'right identity Right')
+  const m = x => Right(x)
+
+  t.equal(
+    m(3).chain(Either.of).either(constant(0), identity),
+    m(3).either(constant(0), identity),
+    'right identity Right'
+  )
 
   t.end()
 })
@@ -500,17 +538,21 @@ test('Either sequence errors', t => {
 })
 
 test('Either sequence functionality', t => {
+  const Right = Either.Right
+  const Left = Either.Left
+
   const x = 284
-  const r = Either.Right(MockCrock(x)).sequence(MockCrock.of)
-  const l = Either.Left('Left').sequence(MockCrock.of)
+
+  const r = Right(MockCrock(x)).sequence(MockCrock.of)
+  const l = Left('Left').sequence(MockCrock.of)
 
   t.equal(r.type(), 'MockCrock', 'Provides an outer type of MockCrock')
   t.equal(r.value().type(), 'Either', 'Provides an inner type of Either')
-  t.equal(r.value().value(), x, 'Either contains original inner value')
+  t.equal(r.value().either(constant(0), identity), x, 'Either contains original inner value')
 
   t.equal(l.type(), 'MockCrock', 'Provides an outer type of MockCrock')
   t.equal(l.value().type(), 'Either', 'Provides an inner type of Either')
-  t.equal(l.value().value(), 'Left', 'Either contains original Left value')
+  t.equal(l.value().either(identity, constant(0)), 'Left', 'Either contains original Left value')
 
   t.end()
 })
@@ -575,18 +617,22 @@ test('Either traverse errors', t => {
 })
 
 test('Either traverse functionality', t => {
-  const x = 284
-  const f = x => MockCrock(x)
-  const r = Either.Right(x).traverse(f, MockCrock)
-  const l = Either.Left('Left').traverse(f, MockCrock)
+  const Right = Either.Right
+  const Left = Either.Left
+
+  const x = 98
+
+  const f = MockCrock
+  const r = Right(x).traverse(f, MockCrock)
+  const l = Left('Left').traverse(f, MockCrock)
 
   t.equal(r.type(), 'MockCrock', 'Provides an outer type of MockCrock')
   t.equal(r.value().type(), 'Either', 'Provides an inner type of Either')
-  t.equal(r.value().value(), x, 'Either contains original inner value')
+  t.equal(r.value().either(constant(0), identity), x, 'Either contains original inner value')
 
   t.equal(l.type(), 'MockCrock', 'Provides an outer type of MockCrock')
   t.equal(l.value().type(), 'Either', 'Provides an inner type of Either')
-  t.equal(l.value().value(), 'Left', 'Either contains original Left value')
+  t.equal(l.value().either(identity, constant(0)), 'Left', 'Either contains original Left value')
 
   t.end()
 })

--- a/crocks/Maybe.js
+++ b/crocks/Maybe.js
@@ -40,14 +40,11 @@ function Maybe(u) {
   const option =
     n => either(constant(n), identity)
 
-  const maybe =
-    constant(option(undefined))
-
   const equals =
     m => isSameType(Maybe, m) && either(
       constant(m.either(constant(true), constant(false))),
-      constant(m.either(constant(false), constant(true)))
-    ) && maybe() === m.maybe()
+      x => m.either(constant(false), y => y === x)
+    )
 
   function inspect() {
     return either(
@@ -153,9 +150,9 @@ function Maybe(u) {
   }
 
   return {
-    inspect, maybe, either, option,
-    type, equals, coalesce, map, ap,
-    of, chain, sequence, traverse
+    inspect, either, option, type,
+    equals, coalesce, map, ap, of,
+    chain, sequence, traverse
   }
 }
 


### PR DESCRIPTION
## You live...You learn

![](http://data.whicdn.com/images/96956568/large.jpg)

This PR addresses [issue#54](https://github.com/evilsoft/crocks/issues/54) and removes `value` from `Either` and `maybe` from `Maybe`. 

These functions were wrought with nasty and would have been a big 👃 if allowed to hang out.

Also did some 💅 on the README fixing up some text and updating the pointfree example to lean on techniques that were added in the last few releases.