### PR TITLE
`Pred` should only return `Boolean`s

### DIFF
--- a/crocks/Pred.js
+++ b/crocks/Pred.js
@@ -15,10 +15,13 @@ const _type =
 const _empty =
   () => Pred(constant(true))
 
-function Pred(runWith) {
-  if(!isFunction(runWith)) {
+function Pred(pred) {
+  if(!isFunction(pred)) {
     throw new TypeError('Pred: Predicate function required')
   }
+
+  const runWith =
+    x => !!pred(x)
 
   const type =
     _type
@@ -37,7 +40,7 @@ function Pred(runWith) {
       throw new TypeError('Pred.concat: Pred required')
     }
 
-    return Pred(x => runWith(x) && m.runWith(x))
+    return Pred(x => !!runWith(x) && !!m.runWith(x))
   }
 
   function contramap(fn) {

--- a/crocks/Pred.spec.js
+++ b/crocks/Pred.spec.js
@@ -56,11 +56,11 @@ test('Pred type', t => {
 })
 
 test('Pred value', t => {
-  const f = constant('some Predicate')
+  const f = constant('')
   const p = Pred(f)
 
   t.ok(isFunction(p.value), 'is a function')
-  t.equal(p.value()(), f(), 'provides the wrapped function')
+  t.equals(p.value()(), !!f(), 'returns a coerced to Boolean version of the function')
 
   t.end()
 })
@@ -69,10 +69,25 @@ test('Pred runWith', t => {
   const fn = sinon.spy(constant('result'))
   const m = Pred(fn)
 
+  const nonBoolPred =
+    x => Pred(constant(x)).runWith()
+
+  t.equals(nonBoolPred(undefined), false, 'returns false when wrapped function returns undefined')
+  t.equals(nonBoolPred(null), false, 'returns false when wrapped function returns null')
+  t.equals(nonBoolPred(0), false, 'returns false when wrapped function returns falsey number')
+  t.equals(nonBoolPred(1), true, 'returns true when wrapped function returns truthy number')
+  t.equals(nonBoolPred(''), false, 'returns false when wrapped function returns falsey string')
+  t.equals(nonBoolPred('string'), true, 'returns true when wrapped function returns truthy string')
+  t.equals(nonBoolPred(false), false, 'returns false when wrapped function returns false')
+  t.equals(nonBoolPred(true), true, 'returns true when wrapped function returns true')
+  t.equals(nonBoolPred({}), true, 'returns true when wrapped function returns an object')
+  t.equals(nonBoolPred([]), true, 'returns true when wrapped function returns an array')
+  t.equals(nonBoolPred(noop), true, 'returns true when wrapped function returns a function')
+
   const result = m.runWith(false)
 
   t.ok(fn.called, 'calls the wrapped function')
-  t.equal(result, fn(),'returns result of the wrapped function' )
+  t.equal(result, !!fn(),'returns Boolean equiv result of the wrapped function' )
 
   t.end()
 })
@@ -108,7 +123,7 @@ test('Pred contramap functionality', t => {
   m.runWith(x)
 
   t.ok(spy.called, 'calls mapping function when ran')
-  t.equal(m.runWith(x), x, 'returns the result of the resulting composition')
+  t.equal(m.runWith(x), !!x, 'returns the Boolean equiv result of the resulting composition')
 
   t.end()
 })


### PR DESCRIPTION
## Through the cracks
![](https://www.zappbug.com/wp-content/uploads/2015/04/8-Steps-to-Get-Rid-of-Bed-Bugs-Banner.png)

Looks like we were not returning `Boolean` values from runWith in `Pred`, we should.
This PR fixes that.