### PR TITLE
Add `alt` and `zero` for `Alt` and `Plus` on the Coproducts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ All `Crocks` are Constructor functions of the given type, with `Writer` being an
 | Crock | Constructor | Instance |
 |---|:---|:---|
 | `Arrow` | `empty` | `both`, `concat`, `contramap`, `empty`, `first`, `map`, `promap`, `runWith`, `second`, `value` |
-| `Async` | `all`, `fromNode`, `fromPromise`, `of`, `rejected` | `ap`, `bimap`, `chain`, `coalesce`, `fork`, `map`, `of`, `swap`, `toPromise` |
+| `Async` | `all`, `fromNode`, `fromPromise`, `of`, `rejected` | `alt`, `ap`, `bimap`, `chain`, `coalesce`, `fork`, `map`, `of`, `swap`, `toPromise` |
 | `Const` | -- | `ap`, `chain`, `concat`, `equals`, `map`, `value` |
-| `Either` | `Left`, `Right`, `of`| `ap`, `bimap`, `chain`, `coalesce`, `either`, `equals`, `map`, `of`, `sequence`, `swap`, `traverse`, `value` |
+| `Either` | `Left`, `Right`, `of`| `alt`, `ap`, `bimap`, `chain`, `coalesce`, `either`, `equals`, `map`, `of`, `sequence`, `swap`, `traverse`, `value` |
 | `Identity` | `of` | `ap`, `chain`, `equals`, `map`, `of`, `sequence`, `traverse`, `value` |
 | `IO` | `of` | `ap`, `chain`, `map`, `of`, `run` |
 | `List` |  `empty`, `of` | `ap`, `chain`, `concat`, `cons`, `empty`, `equals`, `filter`, `head`, `map`, `of`, `reduce`, `sequence`, `tail`, `traverse`, `value` |
-| `Maybe` | `Nothing`, `Just`, `of` | `ap`, `chain`, `coalesce`, `equals`, `either`, `map`, `maybe`, `of`, `option`, `sequence`, `traverse` |
+| `Maybe` | `Nothing`, `Just`, `of`, `zero` | `alt`, `ap`, `chain`, `coalesce`, `equals`, `either`, `map`, `maybe`, `of`, `option`, `sequence`, `traverse`, `zero` |
 | `Pair` | `of` | `ap`, `bimap`, `chain`, `concat`, `equals`, `fst`, `map`, `merge`, `of`, `snd`, `swap`, `value` |
 | `Pred`[*] | `empty` | `concat`, `contramap`, `empty`, `runWith`, `value` |
 | `Reader` | `ask`, `of`| `ap`, `chain`, `map`, `of`, `runWith` |
@@ -198,6 +198,7 @@ There may come a time when you need to adjust a value when a condition is true, 
 All functions in this group have a signature of `* -> Boolean` and are used with the many predicate based functions that ship with `crocks`, like `safe`, `ifElse` and `filter` to name a few. They also fit naturally with the `Pred` ADT. Below is a list of all the current predicates that are included with a description of their truth:
 
 * `hasKey : (String | Number) -> a -> Boolean`: An Array or Object that contains the provided index or key
+* `isAlt : a -> Boolean`: an ADT that provides `map` and `alt` functions
 * `isApplicative : a -> Boolean`: an ADT that provides `map`, `ap` and `of` functions
 * `isApply : a -> Boolean`: an ADT that provides `map` and `ap` functions
 * `isArray : a -> Boolean`: Array
@@ -251,6 +252,7 @@ These functions provide a very clean way to build out very simple functions and 
 ##### Signatures
 | Function | Signature |
 |---|:---|
+| `alt` | `m a -> m a -> m a` |
 | `ap` | `m a -> m (a -> b) -> m b` |
 | `bimap` | `(a -> c) -> (b -> d) -> m a b -> m c d` |
 | `both` | `m (a -> b) -> m ((a, a) -> (b, b))` |
@@ -287,6 +289,7 @@ These functions provide a very clean way to build out very simple functions and 
 ##### Datatypes
 | Function | Datatypes |
 |---|:---|
