### PR TITLE
List: Adds constructor _fromArray_ and instance _toArray_

### DIFF
--- a/crocks/List.js
+++ b/crocks/List.js
@@ -28,10 +28,10 @@ const _empty =
   () => List([])
 
 function fromArray(xs) {
-  if(!arguments.length || !isArray(xs)) {
+  if(!isArray(xs)) {
     throw new TypeError('List.fromArray: Array required')
   }
-  return xs.reduce((res, x)  => res.concat(List.of(x)), List.empty())
+  return xs.reduce((res, x) => res.concat(List.of(x)), List.empty())
 }
 
 function runSequence(acc, x) {
@@ -59,7 +59,7 @@ function runTraverse(f) {
 }
 
 function List(xs) {
-  if(!arguments.length || !isArray(xs)) {
+  if(!isArray(xs)) {
     throw new TypeError('List: Must wrap an array')
   }
 

--- a/crocks/List.js
+++ b/crocks/List.js
@@ -12,6 +12,8 @@ const constant = require('../combinators/constant')
 
 const _concat = require('../pointfree/concat')
 
+const _mconcat = require('../helpers/mconcat')
+
 const Maybe = require('./Maybe')
 const Pred = require('./Pred')
 
@@ -29,9 +31,9 @@ const _empty =
 
 function fromArray(xs) {
   if(!arguments.length || !isArray(xs)) {
-    throw new TypeError('List.fromArray: Must wrap an array')
+    throw new TypeError('List.fromArray: Array required')
   }
-  return List(xs)
+  return _mconcat(List, [xs])
 }
 
 function runSequence(acc, x) {
@@ -85,7 +87,7 @@ function List(xs) {
     () => xs.slice()
 
   const toArray =
-    () => xs.length && xs.reduce((res, x)  => res.concat(x), [])
+    () => xs.slice()
 
   const empty =
     _empty

--- a/crocks/List.js
+++ b/crocks/List.js
@@ -12,8 +12,6 @@ const constant = require('../combinators/constant')
 
 const _concat = require('../pointfree/concat')
 
-const _mconcat = require('../helpers/mconcat')
-
 const Maybe = require('./Maybe')
 const Pred = require('./Pred')
 
@@ -33,7 +31,7 @@ function fromArray(xs) {
   if(!arguments.length || !isArray(xs)) {
     throw new TypeError('List.fromArray: Array required')
   }
-  return _mconcat(List, [xs])
+  return xs.reduce((res, x)  => res.concat(List.of(x)), List.empty())
 }
 
 function runSequence(acc, x) {

--- a/crocks/List.js
+++ b/crocks/List.js
@@ -85,7 +85,7 @@ function List(xs) {
     () => xs.slice()
 
   const toArray =
-    () => xs.slice()
+    value
 
   const empty =
     _empty

--- a/crocks/List.js
+++ b/crocks/List.js
@@ -27,6 +27,13 @@ const _of =
 const _empty =
   () => List([])
 
+function fromArray(xs) {
+  if(!arguments.length || !isArray(xs)) {
+    throw new TypeError('List.fromArray: Must wrap an array')
+  }
+  return List(xs)
+}
+
 function runSequence(acc, x) {
   if(!isApplicative(x)) {
     throw new TypeError('List.sequence: Must wrap Applicatives')
@@ -76,6 +83,9 @@ function List(xs) {
 
   const value =
     () => xs.slice()
+
+  const toArray =
+    () => xs.length && xs.reduce((res, x)  => res.concat(x), [])
 
   const empty =
     _empty
@@ -190,7 +200,7 @@ function List(xs) {
   }
 
   return {
-    inspect, value, head, tail, cons,
+    inspect, value, toArray, head, tail, cons,
     type, equals, concat, empty, reduce,
     filter, map, ap, of, chain, sequence,
     traverse
@@ -205,5 +215,8 @@ List.of =
 
 List.empty =
   _empty
+
+List.fromArray =
+  fromArray
 
 module.exports = List

--- a/crocks/List.spec.js
+++ b/crocks/List.spec.js
@@ -123,7 +123,7 @@ test('List value', t => {
 test('List toArray', t => {
   const a = List([ 'some-thing', ['else', 43], 34 ]).toArray()
 
-  t.same(a, [ 'some-thing', 'else', 43, 34 ], 'folds the wrapped array')
+  t.same(a, [ 'some-thing', ['else', 43], 34 ], 'provides the wrapped array')
 
   t.end()
 })
@@ -395,8 +395,6 @@ test('List of', t => {
 test('List fromArray', t => {
   const fromArray = bindFunc(List.fromArray)
 
-  const notList = { type: constant('List...Not') }
-
   t.throws(fromArray(undefined), TypeError, 'throws with undefined')
   t.throws(fromArray(null), TypeError, 'throws with null')
   t.throws(fromArray(0), TypeError, 'throws with falsey number')
@@ -406,7 +404,6 @@ test('List fromArray', t => {
   t.throws(fromArray(false), TypeError, 'throws with false')
   t.throws(fromArray(true), TypeError, 'throws with true')
   t.throws(fromArray({}), TypeError, 'throws with an object')
-  t.throws(fromArray(notList), TypeError, 'throws when passed non-List')
 
   t.equal(List.fromArray([0]).type(), 'List', 'returns a List')
   t.same(List.fromArray([0]).value(), [ 0 ], 'wraps the value passed into List in an array')

--- a/crocks/List.spec.js
+++ b/crocks/List.spec.js
@@ -121,9 +121,9 @@ test('List value', t => {
 })
 
 test('List toArray', t => {
-  const a = List([ 'some-thing', ['else', 43], 34 ]).toArray()
+  const a = List([ 'some-thing', 34 ]).toArray()
 
-  t.same(a, [ 'some-thing', ['else', 43], 34 ], 'provides the wrapped array')
+  t.same(a, [ 'some-thing', 34 ], 'provides the wrapped array')
 
   t.end()
 })

--- a/crocks/List.spec.js
+++ b/crocks/List.spec.js
@@ -406,7 +406,7 @@ test('List fromArray', t => {
   t.throws(fromArray({}), TypeError, 'throws with an object')
 
   t.equal(List.fromArray([0]).type(), 'List', 'returns a List')
-  t.same(List.fromArray([0]).value(), [ 0 ], 'wraps the value passed into List in an array')
+  t.same(List.fromArray([[2, 1], 'a']).value(), [[2, 1], 'a'], 'wraps the value passed into List in an array')
 
   t.end()
 })

--- a/crocks/List.spec.js
+++ b/crocks/List.spec.js
@@ -26,6 +26,7 @@ test('List', t => {
   t.ok(isObject(List([])), 'returns an object')
 
   t.ok(isFunction(List.of), 'provides an of function')
+  t.ok(isFunction(List.fromArray), 'provides a fromArray function')
   t.ok(isFunction(List.type), 'provides a type function')
 
   t.throws(List, TypeError, 'throws with no parameters')
@@ -115,6 +116,14 @@ test('List value', t => {
   const x = List([ 'some-thing', 34 ]).value()
 
   t.same(x, [ 'some-thing', 34 ], 'provides the wrapped array')
+
+  t.end()
+})
+
+test('List toArray', t => {
+  const a = List([ 'some-thing', ['else', 43], 34 ]).toArray()
+
+  t.same(a, [ 'some-thing', 'else', 43, 34 ], 'folds the wrapped array')
 
   t.end()
 })
@@ -379,6 +388,28 @@ test('List of', t => {
   t.equal(List.of, List([]).of, 'List.of is the same as the instance version')
   t.equal(List.of(0).type(), 'List', 'returns a List')
   t.same(List.of(0).value(), [ 0 ], 'wraps the value passed into List in an array')
+
+  t.end()
+})
+
+test('List fromArray', t => {
+  const fromArray = bindFunc(List.fromArray)
+
+  const notList = { type: constant('List...Not') }
+
+  t.throws(fromArray(undefined), TypeError, 'throws with undefined')
+  t.throws(fromArray(null), TypeError, 'throws with null')
+  t.throws(fromArray(0), TypeError, 'throws with falsey number')
+  t.throws(fromArray(1), TypeError, 'throws with truthy number')
+  t.throws(fromArray(''), TypeError, 'throws with falsey string')
+  t.throws(fromArray('string'), TypeError, 'throws with truthy string')
+  t.throws(fromArray(false), TypeError, 'throws with false')
+  t.throws(fromArray(true), TypeError, 'throws with true')
+  t.throws(fromArray({}), TypeError, 'throws with an object')
+  t.throws(fromArray(notList), TypeError, 'throws when passed non-List')
+
+  t.equal(List.fromArray([0]).type(), 'List', 'returns a List')
+  t.same(List.fromArray([0]).value(), [ 0 ], 'wraps the value passed into List in an array')
 
   t.end()
 })

--- a/crocks/List.spec.js
+++ b/crocks/List.spec.js
@@ -121,9 +121,10 @@ test('List value', t => {
 })
 
 test('List toArray', t => {
-  const a = List([ 'some-thing', 34 ]).toArray()
+  const data = [ 'some-thing', ['else', 43], 34 ]
+  const a = List(data).toArray()
 
-  t.same(a, [ 'some-thing', 34 ], 'provides the wrapped array')
+  t.same(a, data, 'provides the wrapped array')
 
   t.end()
 })
@@ -405,8 +406,10 @@ test('List fromArray', t => {
   t.throws(fromArray(true), TypeError, 'throws with true')
   t.throws(fromArray({}), TypeError, 'throws with an object')
 
+  const data = [[2, 1], 'a']
+
   t.equal(List.fromArray([0]).type(), 'List', 'returns a List')
-  t.same(List.fromArray([[2, 1], 'a']).value(), [[2, 1], 'a'], 'wraps the value passed into List in an array')
+  t.same(List.fromArray(data).value(), data, 'wraps the value passed into List in an array')
 
   t.end()
 })


### PR DESCRIPTION

![squirrel-624939](https://cloud.githubusercontent.com/assets/19234385/22909674/53603ed8-f20a-11e6-9485-bd1c7879b99b.jpg)
#61 

Right now we require an Array to be passed into List and this becomes silly when trying to use List as a Monoid in this fra... 😴 

- [ ] Remove Array constraint on List constructor, and have it work like of breaking
- [x] Add fromArray to List constructor
- [x] Add toArray to a List instance
- [ ] Add listToArray transformation function.
- [ ] Add arrayToList transformation function.
