### PR TITLE
Remove of and value from Pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ All `Crocks` are Constructor functions of the given type, with `Writer` being an
 | `IO` | `of` | `ap`, `chain`, `map`, `of`, `run` |
 | `List` |  `empty`, `fromArray`, `of` | `ap`, `chain`, `concat`, `cons`, `empty`, `equals`, `filter`, `head`, `map`, `of`, `reduce`, `reject`, `sequence`, `tail`, `toArray`, `traverse`, `value` |
 | `Maybe` | `Nothing`, `Just`, `of`, `zero` | `alt`, `ap`, `chain`, `coalesce`, `concat`, `equals`, `either`, `map`, `of`, `option`, `sequence`, `traverse`, `zero` |
-| `Pair` | `of` | `ap`, `bimap`, `chain`, `concat`, `equals`, `fst`, `map`, `merge`, `of`, `snd`, `swap`, `value` |
+| `Pair` | --- | `ap`, `bimap`, `chain`, `concat`, `equals`, `fst`, `map`, `merge`, `of`, `snd`, `swap` |
 | `Pred` * | `empty` | `concat`, `contramap`, `empty`, `runWith`, `value` |
 | `Reader` | `ask`, `of`| `ap`, `chain`, `map`, `of`, `runWith` |
 | `Star` | -- | `both`, `concat`, `contramap`, `map`, `promap`, `runWith` |
@@ -226,7 +226,7 @@ All functions in this group have a signature of `* -> Boolean` and are used with
 * `isNil : a -> Boolean`: undefined or null
 * `isNumber : a -> Boolean`: Number that is not a NaN value, Infinity included
 * `isObject : a -> Boolean`: Plain Old Javascript Object (POJO)
-* `isSameType : a -> b -> Boolean`: both ADTs are of the same type (Instance or TypeRep)
+* `isSameType : a -> b -> Boolean`: Constructor matches a values type, or two values types match
 * `isSemigroup : a -> Boolean`: an ADT that provides a `concat` function
 * `isSetoid : a -> Boolean`: an ADT that provides an `equals` function
 * `isString : a -> Boolean`: String
@@ -334,7 +334,7 @@ These functions provide a very clean way to build out very simple functions and 
 | `swap` | `Async`, `Either`, `Pair` |
 | `tail` | `Array`, `List`, `String` |
 | `traverse` | `Array`, `Either`, `Identity`, `List`, `Maybe` |
-| `value` | `Arrow`, `Const`, `Identity`, `List`, `Pair`, `Pred`, `Unit`, `Writer` |
+| `value` | `Arrow`, `Const`, `Identity`, `List`, `Pred`, `Unit`, `Writer` |
 
 ### Transformation Functions
 Transformation functions are mostly used to reduce unwanted nesting of similar types. Take for example the following structure:

--- a/crocks/Arrow.js
+++ b/crocks/Arrow.js
@@ -70,7 +70,7 @@ function Arrow(runWith) {
 
   function first() {
     return Arrow(function(x) {
-      if(!(x && x.type && x.type() === Pair.type())) {
+      if(!(isSameType(Pair, x))) {
         throw TypeError('Arrow.first: Pair required for inner argument')
       }
       return x.bimap(runWith, identity)
@@ -79,7 +79,7 @@ function Arrow(runWith) {
 
   function second() {
     return Arrow(function(x) {
-      if(!(x && x.type && x.type() === Pair.type())) {
+      if(!(isSameType(Pair, x))) {
         throw TypeError('Arrow.second: Pair required for inner argument')
       }
 
@@ -89,7 +89,7 @@ function Arrow(runWith) {
 
   function both() {
     return Arrow(function(x) {
-      if(!(x && x.type && x.type() === Pair.type())) {
+      if(!(isSameType(Pair, x))) {
         throw TypeError('Arrow.both: Pair required for inner argument')
       }
       return x.bimap(runWith, runWith)

--- a/crocks/Arrow.spec.js
+++ b/crocks/Arrow.spec.js
@@ -362,7 +362,7 @@ test('Arrow first', t => {
   t.throws(runWith([]), TypeError, 'throws with an array as inner argument')
   t.throws(runWith({}), TypeError, 'throws with an object as inner argument')
 
-  t.doesNotThrow(runWith(Pair.of(2)), 'does not throw when inner value is a Pair')
+  t.doesNotThrow(runWith(Pair(1, 2)), 'does not throw when inner value is a Pair')
 
   const result = m.first().runWith(Pair(10, 10))
 
@@ -391,7 +391,7 @@ test('Arrow second', t => {
   t.throws(runWith([]), TypeError, 'throws with an array as inner argument')
   t.throws(runWith({}), TypeError, 'throws with an object as inner argument')
 
-  t.doesNotThrow(runWith(Pair.of(2)), 'does not throw when inner value is a Pair')
+  t.doesNotThrow(runWith(Pair(1, 2)), 'does not throw when inner value is a Pair')
 
   const result = m.second().runWith(Pair(10, 10))
 
@@ -420,7 +420,7 @@ test('Arrow both', t => {
   t.throws(runWith([]), TypeError, 'throws with an array as inner argument')
   t.throws(runWith({}), TypeError, 'throws with an object as inner argument')
 
-  t.doesNotThrow(runWith(Pair.of(2)), 'does not throw when inner value is a Pair')
+  t.doesNotThrow(runWith(Pair(1, 2)), 'does not throw when inner value is a Pair')
 
   const result = m.both().runWith(Pair(10, 10))
 

--- a/crocks/Pair.js
+++ b/crocks/Pair.js
@@ -9,13 +9,8 @@ const isSameType = require('../predicates/isSameType')
 
 const constant = require('../combinators/constant')
 
-const Unit = require('./Unit')
-
 const _type =
   constant('Pair')
-
-const _of =
-  x => Pair(Unit(), x)
 
 function Pair(l, r) {
   if(arguments.length < 2) {
@@ -24,12 +19,6 @@ function Pair(l, r) {
 
   const type =
     _type
-
-  const of =
-    _of
-
-  const value =
-    constant([ l, r ])
 
   const fst =
     constant(l)
@@ -136,17 +125,13 @@ function Pair(l, r) {
   }
 
   return {
-    inspect, value, fst, snd,
-    type, merge, equals, concat,
-    swap, map, bimap, ap, of,
-    chain
+    inspect, fst, snd, type,
+    merge, equals, concat, swap,
+    map, bimap, ap, chain
   }
 }
 
 Pair.type =
   _type
-
-Pair.of =
-  _of
 
 module.exports = Pair

--- a/crocks/Star.js
+++ b/crocks/Star.js
@@ -12,6 +12,7 @@ const compose = require('../helpers/compose')
 const constant = require('../combinators/constant')
 const identity = require('../combinators/identity')
 
+const merge = require('../pointfree/merge')
 const sequence = require('../pointfree/sequence')
 
 const Pair = require('./Pair')
@@ -139,7 +140,7 @@ function Star(runWith) {
         throw new TypeError('Star.both: Computaion must return a Monad')
       }
 
-      return sequence(m.of, p.value()).map(x => Pair(x[0], x[1]))
+      return sequence(m.of, merge((x, y) => [ x, y ], p)).map(x => Pair(x[0], x[1]))
     })
   }
 

--- a/crocks/Star.spec.js
+++ b/crocks/Star.spec.js
@@ -373,7 +373,7 @@ test('Star first', t => {
   t.throws(runWith([]), TypeError, 'throws with an array as input')
   t.throws(runWith({}), TypeError, 'throws with an object as input')
 
-  t.doesNotThrow(runWith(Pair.of(2)), 'does not throw when inner value is a Pair')
+  t.doesNotThrow(runWith(Pair(1, 2)), 'does not throw when inner value is a Pair')
 
   const notValid = bindFunc(x => Star(_ => x).first().runWith(Pair(2, 3)))
 
@@ -414,7 +414,7 @@ test('Star second', t => {
   t.throws(runWith([]), TypeError, 'throws with an array as input')
   t.throws(runWith({}), TypeError, 'throws with an object as input')
 
-  t.doesNotThrow(runWith(Pair.of(2)), 'does not throw when inner value is a Pair')
+  t.doesNotThrow(runWith(Pair(1, 2)), 'does not throw when inner value is a Pair')
 
   const notValid = bindFunc(x => Star(_ => x).second().runWith(Pair(2, 3)))
 
@@ -457,7 +457,7 @@ test('Star both', t => {
   t.throws(runWith([]), TypeError, 'throws with an array as input')
   t.throws(runWith({}), TypeError, 'throws with an object as input')
 
-  t.doesNotThrow(runWith(Pair.of(2)), 'does not throw when inner value is a Pair')
+  t.doesNotThrow(runWith(Pair(1, 2)), 'does not throw when inner value is a Pair')
 
   const notValid = bindFunc(x => Star(_ => x).both().runWith(Pair(2, 3)))
 

--- a/helpers/branch.spec.js
+++ b/helpers/branch.spec.js
@@ -1,24 +1,28 @@
 const test = require('tape')
 
 const isFunction = require('../predicates/isFunction')
+const merge = require('../pointfree/merge')
 
 const branch = require('./branch')
 
 test('branch function', t => {
+  const extract =
+    merge((x, y) => [ x, y ])
+
   t.ok(isFunction(branch), 'is a function')
 
   t.equal(branch(3).type(), 'Pair', 'returns a Pair')
 
-  t.same(branch(undefined).value(), [ undefined, undefined ], 'undefined returns a Pair of undefined')
-  t.same(branch(null).value(), [ null, null ], 'undefined returns a Pair of null')
-  t.same(branch(0).value(), [ 0, 0 ], '0 returns a Pair of 0')
-  t.same(branch(1).value(), [ 1, 1 ], '1 returns a Pair of 1')
-  t.same(branch('').value(), [ '', '' ], 'empty string returns a Pair of empty strings')
-  t.same(branch('string').value(), [ 'string', 'string' ], '"string" returns a Pair of "string"')
-  t.same(branch(false).value(), [ false, false ], 'false returns a Pair of falses')
-  t.same(branch(true).value(), [ true, true ], 'true returns a Pair of trues')
-  t.same(branch([]).value(), [ [], [] ], 'array returns a Pair of arrays')
-  t.same(branch({}).value(), [ {}, {} ], 'object returns a Pair of objects')
+  t.same(extract(branch(undefined)), [ undefined, undefined ], 'undefined returns a Pair of undefined')
+  t.same(extract(branch(null)), [ null, null ], 'undefined returns a Pair of null')
+  t.same(extract(branch(0)), [ 0, 0 ], '0 returns a Pair of 0')
+  t.same(extract(branch(1)), [ 1, 1 ], '1 returns a Pair of 1')
+  t.same(extract(branch('')), [ '', '' ], 'empty string returns a Pair of empty strings')
+  t.same(extract(branch('string')), [ 'string', 'string' ], '"string" returns a Pair of "string"')
+  t.same(extract(branch(false)), [ false, false ], 'false returns a Pair of falses')
+  t.same(extract(branch(true)), [ true, true ], 'true returns a Pair of trues')
+  t.same(extract(branch([])), [ [], [] ], 'array returns a Pair of arrays')
+  t.same(extract(branch({})), [ {}, {} ], 'object returns a Pair of objects')
 
   t.end()
 })


### PR DESCRIPTION
## Some ideas are bad
![](http://img13.deviantart.net/6073/i/2011/256/d/9/i_got_some_bad_ideas_in_myhead_by_roastedrat-d49sqmg.jpg)

This PR addresses [issue#59](https://github.com/evilsoft/crocks/issues/59).

`of` and `value` are proving to be problematic and create more issues then solve. This removes them and switches over all dependent specs to use `merge` for extraction.