### PR TITLE
Add publish bits for new api

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,23 +1,6 @@
-node_modules
-test
-src
 *.spec.js
-
 .npmignore
-.babelrc
-webpack.config.js
 
-CHANGELOG.md
-
-.travis.yml
-.eslintignore
-.eslintrc
-
-coverage
-.coveralls.yml
-.nyc_output/
-
-.node-version
 *.log
 .DS_Store
 .DS_Store?

--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+BUILD_DIR=build
+
+mkdir -p $BUILD_DIR
+cd $BUILD_DIR
+
+cp ../{.npmignore,package.json,LICENSE,README.md} .
+
+npm publish

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+module.exports =
+  require('./src')

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./index.js",
   "scripts": {
     "preversion": "npm run build",
-    "build:publish": "npm test && npm run build && npm publish",
+    "build:publish": "npm test && ./bin/publish",
     "build:dist": "webpack && uglifyjs build/dist/crocks.js -c \"warnings=false\" -m -o build/dist/crocks.min.js",
     "build": "rm -rf build && buble -i src -o build && npm run build:dist",
     "lint": "eslint .",


### PR DESCRIPTION
## All coming together nicely!
![image](https://user-images.githubusercontent.com/3665793/28495007-503c2958-6ef4-11e7-872a-e995ca3cd7a3.png)

This is the penultimate PR for the new API change. This will get us yet another step to a well needed mono-repo. All this does is add a simple script that copies over the non-built assets needed for publish and ONLY publishes the compiled code directory allowing for references like:
```js
const Maybe = require('crocks/Maybe')
const safe = require('crocks/Maybe/safe')

// also can just:
const { Maybe, safe } = require('crocks')
```

The FINAL step before `0.7.0` is to allow for Type Proxies to remove dependencies for simple type checks. This will allow, say, functions that depend on a `Pair` but do not construct a `Pair` exists without needing to bring in `Pair`. Removing unneeded inner-dependencies.