### PR TITLE
Remove parent type on inspect string for sum types

### DIFF
--- a/crocks/Either.js
+++ b/crocks/Either.js
@@ -60,8 +60,8 @@ function Either(u) {
 
   const inspect = constant(
     either(
-       l => `Either.Left${_inspect(l)}`,
-       r => `Either.Right${_inspect(r)}`
+       l => `Left${_inspect(l)}`,
+       r => `Right${_inspect(r)}`
     )
   )
 

--- a/crocks/Either.spec.js
+++ b/crocks/Either.spec.js
@@ -60,8 +60,8 @@ test('Either inspect', t => {
   t.ok(isFunction(l.inspect), 'Left provides an inspect function')
   t.ok(isFunction(r.inspect), 'Right provides an inpsect function')
 
-  t.equal(l.inspect(), 'Either.Left 0', 'Left returns inspect string')
-  t.equal(r.inspect(), 'Either.Right 1', 'Right returns inspect string')
+  t.equal(l.inspect(), 'Left 0', 'Left returns inspect string')
+  t.equal(r.inspect(), 'Right 1', 'Right returns inspect string')
 
   t.end()
 })

--- a/crocks/Maybe.js
+++ b/crocks/Maybe.js
@@ -59,12 +59,11 @@ function Maybe(u) {
       x => m.either(constant(false), y => y === x)
     )
 
-  function inspect() {
-    return either(
-      constant(`Maybe.Nothing`),
-      x => `Maybe.Just${_inspect(x)}`
+  const inspect = () =>
+    either(
+      constant(`Nothing`),
+      x => `Just${_inspect(x)}`
     )
-  }
 
   function either(f, g) {
     if(!isFunction(f) || !isFunction(g)) {

--- a/crocks/Maybe.spec.js
+++ b/crocks/Maybe.spec.js
@@ -41,9 +41,10 @@ test('Maybe inspect', t => {
   const m = Maybe.Just('great')
   const n = Maybe.Nothing()
 
-  t.ok(isFunction(m.inspect), 'provides an inspect function')
-  t.equal(m.inspect(), 'Maybe.Just "great"', 'returns inspect string')
-  t.equal(n.inspect(), 'Maybe.Nothing', 'Nothing returns inspect string')
+  t.ok(isFunction(m.inspect), 'Just provides an inspect function')
+  t.ok(isFunction(n.inspect), 'Nothing provides an inspect function')
+  t.equal(m.inspect(), 'Just "great"', 'returns inspect string')
+  t.equal(n.inspect(), 'Nothing', 'Nothing returns inspect string')
 
   t.end()
 })

--- a/crocks/Result.js
+++ b/crocks/Result.js
@@ -65,12 +65,11 @@ function Result(u) {
   const of =
     _of
 
-  const inspect = constant(
+  const inspect = () =>
     either(
-      l => `Result.Err${_inspect(l)}`,
-      r => `Result.Ok${_inspect(r)}`
+      l => `Err${_inspect(l)}`,
+      r => `Ok${_inspect(r)}`
     )
-  )
 
   function either(f, g) {
     if(!isFunction(f) || !isFunction(g)) {

--- a/crocks/Result.spec.js
+++ b/crocks/Result.spec.js
@@ -62,8 +62,8 @@ test('Result inspect', t => {
   t.ok(isFunction(l.inspect), 'Err provides an inspect function')
   t.ok(isFunction(r.inspect), 'Ok provides an inspect function')
 
-  t.equal(l.inspect(), 'Result.Err 0', 'Err returns inspect string')
-  t.equal(r.inspect(), 'Result.Ok 1', 'Ok returns inspect string')
+  t.equal(l.inspect(), 'Err 0', 'Err returns inspect string')
+  t.equal(r.inspect(), 'Ok 1', 'Ok returns inspect string')
 
   t.end()
 })


### PR DESCRIPTION
## What does that even mean?!?
![image](https://cloud.githubusercontent.com/assets/3665793/24324414/3a5617e8-1143-11e7-8bdc-6c9189cd1f0a.png)

Found that prefixing the type was so gross in practice. After seeing something that @joneshf did with his `toString` function on his Trees read sooo much better. So we gonna drop dat type from the inspect string. So instead of `Maybe.Just 23`, only going to show `Just 23`
