### PR TITLE
Add Star skeleton

### DIFF
--- a/docs/crocks/Arrow.md
+++ b/docs/crocks/Arrow.md
@@ -14,13 +14,9 @@
 
 | Constructor | Instance |
 |:---|:---|
-| [`empty`](#empty), [`type`](#type) | [`both`](#both), [`concat`](#concat), [`contramap`](#contramap), [`empty`](#empty), [`first`](#first), [`inspect`](#inspect), [`map`](#map), [`promap`](#promap), [`runWith`](#runWith), [`second`](#second), [`type`](#type), [`value`](#value) |
+| [`type`](#type) | [`both`](#both), [`contramap`](#contramap), [`first`](#first), [`inspect`](#inspect), [`map`](#map), [`promap`](#promap), [`runWith`](#runWith), [`second`](#second), [`type`](#type) |
 
 ## Constructor
-
-### empty
-
-`Arrow m => () -> m a a`
 
 ### type
 
@@ -32,17 +28,9 @@
 
 `Arrow m, Pair p => m a b ~> () -> m (p a a) (p b b)`
 
-### concat
-
-`Arrow m => m a b ~> m a b -> m a b`
-
 ### contramap
 
 `Arrow m => m a b ~> (c -> a) -> m c b`
-
-### empty
-
-`Arrow m => () -> m a a`
 
 ### first
 
@@ -71,7 +59,3 @@
 ### type
 
 `() -> String`
-
-### value
-
-`Arrow m => m a b ~> (a -> b)`

--- a/docs/crocks/Star.md
+++ b/docs/crocks/Star.md
@@ -1,0 +1,61 @@
+# Star
+
+`Star a b` / `Monad m => Star a (m b)`
+
+--
+
+--
+
+```js
+--
+```
+
+`Star` exposes the following functions on the constructor and instance:
+
+| Constructor | Instance |
+|:---|:---|
+| [`type`](#type) | [`both`](#both), [`contramap`](#contramap), [`first`](#first), [`inspect`](#inspect), [`map`](#map), [`promap`](#promap), [`runWith`](#runWith), [`second`](#second), [`type`](#type) |
+
+## Constructor
+
+### type
+
+`() -> String`
+
+## Instance
+
+### both
+
+`Star m, Pair p => m a b ~> () -> m (p a a) (p b b)`
+
+### contramap
+
+`Star m  => m a b ~> (c -> a) -> m c b`
+
+### first
+
+`Star m, Pair p => m a b ~> () -> m (p a c) (p b c)`
+
+### inspect
+
+`() -> String`
+
+### map
+
+`Star m => m a b ~> (b -> c) -> m a c`
+
+### promap
+
+`Star m => m a b ~> ((c -> a), (b -> d)) -> s c d`
+
+### runWith
+
+`Star s, Monad m => s a (m b) ~> a -> m b`
+
+### second
+
+`Star m, Pair p => m a b ~> () -> m (p c a) (p c b)`
+
+### type
+
+`() -> String`


### PR DESCRIPTION
## A Super Star is what you are
![](https://thumb7.shutterstock.com/display_pic_with_logo/436114/443158591/stock-vector-superstar-red-grunge-round-vintage-rubber-stamp-superstar-stamp-superstar-round-stamp-superstar-443158591.jpg)

This PR adds another skeleton to the docs for this [issue#42](https://github.com/evilsoft/crocks/issues/42). This one for the `Star`. Also in anticipation of the removal of the monoidial implementation on `Arrow` (broken in sooo many ways), this PR also removes the `concat`, `empty` and `value` bits off of `Arrow`