+| `alt` | `Async`, `Either`, `Maybe` |
 | `ap` | `Async`, `Const`, `Either`, `Identity`, `IO`, `List`, `Maybe`, `Pair`, `Reader`, `State`, `Unit`, `Writer` |
 | `bimap` | `Async`, `Either`, `Pair` |
 | `both` | `Arrow`, `Function`, `Star` |

--- a/crocks.js
+++ b/crocks.js
@@ -66,6 +66,7 @@ const monoids = {
 }
 
 const pointFree = {
+  alt: require('./pointfree/alt'),
   ap: require('./pointfree/ap'),
   bimap: require('./pointfree/bimap'),
   both: require('./pointfree/both'),
@@ -102,6 +103,7 @@ const pointFree = {
 
 const predicates = {
   hasKey: require('./predicates/hasKey'),
+  isAlt: require('./predicates/isAlt'),
   isApplicative: require('./predicates/isApplicative'),
   isApply: require('./predicates/isApply'),
   isArray: require('./predicates/isArray'),

--- a/crocks.spec.js
+++ b/crocks.spec.js
@@ -34,6 +34,7 @@ const tryCatch = require('./helpers/tryCatch')
 const unless = require('./helpers/unless')
 const when = require('./helpers/when')
 
+const alt = require('./pointfree/alt')
 const ap = require('./pointfree/ap')
 const bimap = require('./pointfree/bimap')
 const chain = require('./pointfree/chain')
@@ -93,6 +94,7 @@ const Prod = require('./monoids/Prod')
 const Sum = require('./monoids/Sum')
 
 const hasKey = require('./predicates/hasKey')
+const isAlt = require('./predicates/isAlt')
 const isApplicative = require('./predicates/isApplicative')
 const isApply = require('./predicates/isApply')
 const isArray = require('./predicates/isArray')
@@ -154,6 +156,7 @@ test('entry', t => {
   t.equal(crocks.unless, unless, 'provides the unless function')
   t.equal(crocks.when, when, 'provides the when function')
 
+  t.equal(crocks.alt, alt, 'provides the alt point-free function')
   t.equal(crocks.ap, ap, 'provides the ap point-free function')
   t.equal(crocks.bimap, bimap, 'provides the bimap point-free function')
   t.equal(crocks.chain, chain, 'provides the chain point-free function')
@@ -213,6 +216,7 @@ test('entry', t => {
   t.equal(crocks.Sum, Sum, 'provides the Sum monoid')
 
   t.equal(crocks.hasKey, hasKey, 'provides the hasKey function')
+  t.equal(crocks.isAlt, isAlt, 'provides the isAlt function')
   t.equal(crocks.isApplicative, isApplicative, 'provides the isApplicative function')
   t.equal(crocks.isApply, isApply, 'provides the isApply function')
   t.equal(crocks.isArray, isArray, 'provides the isArray function')

--- a/crocks/Async.js
+++ b/crocks/Async.js
@@ -158,6 +158,19 @@ function Async(fn) {
     })
   }
 
+  function alt(m) {
+    if(!isSameType(Async, m)) {
+      throw new TypeError('Async.alt: Async required')
+    }
+
+    return Async((rej, res) => {
+      fork(
+        _ => m.fork(rej, res),
+        res
+      )
+    })
+  }
+
   function ap(m) {
     var fn, value
     var fnDone = false
@@ -214,8 +227,8 @@ function Async(fn) {
 
   return {
     fork, toPromise, inspect, type,
-    swap, coalesce, map, bimap, ap,
-    chain, of
+    swap, coalesce, map, bimap, alt,
+    ap, chain, of
   }
 }
 

--- a/crocks/Either.js
+++ b/crocks/Either.js
@@ -116,6 +116,17 @@ function Either(u) {
     )
   }
 
+  function alt(m) {
+    if(!isSameType(Either, m)) {
+      throw new TypeError('Either.alt: Either required')
+    }
+
+    return either(
+      constant(m),
+      Either.Right
+    )
+  }
+
   function ap(m) {
     if(!either(constant(true), isFunction)) {
       throw new TypeError('Either.ap: Wrapped value must be a function')
@@ -172,7 +183,7 @@ function Either(u) {
   return {
     inspect, either, value, type,
     swap, coalesce, equals, map, bimap,
-    ap, of, chain, sequence, traverse
+    alt, ap, of, chain, sequence, traverse
   }
 }
 

--- a/crocks/Maybe.js
+++ b/crocks/Maybe.js
@@ -17,11 +17,20 @@ const _maybe = defineUnion({ Nothing: [], Just: [ 'a' ] })
 const Nothing = _maybe.Nothing
 const Just = _maybe.Just
 
+Maybe.Nothing =
+  composeB(Maybe, Nothing)
+
+Maybe.Just =
+  composeB(Maybe, Just)
+
 const _of =
   composeB(Maybe, Just)
 
 const _type=
   constant('Maybe')
+
+const _zero =
+  composeB(Maybe, Nothing)
 
 function Maybe(u) {
   if(!arguments.length) {
@@ -36,6 +45,9 @@ function Maybe(u) {
 
   const type =
     _type
+
+  const zero =
+    _zero
 
   const option =
     n => either(constant(n), identity)
@@ -83,6 +95,17 @@ function Maybe(u) {
     return either(
       Maybe.Nothing,
       composeB(Maybe.Just, fn)
+    )
+  }
+
+  function alt(m) {
+    if(!isSameType(Maybe, m)) {
+      throw new TypeError('Maybe.alt: Maybe required')
+    }
+
+    return either(
+      constant(m),
+      Maybe.Just
     )
   }
 
@@ -154,8 +177,9 @@ function Maybe(u) {
 
   return {
     inspect, maybe, either, option,
-    type, equals, coalesce, map, ap,
-    of, chain, sequence, traverse
+    type, equals, coalesce, map, alt,
+    zero, ap, of, chain, sequence,
+    traverse
   }
 }
 
@@ -165,10 +189,7 @@ Maybe.of =
 Maybe.type =
   _type
 
-Maybe.Nothing =
-  composeB(Maybe, Nothing)
-
-Maybe.Just =
-  composeB(Maybe, Just)
+Maybe.zero =
+  _zero
 
 module.exports = Maybe

--- a/pointfree/alt.js
+++ b/pointfree/alt.js
@@ -1,0 +1,18 @@
+/** @license ISC License (c) copyright 2017 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const curry = require('../helpers/curry')
+
+const isAlt = require('../predicates/isAlt')
+const isSameType = require('../predicates/isSameType')
+
+// alt :: Alt m => m a -> m a -> m a
+function alt(m, x) {
+  if(!(isAlt(m) && isSameType(m, x))) {
+    throw new TypeError('alt: Both arguments must be Alts of the same type')
+  }
+
+  return x.alt(m)
+}
+
+module.exports = curry(alt)

--- a/pointfree/alt.spec.js
+++ b/pointfree/alt.spec.js
@@ -11,16 +11,16 @@ const identity = require('../combinators/identity')
 const constant = require('../combinators/constant')
 
 const mock = x => Object.assign({}, x, {
-  map: noop, of: noop, chain: noop, type: constant('silly')
+  map: noop, type: constant('silly')
 })
 
-const ap = require('./ap')
+const alt = require('./alt')
 
-test('ap pointfree', t => {
-  const a = bindFunc(ap)
-  const m = mock({ ap: identity })
+test('alt pointfree', t => {
+  const a = bindFunc(alt)
+  const m = mock({ alt: identity })
 
-  t.ok(isFunction(ap), 'is a function')
+  t.ok(isFunction(alt), 'is a function')
 
   t.throws(a(undefined, m), TypeError, 'throws if first arg is undefined')
   t.throws(a(null, m), TypeError, 'throws if first arg is null')
@@ -31,7 +31,7 @@ test('ap pointfree', t => {
   t.throws(a(false, m), TypeError, 'throws if first arg is false')
   t.throws(a(true, m), TypeError, 'throws if first arg is true')
   t.throws(a([], m), TypeError, 'throws if first arg is an array')
-  t.throws(a({}, m), TypeError, 'throws if first arg is an object without an ap method')
+  t.throws(a({}, m), TypeError, 'throws if first arg is an object')
 
   t.throws(a(m, undefined), TypeError, 'throws if second arg is undefined')
   t.throws(a(m, null), TypeError, 'throws if second arg is null')
@@ -42,18 +42,18 @@ test('ap pointfree', t => {
   t.throws(a(m, false), TypeError, 'throws if second arg is false')
   t.throws(a(m, true), TypeError, 'throws if second arg is true')
   t.throws(a(m, []), TypeError, 'throws if second arg is an array')
-  t.throws(a(m, {}), TypeError, 'throws if second arg is an object without an ap method')
+  t.throws(a(m, {}), TypeError, 'throws if second arg is an object')
 
   t.end()
 })
 
-test('ap applicative', t => {
-  const m = mock({ ap: sinon.spy(identity) })
-  const x = mock({ ap: sinon.spy(identity) })
+test('alt with Alt', t => {
+  const m = mock({ alt: sinon.spy(identity) })
+  const x = mock({ alt: sinon.spy(identity) })
 
-  const result = ap(m)(x)
+  const result = alt(m)(x)
 
-  t.ok(x.ap.calledWith(m), 'calls the ap method on the second arg passing in the first arg')
+  t.ok(x.alt.calledWith(m), 'calls the alt function on the second arg passing in the first arg')
 
   t.end()
 })

--- a/pointfree/ap.js
+++ b/pointfree/ap.js
@@ -3,11 +3,12 @@
 
 const curry = require('../helpers/curry')
 
-const isFunction = require('../predicates/isFunction')
+const isApplicative = require('../predicates/isApplicative')
+const isSameType = require('../predicates/isSameType')
 
 // ap :: Applicative m => m a -> m (a -> b) ->  m b
 function ap(m, x) {
-  if(!(m && isFunction(m.ap)) || !(m && isFunction(x.ap))) {
+  if(!(isApplicative(m) && isSameType(m, x))) {
     throw new TypeError('ap: Both arguments must be Applys of the same type')
   }
 

--- a/predicates/isAlt.js
+++ b/predicates/isAlt.js
@@ -1,0 +1,14 @@
+/** @license ISC License (c) copyright 2017 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const isFunction = require('./isFunction')
+const isFunctor = require('./isFunctor')
+
+// isAlt : a -> Boolean
+function isAlt(m) {
+  return !!m
+    && isFunctor(m)
+    && isFunction(m.alt)
+}
+
+module.exports = isAlt

--- a/predicates/isAlt.spec.js
+++ b/predicates/isAlt.spec.js
@@ -1,0 +1,32 @@
+const test = require('tape')
+
+const isFunction = require('./isFunction')
+
+const identity = require('../combinators/identity')
+
+const isAlt = require('./isAlt')
+
+test('isAlt predicate function', t => {
+  const fake = {
+    map: identity,
+    alt: identity
+  }
+
+  t.ok(isFunction(isAlt), 'is a function')
+
+  t.equal(isAlt(undefined), false, 'returns false for undefined')
+  t.equal(isAlt(null), false, 'returns false for null')
+  t.equal(isAlt(0), false, 'returns false for falsey number')
+  t.equal(isAlt(1), false, 'returns false for truthy number')
+  t.equal(isAlt(''), false, 'returns false for falsey string')
+  t.equal(isAlt('string'), false, 'returns false for truthy string')
+  t.equal(isAlt(false), false, 'returns false for false')
+  t.equal(isAlt(true), false, 'returns false for true')
+  t.equal(isAlt({}), false, 'returns false for an object')
+  t.equal(isAlt([]), false, 'returns false for an array')
+  t.equal(isAlt(identity), false, 'returns false for function')
+
+  t.equal(isAlt(fake), true, 'returns true when an Alt is passed')
+
+  t.end()
+})


### PR DESCRIPTION
## The only Alternative to meat
![](https://mir-s3-cdn-cf.behance.net/project_modules/disp/dbe3a713770503.56277fe4f0987.jpg)

This PR adds `alt` to instance of the following:
* `Async`
* `Either`
* `Maybe`

`alt` pointfree and `isAlt` predicates functions were also added. Not going to add `isPlus` right now because I am deciding how to deal with JS types that can be falsey.

Also adds `zero` to both the instance and constructor of `Maybe`