### PR TITLE
Better compose and pipe functions

### DIFF
--- a/helpers/compose.js
+++ b/helpers/compose.js
@@ -1,25 +1,41 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const pipe = require('./pipe')
 const argsArray = require('../internal/argsArray')
-
+const identity = require('../combinators/identity')
 const isFunction = require('../predicates/isFunction')
 
+const err = 'compose: Functions required'
+
+function applyPipe(f, g) {
+  if(!isFunction(g)) {
+    throw new TypeError(err)
+  }
+
+  return function() {
+    return g.call(null, f.apply(null, argsArray(arguments)))
+  }
+}
 // compose : ((y -> z), (x -> y), ..., (a -> b)) -> a -> z
 function compose() {
   if(!arguments.length) {
-    throw new TypeError('compose: At least one function required')
+    throw new TypeError(err)
   }
 
   const fns =
-    argsArray(arguments)
+    argsArray(arguments).slice().reverse()
 
-  if(fns.filter(x => !isFunction(x)).length) {
-    throw new TypeError('compose: Only accepts functions')
+  const head =
+    fns[0]
+
+  if(!isFunction(head)) {
+    throw new TypeError(err)
   }
 
-  return pipe.apply(null, fns.slice().reverse())
+  const tail =
+    fns.slice(1).concat(identity)
+
+  return tail.reduce(applyPipe, head)
 }
 
 module.exports = compose

--- a/helpers/compose.spec.js
+++ b/helpers/compose.spec.js
@@ -14,20 +14,30 @@ test('compose parameters', t => {
 
   t.ok(isFunction(compose), 'compose is a function')
 
-  t.throws(compose, TypeError, 'throws Error when nothing passed')
+  const err = /compose: Functions required/
+  t.throws(compose, err, 'throws Error when nothing passed')
 
-  t.throws(c(undefined), TypeError, 'throws TypeError when undefined passed')
-  t.throws(c(null), TypeError, 'throws TypeError when null passed')
+  t.throws(c(undefined), err, 'throws when undefined passed')
+  t.throws(c(null), err, 'throws when null passed')
+  t.throws(c(''), err, 'throws when falsey string passed')
+  t.throws(c('string'), err, 'throws when truthy string passed')
+  t.throws(c(0), err, 'throws when falsy number passed')
+  t.throws(c(1), err, 'throws when truthy number passed')
+  t.throws(c(false), err, 'throws when false passed')
+  t.throws(c(true), err, 'throws when true passed')
+  t.throws(c({}), err, 'throws when object passed')
+  t.throws(c([]), err, 'throws when array passed')
 
-  t.throws(c(''), TypeError, 'throws TypeError when falsey string passed')
-  t.throws(c('string'), TypeError, 'throws TypeError when truthy string passed')
-  t.throws(c(0), TypeError, 'throws TypeError when falsy number passed')
-  t.throws(c(1), TypeError, 'throws TypeError when truthy number passed')
-  t.throws(c(false), TypeError, 'throws TypeError when false passed')
-  t.throws(c(true), TypeError, 'throws TypeError when true passed')
-
-  t.throws(c({}), TypeError, 'throws TypeError when object passed')
-  t.throws(c([]), TypeError, 'throws TypeError when array passed')
+  t.throws(c(undefined, unit), err, 'throws when undefined passed as second argument')
+  t.throws(c(null, unit), err, 'throws when null passed as second argument')
+  t.throws(c('', unit), err, 'throws when falsey string passed as second argument')
+  t.throws(c('string', unit), err, 'throws when truthy string passed as second argument')
+  t.throws(c(0, unit), err, 'throws when falsy number passed as second argument')
+  t.throws(c(1, unit), err, 'throws when truthy number passed as second argument')
+  t.throws(c(false, unit), err, 'throws when false passed as second argument')
+  t.throws(c(true, unit), err, 'throws when true passed as second argument')
+  t.throws(c({}, unit), err, 'throws when object passed as second argument')
+  t.throws(c([], unit), err, 'throws when array passed as second argument')
 
   t.ok(isFunction(compose(unit)), 'returns a function')
 

--- a/helpers/composeP.spec.js
+++ b/helpers/composeP.spec.js
@@ -9,38 +9,48 @@ const isFunction = require('../predicates/isFunction')
 
 const composeP = require('./composeP')
 
-test('composeP parameters', t => {
+test('composeP errors', t => {
   const prom = x => Promise.resolve(x)
 
   const pp = bindFunc(composeP)
   const f = bindFunc(composeP(unit))
   const g = bindFunc(composeP(prom, unit))
 
-  t.ok(isFunction(composeP), 'composeP is a function')
+  const err = /composeP: Promise returning functions required/
+  t.throws(composeP, err, 'throws when nothing passed')
 
-  const noArgs = /composeP: At least one Promise returning function required/
-  t.throws(composeP, noArgs, 'throws when nothing passed')
+  t.throws(f(), err, 'throws when single function does not return a Promise')
+  t.throws(g(), err, 'throws when head function does not return a Promise')
 
-  const noFuncs = /composeP: Only accepts Promise returning functions/
-  t.throws(f(), noFuncs, 'throws when single function does not return a Promise')
-  t.throws(g(), noFuncs, 'throws when head function does not return a Promise')
+  t.throws(pp(undefined), err, 'throws when undefined passed')
+  t.throws(pp(null), err, 'throws when null passed')
+  t.throws(pp(''), err, 'throws when falsey string passed')
+  t.throws(pp('string'), err, 'throws when truthy string passed')
+  t.throws(pp(0), err, 'throws when falsy number passed')
+  t.throws(pp(1), err, 'throws when truthy number passed')
+  t.throws(pp(false), err, 'throws when false passed')
+  t.throws(pp(true), err, 'throws when true passed')
+  t.throws(pp({}), err, 'throws when object passed')
+  t.throws(pp([]), err, 'throws when array passed')
 
-  t.throws(pp(undefined), noFuncs, 'throws when undefined passed')
-  t.throws(pp(null), noFuncs, 'throws when null passed')
-  t.throws(pp(''), noFuncs, 'throws when falsey string passed')
-  t.throws(pp('string'), noFuncs, 'throws when truthy string passed')
-  t.throws(pp(0), noFuncs, 'throws when falsy number passed')
-  t.throws(pp(1), noFuncs, 'throws when truthy number passed')
-  t.throws(pp(false), noFuncs, 'throws when false passed')
-  t.throws(pp(true), noFuncs, 'throws when true passed')
-  t.throws(pp({}), noFuncs, 'throws when object passed')
-  t.throws(pp([]), noFuncs, 'throws when array passed')
+  t.throws(pp(undefined, prom), err, 'throws when undefined passed')
+  t.throws(pp(null, prom), err, 'throws when null passed')
+  t.throws(pp('', prom), err, 'throws when falsey string passed')
+  t.throws(pp('string', prom), err, 'throws when truthy string passed')
+  t.throws(pp(0, prom), err, 'throws when falsy number passed')
+  t.throws(pp(1, prom), err, 'throws when truthy number passed')
+  t.throws(pp(false, prom), err, 'throws when false passed')
+  t.throws(pp(true, prom), err, 'throws when true passed')
+  t.throws(pp({}, prom), err, 'throws when object passed')
+  t.throws(pp([], prom), err, 'throws when array passed')
 
   t.end()
 })
 
 test('composeP functionality', t => {
-  t.plan(5)
+  t.plan(6)
+
+  t.ok(isFunction(composeP), 'composeP is a function')
 
   const res = x => Promise.resolve(x)
   const rej = x => Promise.reject(x)

--- a/helpers/pipe.js
+++ b/helpers/pipe.js
@@ -5,7 +5,13 @@ const argsArray = require('../internal/argsArray')
 const identity = require('../combinators/identity')
 const isFunction = require('../predicates/isFunction')
 
+const err = 'pipe: Functions required'
+
 function applyPipe(f, g) {
+  if(!isFunction(g)) {
+    throw new TypeError(err)
+  }
+
   return function() {
     return g.call(null, f.apply(null, argsArray(arguments)))
   }
@@ -14,18 +20,18 @@ function applyPipe(f, g) {
 // pipe : ((a -> b), (b -> c), ..., (y -> z)) -> a -> z
 function pipe() {
   if(!arguments.length) {
-    throw new TypeError('pipe: At least one function required')
+    throw new TypeError(err)
   }
 
   const fns =
     argsArray(arguments)
 
-  if(fns.filter(x => !isFunction(x)).length) {
-    throw new TypeError('pipe: Only accepts functions')
-  }
-
   const head =
     fns[0]
+
+  if(!isFunction(head)) {
+    throw new TypeError(err)
+  }
 
   const tail =
     fns.slice(1).concat(identity)

--- a/helpers/pipe.spec.js
+++ b/helpers/pipe.spec.js
@@ -9,27 +9,33 @@ const unit = require('../helpers/unit')
 
 const pipe = require('./pipe')
 
-test('pipe parameters', t => {
+test('pipe errors', t => {
   const c = bindFunc(pipe)
+  const err = /pipe: Functions required/
 
-  t.ok(isFunction(pipe), 'pipe is a function')
+  t.throws(pipe, err, 'throws when nothing passed')
 
-  t.throws(pipe, TypeError, 'throws Error when nothing passed')
+  t.throws(c(undefined), err, 'throws when undefined passed')
+  t.throws(c(null), err, 'throws when null passed')
+  t.throws(c(''), err, 'throws when falsey string passed')
+  t.throws(c('string'), err, 'throws err when truthy string passed')
+  t.throws(c(0), err, 'throws err when falsy number passed')
+  t.throws(c(1), err, 'throws err when truthy number passed')
+  t.throws(c(false), err, 'throws err when false passed')
+  t.throws(c(true), err, 'throws err when true passed')
+  t.throws(c({}), err, 'throws err when object passed')
+  t.throws(c([]), err, 'throws err when array passed')
 
-  t.throws(c(undefined), TypeError, 'throws TypeError when undefined passed')
-  t.throws(c(null), TypeError, 'throws TypeError when null passed')
-
-  t.throws(c(''), TypeError, 'throws TypeError when falsey string passed')
-  t.throws(c('string'), TypeError, 'throws TypeError when truthy string passed')
-  t.throws(c(0), TypeError, 'throws TypeError when falsy number passed')
-  t.throws(c(1), TypeError, 'throws TypeError when truthy number passed')
-  t.throws(c(false), TypeError, 'throws TypeError when false passed')
-  t.throws(c(true), TypeError, 'throws TypeError when true passed')
-
-  t.throws(c({}), TypeError, 'throws TypeError when object passed')
-  t.throws(c([]), TypeError, 'throws TypeError when array passed')
-
-  t.ok(isFunction(pipe(unit)), 'returns a function')
+  t.throws(c(unit, undefined), err, 'throws when undefined passed as second argument')
+  t.throws(c(unit, null), err, 'throws when null passed as second argument')
+  t.throws(c(unit, ''), err, 'throws when falsey string passed as second argument')
+  t.throws(c(unit, 'string'), err, 'throws err when truthy string passed as second argument')
+  t.throws(c(unit, 0), err, 'throws err when falsy number passed as second argument')
+  t.throws(c(unit, 1), err, 'throws err when truthy number passed as second argument')
+  t.throws(c(unit, false), err, 'throws err when false passed as second argument')
+  t.throws(c(unit, true), err, 'throws err when true passed as second argument')
+  t.throws(c(unit, {}), err, 'throws err when object passed as second argument')
+  t.throws(c(unit, []), err, 'throws err when array passed as second argument')
 
   t.end()
 })
@@ -43,6 +49,8 @@ test('pipe function', t => {
 
   const args = [ 'first', 'second' ]
   const result = pipe(first, second).apply(null, args)
+
+  t.ok(isFunction(pipe(unit)), 'returns a function')
 
   t.ok(first.calledBefore(second), 'left-most function is called first')
   t.ok(first.calledWith.apply(first, args), 'right-most function applied with all arguments')

--- a/helpers/pipeP.js
+++ b/helpers/pipeP.js
@@ -3,49 +3,48 @@
 
 const argsArray = require('../internal/argsArray')
 
-const isEmpty = require('../predicates/isEmpty')
+const identity = require('../combinators/identity')
 const isFunction = require('../predicates/isFunction')
 const isPromise = require('../predicates/isPromise')
 
+const err = 'pipeP: Promise returning functions required'
+
 function applyPipe(f, g) {
+  if(!isFunction(g)) {
+    throw new TypeError(err)
+  }
+
   return function() {
     const p = f.apply(null, arguments)
 
     if(!isPromise(p)) {
-      throw new TypeError('pipeP: Only accepts Promise returning functions')
+      throw new TypeError(err)
     }
 
     return p.then(g)
   }
 }
 
+// pipeP : Promise p => ((a -> p b), (b -> p c), ..., (y -> p z)) -> a -> p z
 function pipeP() {
   if(!arguments.length) {
-    throw new TypeError('pipeP: At least one Promise returning function required')
+    throw new TypeError(err)
   }
 
   const fns =
     argsArray(arguments)
 
-  if(fns.filter(x => !isFunction(x)).length) {
-    throw new TypeError('pipeP: Only accepts Promise returning functions')
-  }
-
   const head =
-    fns.shift()
+    fns[0]
 
-  if(isEmpty(fns)) {
-    return function() {
-      const m = head.apply(null, arguments)
-
-      if(!isPromise(m)) {
-        throw new TypeError('pipeP: Only accepts Promise returning functions')
-      }
-      return m
-    }
+  if(!isFunction(head)) {
+    throw new TypeError(err)
   }
 
-  return fns.reduce(applyPipe, head)
+  const tail =
+    fns.slice(1).concat(identity)
+
+  return tail.reduce(applyPipe, head)
 }
 
 module.exports = pipeP

--- a/helpers/pipeP.spec.js
+++ b/helpers/pipeP.spec.js
@@ -9,7 +9,7 @@ const isFunction = require('../predicates/isFunction')
 
 const pipeP = require('./pipeP')
 
-test('pipeP parameters', t => {
+test('pipeP errors', t => {
   const prom = x => Promise.resolve(x)
 
   const pp = bindFunc(pipeP)
@@ -18,23 +18,33 @@ test('pipeP parameters', t => {
 
   t.ok(isFunction(pipeP), 'pipeP is a function')
 
-  const noArgs = /pipeP: At least one Promise returning function required/
-  t.throws(pipeP, noArgs, 'throws when nothing passed')
+  const err = /pipeP: Promise returning functions required/
+  t.throws(pipeP, err, 'throws when nothing passed')
 
-  const noFuncs = /pipeP: Only accepts Promise returning functions/
-  t.throws(f(), noFuncs, 'throws when single function does not return a Promise')
-  t.throws(g(), noFuncs, 'throws when head function does not return a Promise')
+  t.throws(f(), err, 'throws when single function does not return a Promise')
+  t.throws(g(), err, 'throws when head function does not return a Promise')
 
-  t.throws(pp(undefined), noFuncs, 'throws when undefined passed')
-  t.throws(pp(null), noFuncs, 'throws when null passed')
-  t.throws(pp(''), noFuncs, 'throws when falsey string passed')
-  t.throws(pp('string'), noFuncs, 'throws when truthy string passed')
-  t.throws(pp(0), noFuncs, 'throws when falsy number passed')
-  t.throws(pp(1), noFuncs, 'throws when truthy number passed')
-  t.throws(pp(false), noFuncs, 'throws when false passed')
-  t.throws(pp(true), noFuncs, 'throws when true passed')
-  t.throws(pp({}), noFuncs, 'throws when object passed')
-  t.throws(pp([]), noFuncs, 'throws when array passed')
+  t.throws(pp(undefined), err, 'throws when undefined passed')
+  t.throws(pp(null), err, 'throws when null passed')
+  t.throws(pp(''), err, 'throws when falsey string passed')
+  t.throws(pp('string'), err, 'throws when truthy string passed')
+  t.throws(pp(0), err, 'throws when falsy number passed')
+  t.throws(pp(1), err, 'throws when truthy number passed')
+  t.throws(pp(false), err, 'throws when false passed')
+  t.throws(pp(true), err, 'throws when true passed')
+  t.throws(pp({}), err, 'throws when object passed')
+  t.throws(pp([]), err, 'throws when array passed')
+
+  t.throws(pp(prom, undefined), err, 'throws when undefined passed as second argument')
+  t.throws(pp(prom, null), err, 'throws when null passed as second argument')
+  t.throws(pp(prom, ''), err, 'throws when falsey string passed as second argument')
+  t.throws(pp(prom, 'string'), err, 'throws when truthy string passed as second argument')
+  t.throws(pp(prom, 0), err, 'throws when falsy number passed as second argument')
+  t.throws(pp(prom, 1), err, 'throws when truthy number passed as second argument')
+  t.throws(pp(prom, false), err, 'throws when false passed as second argument')
+  t.throws(pp(prom, true), err, 'throws when true passed as second argument')
+  t.throws(pp(prom, {}), err, 'throws when object passed as second argument')
+  t.throws(pp(prom, []), err, 'throws when array passed as second argument')
 
   t.end()
 })


### PR DESCRIPTION
## Making the world a little better...One commit at a time
![image](https://cloud.githubusercontent.com/assets/3665793/26184037/3c55cb2e-3b37-11e7-9e20-e4c5ff11ab4b.png)

The initial implementation of one of the most commonly used functions made me...well...a little :sob:. We were traversing the list of functions twice, once for validation and another time to build the composition. On top of that, if people use `compose` (the more popular of these functions) we actually went through it (3) times. 

While there is a little duplication, that may turn out to be okay as we trudge onto a mono-repo. So I am okay with it here. (I guess). In addition to these flow changes, I also updated the specs to look for specific errors instead of the `TypeError` blanket for `pipe` and `compose`