### PR TITLE
Add the `Async` Skeleton.

### DIFF
--- a/docs/crocks/Async.md
+++ b/docs/crocks/Async.md
@@ -1,0 +1,96 @@
+# Async
+
+`Async c a`
+
+--
+
+--
+
+```js
+--
+```
+
+`Async` exposes the following functions on the constructor and instance:
+
+| Constructor | Instance |
+|:---|:---|
+| [`Rejected`](#rejected), [`Resolved`](#resolved), [`all`](#all), [`fromNode`](#fromnode), [`fromPromise`](#frompromise), [`of`](#of), [`type`](#type) | [`alt`](#alt), [`ap`](#ap), [`bimap`](#bimap), [`chain`](#chain), [`coalesce`](#coalesce), [`fork`](#fork), [`inspect`](#inspect), [`map`](#map),  [`of`](#of), [`swap`](#swap), [`toPromise`](#topromise), [`type`](#type) |
+
+## Constructor
+
+### Rejected
+
+`Async m => c -> m c _`
+
+### Resolved
+
+`Async m => a -> m _ a`
+
+### all
+`Async m, Foldable f => f (m c a) -> m c (f a)`
+
+### fromNode
+
+`Async m, CPSFunc f, Context ctx => (f, ctx) -> (* -> m c a)`
+
+### fromPromise
+
+`Async m, Promise p => (* -> p a c) -> (* -> m c a)`
+
+### of
+
+`Async m => a -> m _ a`
+
+### type
+
+`() -> String`
+
+## Instance
+
+### alt
+
+`Async m => m c a ~> m c a -> m c a`
+
+### ap
+
+`Async m => m c (a -> b) ~> m c a -> m c b`
+
+### bimap
+
+`Async m => m c a ~> ((c -> d), (a -> b)) -> m d b`
+
+### chain
+
+`Async m => m c a ~> (a -> m c b) -> m c b`
+
+### coalesce
+
+`Async m => m c a ~> ((c -> b), (a -> b)) -> m _ b`
+
+### fork
+
+`Async m => m c a ~> ((c -> ()), (a -> ())) -> ()`
+
+### inspect
+
+`() -> String`
+
+### map
+
+`Async m => m c a ~> (a -> b) -> m c b`
+
+### of
+
+`Async m => a -> m _ a`
+
+### swap
+
+`Async m => m c a ~> ((c -> d), (a -> b)) -> m b d`
+
+### toPromise
+
+`Async m, Promise p => m c a ~> () -> p a c`
+
+### type
+
+`() -> String`

--- a/docs/crocks/Either.md
+++ b/docs/crocks/Either.md
@@ -46,7 +46,7 @@
 
 ### bimap
 
-`Either m => m c a ~> (c -> d) -> (a -> b) -> m d b`
+`Either m => m c a ~> ((c -> d), (a -> b)) -> m d b`
 
 ### chain
 
@@ -54,7 +54,7 @@
 
 ### coalesce
 
-`Either m => m c a ~> (c -> b) -> (a -> b) -> m _ b`
+`Either m => m c a ~> ((c -> b), (a -> b)) -> m _ b`
 
 ### concat
 
@@ -62,7 +62,7 @@
 
 ### either
 
-`Either m => m c a ~> (c -> b) -> (a -> b) -> b`
+`Either m => m c a ~> ((c -> b), (a -> b)) -> b`
 
 ### equals
 
@@ -86,7 +86,7 @@
 
 ### swap
 
-`Either m => m c a ~> (c -> d) -> (a -> b) -> m b d`
+`Either m => m c a ~> ((c -> d), (a -> b)) -> m b d`
 
 ### traverse
 

--- a/docs/crocks/Maybe.md
+++ b/docs/crocks/Maybe.md
@@ -54,7 +54,7 @@
 
 ### coalesce
 
-`Maybe m => m a ~> (() -> b) -> (a -> b) -> m b`
+`Maybe m => m a ~> ((() -> b), (a -> b)) -> m b`
 
 ### concat
 
@@ -62,7 +62,7 @@
 
 ### either
 
-`Maybe m => m a ~> (() -> b) -> (a -> b) -> b`
+`Maybe m => m a ~> ((() -> b), (a -> b)) -> b`
 
 ### equals
 

--- a/docs/crocks/Pair.md
+++ b/docs/crocks/Pair.md
@@ -30,7 +30,7 @@
 
 ### bimap
 
-`Pair m => m c a ~> (c -> d) -> (a -> b) -> m d b`
+`Pair m => m c a ~> ((c -> d), (a -> b)) -> m d b`
 
 ### chain
 
@@ -70,4 +70,4 @@
 
 ### swap
 
-`Pair m => m c a ~> (c -> d) -> (a -> b) -> m b d`
+`Pair m => m c a ~> ((c -> d), (a -> b)) -> m b d`


### PR DESCRIPTION
## At the same time
![](https://remote.co/wp-content/uploads/2016/04/asynchronous-communitcation.png)

This PR addresses a portion of [issue#42](https://github.com/evilsoft/crocks/issues/42), namely adding the skeleton for the `Async` crock. As a super duper bonus, fixed up some of the other binary functions on `Either`, `Maybe` and `Pair` to represent their "uncurried" interface when on the `crock` itself.