### PR TITLE
Update docs to match 0.4.0 release

### DIFF
--- a/docs/crocks/Either.md
+++ b/docs/crocks/Either.md
@@ -14,7 +14,7 @@
 
 | Constructor | Instance |
 |:---|:---|
-| [`Left`](#left), [`Right`](#right), [`of`](#of), [`type`](#type) | [`alt`](#alt), [`ap`](#ap), [`bimap`](#bimap), [`chain`](#chain), [`coalesce`](#coalesce), [`either`](#either), [`equals`](#equals), [`inspect`](#inspect), [`map`](#map),  [`of`](#of), [`sequence`](#sequence), [`swap`](#swap), [`traverse`](#traverse), [`type`](#type) |
+| [`Left`](#left), [`Right`](#right), [`of`](#of), [`type`](#type) | [`alt`](#alt), [`ap`](#ap), [`bimap`](#bimap), [`chain`](#chain), [`coalesce`](#coalesce), [`concat`](#concat), [`either`](#either), [`equals`](#equals), [`inspect`](#inspect), [`map`](#map),  [`of`](#of), [`sequence`](#sequence), [`swap`](#swap), [`traverse`](#traverse), [`type`](#type) |
 
 ## Constructor
 
@@ -55,6 +55,10 @@
 ### coalesce
 
 `Either m => m c a ~> (c -> b) -> (a -> b) -> m _ b`
+
+### concat
+
+`Either m, Semigroup a => m c a ~> m c a -> m c a`
 
 ### either
 

--- a/docs/crocks/Identity.md
+++ b/docs/crocks/Identity.md
@@ -14,7 +14,7 @@
 
 | Constructor | Instance |
 |:---|:---|
-| [`of`](#of), [`type`](#type) | [`ap`](#ap), [`chain`](#chain), [`equals`](#equals), [`inspect`](#inspect), [`map`](#map), [`of`](#of), [`sequence`](#sequence), [`traverse`](#traverse), [`type`](#type), [`value`](#value) |
+| [`of`](#of), [`type`](#type) | [`ap`](#ap), [`chain`](#chain), [`concat`](#concat), [`equals`](#equals), [`inspect`](#inspect), [`map`](#map), [`of`](#of), [`sequence`](#sequence), [`traverse`](#traverse), [`type`](#type), [`value`](#value) |
 
 ## Constructor
 
@@ -35,6 +35,10 @@
 ### chain
 
 `Identity m => m a ~> (a -> m b) -> m b`
+
+### concat
+
+`Identity m, Semigroup a => m a ~> m a -> m a`
 
 ### equals
 

--- a/docs/crocks/Maybe.md
+++ b/docs/crocks/Maybe.md
@@ -14,7 +14,7 @@
 
 | Constructor | Instance |
 |:---|:---|
-| [`Just`](#just), [`Nothing`](#nothing), [`of`](#of), [`type`](#type), [`zero`](#zero) | [`alt`](#alt), [`ap`](#ap), [`chain`](#chain), [`coalesce`](#coalesce), [`either`](#either), [`equals`](#equals), [`inspect`](#inspect), [`map`](#map), [`maybe`](#maybe), [`of`](#of), [`option`](#option), [`sequence`](#sequence), [`traverse`](#traverse), [`type`](#type) |
+| [`Just`](#just), [`Nothing`](#nothing), [`of`](#of), [`type`](#type), [`zero`](#zero) | [`alt`](#alt), [`ap`](#ap), [`chain`](#chain), [`coalesce`](#coalesce), [`concat`](#concat), [`either`](#either), [`equals`](#equals), [`inspect`](#inspect), [`map`](#map), [`maybe`](#maybe), [`of`](#of), [`option`](#option), [`sequence`](#sequence), [`traverse`](#traverse), [`type`](#type) |
 
 ## Constructor
 
@@ -55,6 +55,10 @@
 ### coalesce
 
 `Maybe m => m a ~> (() -> b) -> (a -> b) -> m b`
+
+### concat
+
+`Maybe m, Semigroup a => m a ~> m a -> m a`
 
 ### either
 

--- a/docs/crocks/Pair.md
+++ b/docs/crocks/Pair.md
@@ -14,7 +14,7 @@
 
 | Constructor | Instance |
 |:---|:---|
-| [`type`](#type) | [`ap`](#ap), [`bimap`](#bimap), [`chain`](#chain), [`concat`](#concat), [`equals`](#equals), [`fst`](#fst), [`inspect`](#inspect),  [`map`](#map), [`merge`](#merge), [`of`](#of), [`type`](#type), [`snd`](#snd), [`swap`](#swap), [`value`](#value) |
+| [`type`](#type) | [`ap`](#ap), [`bimap`](#bimap), [`chain`](#chain), [`concat`](#concat), [`equals`](#equals), [`fst`](#fst), [`inspect`](#inspect), [`map`](#map), [`merge`](#merge), [`of`](#of), [`type`](#type), [`snd`](#snd), [`swap`](#swap) |
 
 ## Constructor
 
@@ -71,7 +71,3 @@
 ### swap
 
 `Pair m => m c a ~> (c -> d) -> (a -> b) -> m b d`
-
-### value
-
-`Pair m => m c a ~> () -> [ c, a ]`


### PR DESCRIPTION
## The joy of writing docs early
![](https://media.giphy.com/media/LfkvjQD6CEgHS/giphy.gif)

This updates the docs to match the upcoming/already released `0.4.0`

This tracks: 
* Removal of `of` and `value` from `Pair`.
* Addition of `concat` to `Identity`, `Either` and `Maybe`