### PR TITLE
Add the `Unit` Skeleton

### DIFF
--- a/docs/crocks/Unit.md
+++ b/docs/crocks/Unit.md
@@ -1,0 +1,73 @@
+# Unit
+
+`Unit a`
+
+--
+
+--
+
+```js
+--
+```
+
+`Unit` exposes the following functions on the constructor and instance:
+
+| Constructor | Instance |
+|:---|:---|
+| [`empty`](#empty), [`of`](#of), [`type`](#type) | [`ap`](#ap), [`chain`](#chain), [`concat`](#concat), [`empty`](#empty), [`equals`](#equals), [`inspect`](#inspect), [`map`](#map), [`of`](#of), [`type`](#type), [`value`](#value) |
+
+## Constructor
+
+### empty
+
+`Unit m => () -> m _`
+
+### of
+
+`Unit m => a -> m a`
+
+### type
+
+`() -> String`
+
+## Instance
+
+### ap
+
+`Unit m => m (a -> b) ~> m a -> m b`
+
+### chain
+
+`Unit m => m a ~> (a -> m b) -> m b`
+
+### concat
+
+`Unit m => m a ~> m a -> m a`
+
+### empty
+
+`Unit m => () -> m a`
+
+### equals
+
+`a -> Boolean`
+
+### inspect
+
+`() => String`
+
+### map
+
+`Unit m => m a ~> (a -> b) -> m b`
+
+### of
+
+`Unit m => a -> m a`
+
+### type
+
+`() -> String`
+
+### value
+
+`Unit m => m a ~> () -> undefined`


### PR DESCRIPTION
## Are you one Herbert? I am not Herbert!

![](http://img.trekmovie.com/tosrem/waytoeden/new_tosr075_extra_02.jpg)

This PR addresses a portion of [issue#42](https://github.com/evilsoft/crocks/issues/42), namely adding the skeleton for the `Unit` crock. Was going to remove it, but I like how it fits in with `State` gonna be a keeper.