### PR TITLE
Make `Reader.ask` and `State.get` use identity by default

### DIFF
--- a/src/Reader/Reader.spec.js
+++ b/src/Reader/Reader.spec.js
@@ -88,23 +88,25 @@ test('Reader runWith', t => {
 test('Reader ask errors', t => {
   const ask = bindFunc(Reader.ask)
 
-  t.throws(ask(undefined), TypeError, 'throws with undefined')
-  t.throws(ask(null), TypeError, 'throws with null')
-  t.throws(ask(0), TypeError, 'throws with falsey number')
-  t.throws(ask(1), TypeError, 'throws with truthy number')
-  t.throws(ask(''), TypeError, 'throws with falsey string')
-  t.throws(ask('string'), TypeError, 'throws with truthy string')
-  t.throws(ask(false), TypeError, 'throws with false')
-  t.throws(ask(true), TypeError, 'throws with true')
-  t.throws(ask([]), TypeError, 'throws with an array')
-  t.throws(ask({}), TypeError, 'throws with an object')
+  const err = /Reader.ask: No argument or function required/
+  t.throws(ask(undefined), err, 'throws with undefined')
+  t.throws(ask(null), err, 'throws with null')
+  t.throws(ask(0), err, 'throws with falsey number')
+  t.throws(ask(1), err, 'throws with truthy number')
+  t.throws(ask(''), err, 'throws with falsey string')
+  t.throws(ask('string'), err, 'throws with truthy string')
+  t.throws(ask(false), err, 'throws with false')
+  t.throws(ask(true), err, 'throws with true')
+  t.throws(ask([]), err, 'throws with an array')
+  t.throws(ask({}), err, 'throws with an object')
 
   t.doesNotThrow(ask(unit), 'allows a function')
+  t.doesNotThrow(ask(), 'allows nothing')
 
   t.end()
 })
 
-test('Reader ask functionality', t => {
+test('Reader ask with function', t => {
   const f = sinon.spy(identity)
   const x = Reader.ask(f)
 
@@ -112,6 +114,17 @@ test('Reader ask functionality', t => {
 
   t.equal(x.type(), 'Reader', 'returns a Reader')
   t.ok(f.calledWith(3), 'returned Reader wraps the passed function')
+  t.end()
+})
+
+test('Reader ask without function', t => {
+  const x = Reader.ask()
+  const data = 3
+
+  const result = x.runWith(data)
+
+  t.equal(x.type(), 'Reader', 'returns a Reader')
+  t.equal(result,  data, 'returns identity of passed value')
   t.end()
 })
 

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -13,10 +13,15 @@ const _of =
   x => Reader(() => x)
 
 function ask(fn) {
-  if(!isFunction(fn)) {
-    throw new TypeError('Reader.ask: Function required')
+  if(!arguments.length) {
+    return Reader(x => x)
   }
-  return Reader(fn)
+
+  if(isFunction(fn)) {
+    return Reader(fn)
+  }
+
+  throw new TypeError('Reader.ask: No argument or function required')
 }
 
 function Reader(runWith) {

--- a/src/State/State.spec.js
+++ b/src/State/State.spec.js
@@ -137,10 +137,10 @@ test('State evalWith', t => {
   t.end()
 })
 
-test('State get', t => {
+test('State get errors', t => {
   const get = bindFunc(State.get)
 
-  const err = /State.get: Function Required/
+  const err = /State.get: No arguments or function required/
   t.throws(get(undefined), err, 'throws with undefined')
   t.throws(get(null), err, 'throws with null')
   t.throws(get(0), err, 'throws with falsey number')
@@ -152,14 +152,36 @@ test('State get', t => {
   t.throws(get([]), err, 'throws with an array')
   t.throws(get({}), err, 'throws with an object')
 
+  t.doesNotThrow(get(identity), 'does not throw with a function')
+  t.doesNotThrow(get(), 'does not throw without a function')
+
+  t.end()
+})
+
+test('State get with function', t => {
   const f = x => x * 2
   const v = 75
 
   const state = State.get(f)
 
   t.equals(state.type(), State.type(), 'returns a State')
+
   t.equals(state.runWith(v).type(), Pair.type(), 'returns a Pair when ran')
   t.equals(state.evalWith(v), f(v), 'sets the result value to value returned by the function')
+  t.equals(state.execWith(v), v, 'sets the state value to ran state')
+
+  t.end()
+})
+
+test('State get without function', t => {
+  const v = 75
+
+  const state = State.get()
+
+  t.equals(state.type(), State.type(), 'returns a State')
+
+  t.equals(state.runWith(v).type(), Pair.type(), 'returns a Pair when ran')
+  t.equals(state.evalWith(v), v, 'sets the result value to value returned by the function')
   t.equals(state.execWith(v), v, 'sets the state value to ran state')
 
   t.end()

--- a/src/State/index.js
+++ b/src/State/index.js
@@ -15,11 +15,15 @@ const _of =
   x => State(s => Pair(x, s))
 
 function get(fn) {
-  if(!isFunction(fn)) {
-    throw new TypeError('State.get: Function Required')
+  if(!arguments.length) {
+    return State(s => Pair(s, s))
   }
 
-  return State(s => Pair(fn(s), s))
+  if(isFunction(fn)) {
+    return State(s => Pair(fn(s), s))
+  }
+
+  throw new TypeError('State.get: No arguments or function required')
 }
 
 function modify(fn) {

--- a/src/core/List.js
+++ b/src/core/List.js
@@ -3,7 +3,7 @@
 
 const _implements = require('./implements')
 const _inspect = require('./inspect')
-const type = require('../core/types').type('List')
+const type = require('./types').type('List')
 
 const isApplicative = require('./isApplicative')
 const isArray = require('./isArray')

--- a/src/core/Maybe.js
+++ b/src/core/Maybe.js
@@ -5,7 +5,7 @@ const _defineUnion = require('./defineUnion')
 const _implements = require('./implements')
 const _innerConcat = require('./innerConcat')
 const _inspect = require('./inspect')
-const type = require('../core/types').type('Maybe')
+const type = require('./types').type('Maybe')
 
 const compose = require('./compose')
 const constant = require('./constant')

--- a/src/core/Pair.js
+++ b/src/core/Pair.js
@@ -3,7 +3,7 @@
 
 const _implements = require('./implements')
 const _inspect = require('./inspect')
-const type = require('../core/types').type('Pair')
+const type = require('./types').type('Pair')
 
 const isFunction = require('./isFunction')
 const isSameType = require('./isSameType')

--- a/src/core/Unit.js
+++ b/src/core/Unit.js
@@ -2,7 +2,7 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const _implements = require('./implements')
-const type = require('../core/types').type('Unit')
+const type = require('./types').type('Unit')
 
 const isFunction = require('./isFunction')
 const isSameType = require('./isSameType')


### PR DESCRIPTION
## Make things more flexible
![image](https://user-images.githubusercontent.com/3665793/28508445-c13c6ad6-6fef-11e7-901b-07a5fb0b2343.png)

A common pattern when using `Reader.get` is to do something like `Reader.get(identity)` when one wants to use the environment as is, with no additional mapping. Because of this, it makes sense to allow for a version of the function that will automatically map identity when no arguments are passed.

As `State` provides a similar function with `State.get`, it makes sense to have that function follow suit. So now, with this PR both `Reader.ask` and `State.get` will map identity when nothing is passed to the function. If a function is in fact passed to those functions, then they will behave as normal, mapping the function over the environment or state.