### PR TITLE
Clean up Logic functions with new `predOrFunc` internal helper

### DIFF
--- a/crocks/List.js
+++ b/crocks/List.js
@@ -7,6 +7,7 @@ const isFunction = require('../predicates/isFunction')
 const isSameType = require('../predicates/isSameType')
 
 const _inspect = require('../internal/inspect')
+const predOrFunc = require('../internal/predOrFunc')
 
 const constant = require('../combinators/constant')
 const not = require('../logic/not')
@@ -141,9 +142,7 @@ function List(x) {
       throw new TypeError('List.filter: Pred or predicate function required')
     }
 
-    const fn = isFunction(pred)
-      ? pred
-      : pred.runWith
+    const fn = predOrFunc(pred)
 
     return reduce(
       (x, y) => fn(y) ? x.concat(x.of(y)) : x,
@@ -156,7 +155,7 @@ function List(x) {
       throw new TypeError('List.reject: Pred or predicate function required')
     }
 
-    const fn = not(isFunction(pred) ? pred : pred.runWith)
+    const fn = not(predOrFunc(pred))
 
     return reduce(
       (x, y) => fn(y) ? x.concat(x.of(y)) : x,

--- a/helpers/safe.js
+++ b/helpers/safe.js
@@ -9,6 +9,7 @@ const ifElse = require('../logic/ifElse')
 
 const Maybe = require('../crocks/Maybe')
 const Pred = require('../crocks/Pred')
+const predOrFunc = require('../internal/predOrFunc')
 
 const Nothing = Maybe.Nothing
 const Just = Maybe.Just
@@ -18,11 +19,8 @@ function safe(pred) {
   if(!(isFunction(pred) || isSameType(Pred, pred))) {
     throw new TypeError('safe: Pred or predicate function required for first argument')
   }
-  const fn = isFunction(pred)
-    ? pred
-    : pred.runWith
 
-  return ifElse(fn, Just, Nothing)
+  return ifElse(predOrFunc(pred), Just, Nothing)
 }
 
 module.exports = curry(safe)

--- a/internal/predOrFunc.js
+++ b/internal/predOrFunc.js
@@ -1,0 +1,10 @@
+/** @license ISC License (c) copyright 2017 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const flip = require('../combinators/flip')
+const identity = require('../combinators/identity')
+const ifElse = require('../logic/ifElse')
+const isFunction = require('../predicates/isFunction')
+const runWith = require('../pointfree/runWith')
+
+module.exports = ifElse(isFunction, identity, flip(runWith))

--- a/internal/predOrFunc.spec.js
+++ b/internal/predOrFunc.spec.js
@@ -1,0 +1,30 @@
+const test = require('tape')
+const sinon = require('sinon')
+
+const helpers = require('../test/helpers')
+
+const noop = helpers.noop
+
+const isFunction = require('../predicates/isFunction')
+const predOrFunc = require('./predOrFunc')
+
+test('predOrFunc internal', t => {
+  t.ok(isFunction(predOrFunc), 'is a function')
+
+  const f = sinon.spy()
+  const P = { runWith: sinon.spy() }
+
+  const withFunc = predOrFunc(f)
+  const withPred = predOrFunc(P)
+
+  t.ok(isFunction(withFunc), 'passing a function returns a function')
+  t.ok(isFunction(withPred), 'passing a Pred returns a function')
+
+  withFunc('func')
+  withPred('pred')
+
+  t.ok(f.calledWith('func'), 'calls the function, passing the argument')
+  t.ok(P.runWith.calledWith('pred'), 'calls the `runWith` function on Pred, passing the argument')
+
+  t.end()
+})

--- a/logic/and.js
+++ b/logic/and.js
@@ -5,14 +5,9 @@ const isFunction = require('../predicates/isFunction')
 const isSameType = require('../predicates/isSameType')
 
 const Pred = require('../crocks/Pred')
+const predOrFunc = require('../internal/predOrFunc')
 
 const curry = require('../helpers/curry')
-const identity = require('../combinators/identity')
-
-const ifElse = require('./ifElse')
-
-const predOrFunc =
-  ifElse(isFunction, identity, x => x.runWith)
 
 // and : (a -> Boolean) | Pred -> (a -> Boolean) | Pred -> a -> Boolean
 function and(f, g) {

--- a/logic/ifElse.js
+++ b/logic/ifElse.js
@@ -18,9 +18,8 @@ function ifElse(pred, f, g) {
     throw new TypeError('ifElse: Functions required for second and third arguments')
   }
 
-  const func = isFunction(pred)
-    ? pred
-    : pred.runWith
+  const func =
+    isFunction(pred) ? pred : pred.runWith
 
   return x => !!func(x) ? f(x) : g(x)
 }

--- a/logic/not.js
+++ b/logic/not.js
@@ -7,6 +7,7 @@ const isFunction = require('../predicates/isFunction')
 const isSameType = require('../predicates/isSameType')
 
 const Pred = require('../crocks/Pred')
+const predOrFunc = require('../internal/predOrFunc')
 
 // not : (a -> Boolean) | Pred -> a -> Boolean
 function not(pred, x) {
@@ -14,11 +15,7 @@ function not(pred, x) {
     throw new TypeError('not: Pred or predicate function required for first argument')
   }
 
-  const func = isFunction(pred)
-    ? pred
-    : pred.runWith
-
-  return !func(x)
+  return !predOrFunc(pred, x)
 }
 
 module.exports = curry(not)

--- a/logic/or.js
+++ b/logic/or.js
@@ -5,14 +5,9 @@ const isFunction = require('../predicates/isFunction')
 const isSameType = require('../predicates/isSameType')
 
 const Pred = require('../crocks/Pred')
+const predOrFunc = require('../internal/predOrFunc')
 
 const curry = require('../helpers/curry')
-const identity = require('../combinators/identity')
-
-const ifElse = require('./ifElse')
-
-const predOrFunc =
-  ifElse(isFunction, identity, x => x.runWith)
 
 // or : (a -> Boolean) | Pred -> (a -> Boolean) | Pred -> a -> Boolean
 function or(f, g) {

--- a/logic/unless.js
+++ b/logic/unless.js
@@ -5,6 +5,11 @@ const isFunction = require('../predicates/isFunction')
 const isSameType = require('../predicates/isSameType')
 
 const Pred = require('../crocks/Pred')
+const predOrFunc = require('../internal/predOrFunc')
+
+const identity = require('../combinators/identity')
+const ifElse = require('./ifElse')
+const not = require('./not')
 
 const curry = require('../helpers/curry')
 
@@ -18,11 +23,7 @@ function unless(pred, f) {
     throw new TypeError('unless: Function required for second argument')
   }
 
-  const func = isFunction(pred)
-    ? pred
-    : pred.runWith
-
-  return x => !func(x) ? f(x) : x
+  return ifElse(not(predOrFunc(pred)), f, identity)
 }
 
 module.exports = curry(unless)

--- a/logic/when.js
+++ b/logic/when.js
@@ -5,6 +5,10 @@ const isFunction = require('../predicates/isFunction')
 const isSameType = require('../predicates/isSameType')
 
 const Pred = require('../crocks/Pred')
+const predOrFunc = require('../internal/predOrFunc')
+
+const identity = require('../combinators/identity')
+const ifElse = require('./ifElse')
 
 const curry = require('../helpers/curry')
 
@@ -18,11 +22,7 @@ function when(pred, f) {
     throw new TypeError('when: Function required for second argument')
   }
 
-  const func = isFunction(pred)
-    ? pred
-    : pred.runWith
-
-  return x => !!func(x) ? f(x) : x
+  return ifElse(predOrFunc(pred), f, identity)
 }
 
 module.exports = curry(when)

--- a/pointfree/filter.js
+++ b/pointfree/filter.js
@@ -7,6 +7,7 @@ const isFunction = require('../predicates/isFunction')
 const isSameType = require('../predicates/isSameType')
 
 const Pred = require('../crocks/Pred')
+const predOrFunc = require('../internal/predOrFunc')
 
 // filter : Foldable f => (a -> Boolean) -> f a -> f a
 function filter(pred, m) {
@@ -14,15 +15,10 @@ function filter(pred, m) {
     throw new TypeError('filter: Pred or predicate function required for first argument')
   }
   else if(m && isFunction(m.filter)) {
-    const fn = isFunction(pred)
-      ? pred
-      : pred.runWith
+    return m.filter(predOrFunc(pred))
+  }
 
-    return m.filter(fn)
-  }
-  else {
-    throw new TypeError('filter: Foldable required for second argument')
-  }
+  throw new TypeError('filter: Foldable required for second argument')
 }
 
 module.exports = curry(filter)

--- a/pointfree/filter.spec.js
+++ b/pointfree/filter.spec.js
@@ -1,5 +1,4 @@
 const test = require('tape')
-const sinon = require('sinon')
 const helpers = require('../test/helpers')
 
 const bindFunc = helpers.bindFunc
@@ -7,6 +6,7 @@ const noop = helpers.noop
 
 const isFunction = require('../predicates/isFunction')
 
+const constant = require('../combinators/constant')
 const identity = require('../combinators/identity')
 
 const Pred = require('../crocks/Pred')
@@ -50,11 +50,11 @@ test('filter pointfree', t => {
 })
 
 test('filter Foldable', t => {
-  const m = { filter: sinon.spy(noop) }
+  const m = { filter: constant('called') }
 
-  filter(identity, m)
+  const result = filter(identity, m)
 
-  t.ok(m.filter.calledWith(identity), 'calls filter on Foldable, passing the function')
+  t.equals(result, 'called', 'calls filter on Foldable, passing the function')
 
   t.end()
 })

--- a/pointfree/reject.js
+++ b/pointfree/reject.js
@@ -3,15 +3,13 @@
 
 const curry = require('../helpers/curry')
 
-const ifElse = require('../logic/ifElse')
 const isArray = require('../predicates/isArray')
 const isFunction = require('../predicates/isFunction')
 const isSameType = require('../predicates/isSameType')
 const not = require('../logic/not')
 
-const identity = require('../combinators/identity')
-
 const Pred = require('../crocks/Pred')
+const predOrFunc = require('../internal/predOrFunc')
 
 // reject : Foldable f => (a -> Boolean) -> f a -> f a
 function reject(pred, m) {
@@ -19,8 +17,7 @@ function reject(pred, m) {
     throw new TypeError('reject: Pred or predicate function required for first argument')
   }
 
-  const fn =
-    ifElse(isFunction, identity, p => p.runWith, pred)
+  const fn = predOrFunc(pred)
 
   if(isArray(m)) {
     return m.filter(not(fn))


### PR DESCRIPTION
## Clean it UP
![](https://c1.staticflickr.com/2/1091/623559183_9a6bcd3028_b.jpg)

Well time to DRY some bits up, we are at that stage now as many of the abstractions are presenting themselves. The simplest and most obvious is the selection of either a predicate function or running a `Pred`. This is the first of many clean up PRs that will be coming down the pipe as we get close to `1.0.0`

All this does is replace the copied selection code with a new helper that captures that flow.