### PR TITLE
Update `reject` and `filter` to accept Objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ These functions provide a very clean way to build out very simple functions and 
 | `either` | `Either`, `Maybe`, `Result` |
 | `evalWith` | `State` |
 | `execWith` | `State` |
-| `filter` | `Array`, `List` |
+| `filter` | `Array`, `List`, `Object` |
 | `first` | `Arrow`, `Function`, `Star` |
 | `fold` | `Array`, `List` |
 | `fst` | `Pair` |
@@ -461,7 +461,7 @@ These functions provide a very clean way to build out very simple functions and 
 | `promap` | `Arrow`, `Star` |
 | `read` | `Writer` |
 | `reduce` | `Array`, `List` |
-| `reject` | `Array`, `List` |
+| `reject` | `Array`, `List`, `Object` |
 | `run` | `IO` |
 | `runWith` | `Arrow`, `Endo`, `Pred`, `Reader`, `Star`, `State` |
 | `second` | `Arrow`, `Function`, `Star` |

--- a/internal/array.js
+++ b/internal/array.js
@@ -1,3 +1,6 @@
+/** @license ISC License (c) copyright 2017 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
 const isFunction = require('../predicates/isFunction')
 const isArray = require('../predicates/isArray')
 

--- a/internal/object.js
+++ b/internal/object.js
@@ -1,0 +1,15 @@
+/** @license ISC License (c) copyright 2017 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+function filter(f, m) {
+  return Object.keys(m).reduce((acc, key) => {
+    if(f(m[key])) {
+      acc[key] = m[key]
+    }
+    return acc
+  }, {})
+}
+
+module.exports = {
+  filter
+}

--- a/internal/object.spec.js
+++ b/internal/object.spec.js
@@ -1,0 +1,14 @@
+const test = require('tape')
+
+const object= require('./object')
+
+const filter = object.filter
+
+test('object filter functionality', t => {
+  const obj = { a: 'cat', b: 'great', d: 'dog' }
+  const fn = x => x.length > 3
+
+  t.same(filter(fn, obj), { b: 'great' }, 'filters as expected when populated')
+  t.same(filter(fn, {}), {}, 'filters as expected when empty')
+  t.end()
+})

--- a/pointfree/filter.js
+++ b/pointfree/filter.js
@@ -4,21 +4,29 @@
 const curry = require('../helpers/curry')
 
 const isFunction = require('../predicates/isFunction')
+const isObject = require('../predicates/isObject')
 const isSameType = require('../predicates/isSameType')
 
 const Pred = require('../crocks/Pred')
 const predOrFunc = require('../internal/predOrFunc')
+
+const object = require('../internal/object')
 
 // filter : Foldable f => (a -> Boolean) -> f a -> f a
 function filter(pred, m) {
   if(!(isFunction(pred) || isSameType(Pred, pred))) {
     throw new TypeError('filter: Pred or predicate function required for first argument')
   }
-  else if(m && isFunction(m.filter)) {
-    return m.filter(predOrFunc(pred))
+  const fn = predOrFunc(pred)
+
+  if(m && isFunction(m.filter)) {
+    return m.filter(fn)
+  }
+  else if(m && isObject(m)) {
+    return object.filter(fn, m)
   }
 
-  throw new TypeError('filter: Foldable required for second argument')
+  throw new TypeError('filter: Foldable or Object required for second argument')
 }
 
 module.exports = curry(filter)

--- a/pointfree/filter.spec.js
+++ b/pointfree/filter.spec.js
@@ -19,32 +19,35 @@ test('filter pointfree', t => {
 
   t.ok(isFunction(filter), 'is a function')
 
-  t.throws(m(undefined, f), 'throws if first arg is undefined')
-  t.throws(m(null, f), 'throws if first arg is null')
-  t.throws(m(0, f), 'throws if first arg is a falsey number')
-  t.throws(m(1, f), 'throws if first arg is a truthy number')
-  t.throws(m('', f), 'throws if first arg is a falsey string')
-  t.throws(m('string', f), 'throws if first arg is a truthy string')
-  t.throws(m(false, f), 'throws if first arg is false')
-  t.throws(m(true, f), 'throws if first arg is true')
-  t.throws(m([], f), 'throws if first arg is an array')
-  t.throws(m({}, f), 'throws if first arg is an object')
+  const noFunc = /filter: Pred or predicate function required for first argument/
+  t.throws(m(undefined, f), noFunc, 'throws if first arg is undefined')
+  t.throws(m(null, f), noFunc, 'throws if first arg is null')
+  t.throws(m(0, f), noFunc, 'throws if first arg is a falsey number')
+  t.throws(m(1, f), noFunc, 'throws if first arg is a truthy number')
+  t.throws(m('', f), noFunc, 'throws if first arg is a falsey string')
+  t.throws(m('string', f), noFunc, 'throws if first arg is a truthy string')
+  t.throws(m(false, f), noFunc, 'throws if first arg is false')
+  t.throws(m(true, f), noFunc, 'throws if first arg is true')
+  t.throws(m([], f), noFunc, 'throws if first arg is an array')
+  t.throws(m({}, f), noFunc, 'throws if first arg is an object')
 
-  t.throws(m(noop, undefined), 'throws if second arg is undefined')
-  t.throws(m(noop, null), 'throws if second arg is null')
-  t.throws(m(noop, 0), 'throws if second arg is a falsey number')
-  t.throws(m(noop, 1), 'throws if second arg is a truthy number')
-  t.throws(m(noop, ''), 'throws if second arg is a falsey string')
-  t.throws(m(noop, 'string'), 'throws if second arg is a truthy string')
-  t.throws(m(noop, false), 'throws if second arg is false')
-  t.throws(m(noop, true), 'throws if second arg is true')
-  t.throws(m(noop, {}), 'throws if second arg is an object')
+  const noData = /filter: Foldable or Object required for second argument/
+  t.throws(m(noop, undefined), noData, 'throws if second arg is undefined')
+  t.throws(m(noop, null), noData, 'throws if second arg is null')
+  t.throws(m(noop, 0), noData, 'throws if second arg is a falsey number')
+  t.throws(m(noop, 1), noData, 'throws if second arg is a truthy number')
+  t.throws(m(noop, ''), noData, 'throws if second arg is a falsey string')
+  t.throws(m(noop, 'string'), noData, 'throws if second arg is a truthy string')
+  t.throws(m(noop, false), noData, 'throws if second arg is false')
+  t.throws(m(noop, true), noData, 'throws if second arg is true')
 
   t.doesNotThrow(m(noop, f), 'allows a function and Foldable container')
   t.doesNotThrow(m(noop, []), 'allows a function and an array (also Foldable)')
+  t.doesNotThrow(m(noop, {}), 'allows a function and an object')
 
   t.doesNotThrow(m(Pred(noop), f), 'allows a Pred and Foldable container')
   t.doesNotThrow(m(Pred(noop), []), 'allows a Pred and an array (also Foldable)')
+  t.doesNotThrow(m(Pred(noop), {}), 'allows a Pred and an object')
 
   t.end()
 })
@@ -55,6 +58,28 @@ test('filter Foldable', t => {
   const result = filter(identity, m)
 
   t.equals(result, 'called', 'calls filter on Foldable, passing the function')
+
+  t.end()
+})
+
+test('filter Array', t => {
+  const ar = [ 1, 9, 56, 7 ]
+  const fn = x => x >= 10
+  const pred = Pred(x => x <= 10)
+
+  t.same(filter(fn, ar), [ 56 ], 'filters as expected with a predicate function')
+  t.same(filter(pred, ar), [ 1, 9, 7], 'filters as expected with a Pred')
+
+  t.end()
+})
+
+test('filter Object', t => {
+  const obj = { a: 23, b: 10, c: 40, d: 9 }
+  const fn = x => x <= 20
+  const pred = Pred(x => x >= 20)
+
+  t.same(filter(fn, obj), { b: 10, d: 9 }, 'filters as expected with a predicate function')
+  t.same(filter(pred, obj), { a: 23, c: 40 }, 'filters as expected with a Pred')
 
   t.end()
 })

--- a/pointfree/reject.js
+++ b/pointfree/reject.js
@@ -5,11 +5,14 @@ const curry = require('../helpers/curry')
 
 const isArray = require('../predicates/isArray')
 const isFunction = require('../predicates/isFunction')
+const isObject = require('../predicates/isObject')
 const isSameType = require('../predicates/isSameType')
 const not = require('../logic/not')
 
 const Pred = require('../crocks/Pred')
 const predOrFunc = require('../internal/predOrFunc')
+
+const object = require('../internal/object')
 
 // reject : Foldable f => (a -> Boolean) -> f a -> f a
 function reject(pred, m) {
@@ -19,15 +22,17 @@ function reject(pred, m) {
 
   const fn = predOrFunc(pred)
 
-  if(isArray(m)) {
-    return m.filter(not(fn))
-  }
-  else if(m && isFunction(m.reject)) {
+  if(m && isFunction(m.reject)) {
     return m.reject(fn)
   }
-  else {
-    throw new TypeError('reject: Foldable required for second argument')
+  else if(isArray(m)) {
+    return m.filter(not(fn))
   }
+  else if(isObject(m)) {
+    return object.filter(not(fn), m)
+  }
+
+  throw new TypeError('reject: Foldable or Object required for second argument')
 }
 
 module.exports = curry(reject)

--- a/pointfree/reject.spec.js
+++ b/pointfree/reject.spec.js
@@ -17,32 +17,35 @@ test('reject pointfree', t => {
 
   t.ok(isFunction(reject), 'is a function')
 
-  t.throws(m(undefined, f), 'throws if first arg is undefined')
-  t.throws(m(null, f), 'throws if first arg is null')
-  t.throws(m(0, f), 'throws if first arg is a falsey number')
-  t.throws(m(1, f), 'throws if first arg is a truthy number')
-  t.throws(m('', f), 'throws if first arg is a falsey string')
-  t.throws(m('string', f), 'throws if first arg is a truthy string')
-  t.throws(m(false, f), 'throws if first arg is false')
-  t.throws(m(true, f), 'throws if first arg is true')
-  t.throws(m([], f), 'throws if first arg is an array')
-  t.throws(m({}, f), 'throws if first arg is an object')
+  const noPred = /reject: Pred or predicate function required for first argument/
+  t.throws(m(undefined, f), noPred, 'throws if first arg is undefined')
+  t.throws(m(null, f), noPred, 'throws if first arg is null')
+  t.throws(m(0, f), noPred, 'throws if first arg is a falsey number')
+  t.throws(m(1, f), noPred, 'throws if first arg is a truthy number')
+  t.throws(m('', f), noPred, 'throws if first arg is a falsey string')
+  t.throws(m('string', f), noPred, 'throws if first arg is a truthy string')
+  t.throws(m(false, f), noPred, 'throws if first arg is false')
+  t.throws(m(true, f), noPred, 'throws if first arg is true')
+  t.throws(m([], f), noPred, 'throws if first arg is an array')
+  t.throws(m({}, f), noPred, 'throws if first arg is an object')
 
-  t.throws(m(noop, undefined), 'throws if second arg is undefined')
-  t.throws(m(noop, null), 'throws if second arg is null')
-  t.throws(m(noop, 0), 'throws if second arg is a falsey number')
-  t.throws(m(noop, 1), 'throws if second arg is a truthy number')
-  t.throws(m(noop, ''), 'throws if second arg is a falsey string')
-  t.throws(m(noop, 'string'), 'throws if second arg is a truthy string')
-  t.throws(m(noop, false), 'throws if second arg is false')
-  t.throws(m(noop, true), 'throws if second arg is true')
-  t.throws(m(noop, {}), 'throws if second arg is an object')
+  const noData = /reject: Foldable or Object required for second argument/
+  t.throws(m(noop, undefined), noData, 'throws if second arg is undefined')
+  t.throws(m(noop, null), noData, 'throws if second arg is null')
+  t.throws(m(noop, 0), noData, 'throws if second arg is a falsey number')
+  t.throws(m(noop, 1), noData, 'throws if second arg is a truthy number')
+  t.throws(m(noop, ''), noData, 'throws if second arg is a falsey string')
+  t.throws(m(noop, 'string'), noData, 'throws if second arg is a truthy string')
+  t.throws(m(noop, false), noData, 'throws if second arg is false')
+  t.throws(m(noop, true), noData, 'throws if second arg is true')
 
   t.doesNotThrow(m(noop, f), 'allows a function and Foldable container')
   t.doesNotThrow(m(noop, []), 'allows a function and an array (also Foldable)')
+  t.doesNotThrow(m(noop, {}), 'allows a function and an object')
 
   t.doesNotThrow(m(Pred(noop), f), 'allows a Pred and Foldable container')
   t.doesNotThrow(m(Pred(noop), []), 'allows a Pred and an array (also Foldable)')
+  t.doesNotThrow(m(Pred(noop), {}), 'allows a Pred and an object')
 
   t.end()
 })
@@ -55,6 +58,18 @@ test('reject on Array', t => {
 
   t.same(fn(xs), [ 1, 2 ], 'rejects as expected with predicate function')
   t.same(pred(xs), [ 20, 15 ], 'rejects as expected with Pred')
+
+  t.end()
+})
+
+test('reject on Object', t => {
+  const fn = reject(x => x > 5)
+  const pred = reject(Pred(x => x < 5))
+
+  const xs = { a: 1, b: 20, c: 15, d: 2 }
+
+  t.same(fn(xs), { a: 1, d: 2 }, 'rejects as expected with predicate function')
+  t.same(pred(xs), { b: 20, c: 15 }, 'rejects as expected with Pred')
 
   t.end()
 })


### PR DESCRIPTION
## All inclusive!!
![image](https://cloud.githubusercontent.com/assets/3665793/24834659/6d5d5944-1ca1-11e7-815d-5f4f4d8bd2dd.png)

This PR address [issue#117](https://github.com/evilsoft/crocks/issues/117).

* Adds a type rep for `Object` in the internal folder to implement a common `filter`.
* Update point-free `filter` to work with `Object` values.
* Update point-free `reject` to work with `Object` values.
* fix up some existing specs for both `filter` and `reject`