### PR TITLE
Make `Star` a `Category` by fixing it to a given `Monad`

### DIFF
--- a/src/Star/Star.spec.js
+++ b/src/Star/Star.spec.js
@@ -10,32 +10,65 @@ const constant = require('../core/constant')
 const identity = require('../core/identity')
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isSameType = require('../core/isSameType')
 const unit = require('../core/_unit')
 
 const Pair = require('../core/Pair')
 
-const Star = require('.')
+const _Star = require('.')
+
+const Star = _Star(MockCrock)
 
 test('Star', t => {
-  const a = bindFunc(Star)
+  const a = bindFunc(_Star)
 
-  t.ok(isFunction(Star), 'is a function')
+  t.ok(isFunction(_Star), 'is a function')
 
   t.ok(isFunction(Star.type), 'provides a type function')
 
   t.ok(isObject(Star(unit)), 'returns an object')
 
-  t.throws(Star, TypeError, 'throws with nothing')
-  t.throws(a(undefined), TypeError, 'throws with undefined')
-  t.throws(a(null), TypeError, 'throws with undefined')
-  t.throws(a(0), TypeError, 'throws with falsey number')
-  t.throws(a(1), TypeError, 'throws with truthy number')
-  t.throws(a(''), TypeError, 'throws with falsey string')
-  t.throws(a('string'), TypeError, 'throws with truthy string')
-  t.throws(a(false), TypeError, 'throws with false')
-  t.throws(a(true), TypeError, 'throws with true')
-  t.throws(a({}), TypeError, 'throws with an object')
-  t.throws(a([]), TypeError, 'throws with an array')
+  const err = /Star: Monad required for construction/
+  t.throws(a(), err, 'throws with nothing')
+  t.throws(a(undefined), err, 'throws with undefined')
+  t.throws(a(null), err, 'throws with undefined')
+  t.throws(a(0), err, 'throws with falsey number')
+  t.throws(a(1), err, 'throws with truthy number')
+  t.throws(a(''), err, 'throws with falsey string')
+  t.throws(a('string'), err, 'throws with truthy string')
+  t.throws(a(false), err, 'throws with false')
+  t.throws(a(true), err, 'throws with true')
+  t.throws(a({}), err, 'throws with an object')
+  t.throws(a([]), err, 'throws with an array')
+  t.throws(a(unit), err, 'throws with a function')
+
+  t.doesNotThrow(a(MockCrock), 'allows a Monad')
+
+  t.end()
+})
+
+test('Star construction', t => {
+  const a = bindFunc(Star)
+
+  t.ok(isFunction(Star), 'Constructor returns a function')
+
+  t.ok(isFunction(Star.type), 'provides a type function')
+  t.ok(isFunction(Star.id), 'provides an id function')
+
+  t.ok(isObject(Star(unit)), 'returns an object')
+
+  const err = /Star\( MockCrock \): Function in the form \(a -> m b\) required/
+  t.throws(Star, err, 'throws with nothing')
+  t.throws(a(undefined), err, 'throws with undefined')
+  t.throws(a(null), err, 'throws with undefined')
+  t.throws(a(0), err, 'throws with falsey number')
+  t.throws(a(1), err, 'throws with truthy number')
+  t.throws(a(''), err, 'throws with falsey string')
+  t.throws(a('string'), err, 'throws with truthy string')
+  t.throws(a(false), err, 'throws with false')
+  t.throws(a(true), err, 'throws with true')
+  t.throws(a({}), err, 'throws with an object')
+  t.throws(a([]), err, 'throws with an array')
 
   t.doesNotThrow(a(unit), 'allows a function')
 
@@ -47,6 +80,7 @@ test('Star @@implements', t => {
 
   t.equal(f('compose'), true, 'implements compose func')
   t.equal(f('contramap'), true, 'implements contramap func')
+  t.equal(f('id'), true, 'implements id  func')
   t.equal(f('map'), true, 'implements map func')
   t.equal(f('promap'), true, 'implements promap func')
 
@@ -57,7 +91,7 @@ test('Star inspect', t => {
   const a = Star(unit)
 
   t.ok(isFunction(a.inspect), 'provides an inspect function')
-  t.equal(a.inspect(), 'Star Function', 'returns inspect string')
+  t.equal(a.inspect(), 'Star( MockCrock ) Function', 'returns inspect string')
 
   t.end()
 })
@@ -67,7 +101,7 @@ test('Star type', t => {
   t.ok(isFunction(a.type), 'is a function')
 
   t.equal(a.type, Star.type, 'static and instance versions are the same')
-  t.equal(a.type(), 'Star', 'reports Star')
+  t.equal(a.type(), 'Star( MockCrock )', 'reports Star with embeded type')
 
   t.end()
 })
@@ -96,44 +130,47 @@ test('Star compose functionality', t => {
 
   const cat = bindFunc(a.compose)
 
-  t.throws(cat(undefined), TypeError, 'throws with undefined')
-  t.throws(cat(null), TypeError, 'throws with null')
-  t.throws(cat(0), TypeError, 'throws with falsey number')
-  t.throws(cat(1), TypeError, 'throws with truthy number')
-  t.throws(cat(''), TypeError, 'throws with falsey string')
-  t.throws(cat('string'), TypeError, 'throws with truthy string')
-  t.throws(cat(false), TypeError, 'throws with false')
-  t.throws(cat(true), TypeError, 'throws with true')
-  t.throws(cat([]), TypeError, 'throws with an array')
-  t.throws(cat({}), TypeError, 'throws with an object')
-  t.throws(cat(notStar), TypeError, 'throws with non-Star')
+  const noStar = /Star\( MockCrock \).compose: Star\( MockCrock \) required/
+  t.throws(cat(undefined), noStar, 'throws with undefined')
+  t.throws(cat(null), noStar, 'throws with null')
+  t.throws(cat(0), noStar, 'throws with falsey number')
+  t.throws(cat(1), noStar, 'throws with truthy number')
+  t.throws(cat(''), noStar, 'throws with falsey string')
+  t.throws(cat('string'), noStar, 'throws with truthy string')
+  t.throws(cat(false), noStar, 'throws with false')
+  t.throws(cat(true), noStar, 'throws with true')
+  t.throws(cat([]), noStar, 'throws with an array')
+  t.throws(cat({}), noStar, 'throws with an object')
+  t.throws(cat(notStar), noStar, 'throws with non-Star')
 
   const noMonadFst = bindFunc(Star(identity).compose(a).runWith)
 
-  t.throws(noMonadFst(undefined), TypeError, 'throws when first computation returns undefined')
-  t.throws(noMonadFst(null), TypeError, 'throws when first computation returns null')
-  t.throws(noMonadFst(0), TypeError, 'throws when first computation returns falsey number')
-  t.throws(noMonadFst(1), TypeError, 'throws when first computation returns truthy number')
-  t.throws(noMonadFst(''), TypeError, 'throws when first computation returns falsey string')
-  t.throws(noMonadFst('string'), TypeError, 'throws when first computation returns truthy string')
-  t.throws(noMonadFst(false), TypeError, 'throws when first computation returns false')
-  t.throws(noMonadFst(true), TypeError, 'throws when first computation returns true')
-  t.throws(noMonadFst({}), TypeError, 'throws when first computation returns false')
-  t.throws(noMonadFst([]), TypeError, 'throws when first computation returns true')
+  const noFst = /Star\( MockCrock \).compose: Computations must return a type of MockCrock/
+  t.throws(noMonadFst(undefined), noFst, 'throws when first computation returns undefined')
+  t.throws(noMonadFst(null), noFst, 'throws when first computation returns null')
+  t.throws(noMonadFst(0), noFst, 'throws when first computation returns falsey number')
+  t.throws(noMonadFst(1), noFst, 'throws when first computation returns truthy number')
+  t.throws(noMonadFst(''), noFst, 'throws when first computation returns falsey string')
+  t.throws(noMonadFst('string'), noFst, 'throws when first computation returns truthy string')
+  t.throws(noMonadFst(false), noFst, 'throws when first computation returns false')
+  t.throws(noMonadFst(true), noFst, 'throws when first computation returns true')
+  t.throws(noMonadFst({}), noFst, 'throws when first computation returns false')
+  t.throws(noMonadFst([]), noFst, 'throws when first computation returns true')
 
   const noMonadSnd = bindFunc(x => a.compose(Star(constant(x))).runWith(10))
 
-  t.throws(noMonadSnd(undefined), TypeError, 'throws when second computation returns undefined')
-  t.throws(noMonadSnd(null), TypeError, 'throws when second computation returns null')
-  t.throws(noMonadSnd(0), TypeError, 'throws when second computation returns falsey number')
-  t.throws(noMonadSnd(1), TypeError, 'throws when second computation returns truthy number')
-  t.throws(noMonadSnd(''), TypeError, 'throws when second computation returns falsey string')
-  t.throws(noMonadSnd('string'), TypeError, 'throws when second computation returns truthy string')
-  t.throws(noMonadSnd(false), TypeError, 'throws when second computation returns false')
-  t.throws(noMonadSnd(true), TypeError, 'throws when second computation returns true')
-  t.throws(noMonadSnd({}), TypeError, 'throws when second computation returns false')
-  t.throws(noMonadSnd([]), TypeError, 'throws when second computation returns true')
-  t.throws(noMonadSnd(notMock), TypeError, 'throws when second computation returns non-MockCrock')
+  const noSnd = /Star\( MockCrock \).compose: Both computations must return a type of MockCrock/
+  t.throws(noMonadSnd(undefined), noSnd, 'throws when second computation returns undefined')
+  t.throws(noMonadSnd(null), noSnd, 'throws when second computation returns null')
+  t.throws(noMonadSnd(0), noSnd, 'throws when second computation returns falsey number')
+  t.throws(noMonadSnd(1), noSnd, 'throws when second computation returns truthy number')
+  t.throws(noMonadSnd(''), noSnd, 'throws when second computation returns falsey string')
+  t.throws(noMonadSnd('string'), noSnd, 'throws when second computation returns truthy string')
+  t.throws(noMonadSnd(false), noSnd, 'throws when second computation returns false')
+  t.throws(noMonadSnd(true), noSnd, 'throws when second computation returns true')
+  t.throws(noMonadSnd({}), noSnd, 'throws when second computation returns false')
+  t.throws(noMonadSnd([]), noSnd, 'throws when second computation returns true')
+  t.throws(noMonadSnd(notMock), noSnd, 'throws when second computation returns non-MockCrock')
 
   const x = 13
   const g = x => MockCrock(x * 10)
@@ -163,25 +200,57 @@ test('Star compose properties (Semigroupoid)', t => {
   t.end()
 })
 
+test('Star id functionality', t => {
+  const m = Star.id()
+  const value = 13
+  const result = m.runWith(value)
+
+  t.equal(m.id, Star.id, 'static and instance versions are the same')
+
+  t.ok(isSameType(Star, m), 'provides an Arrow')
+  t.ok(isSameType(MockCrock, result), 'returns an instance of the wraped monad')
+  t.equals(result.value(), value, 'resulting instance wraps idenity of input')
+
+  t.end()
+})
+
+test('Star id properties (Category)', t => {
+  const m = Star(x => MockCrock(x + 45))
+  const x = 32
+
+  t.ok(isFunction(m.compose), 'provides a compose function')
+  t.ok(isFunction(m.id), 'provides an id function')
+
+  const right = m.compose(m.id()).runWith
+  const left = m.id().compose(m).runWith
+
+  t.same(right(x).value(), m.runWith(x).value(), 'right identity')
+  t.same(left(x).value(), m.runWith(x).value(), 'left identity')
+
+  t.end()
+})
+
 test('Star map errors', t => {
   const map = bindFunc(Star(unit).map)
 
-  t.throws(map(undefined), TypeError, 'throws with undefined')
-  t.throws(map(null), TypeError, 'throws with null')
-  t.throws(map(0), TypeError, 'throws with falsey number')
-  t.throws(map(1), TypeError, 'throws with truthy number')
-  t.throws(map(''), TypeError, 'throws with falsey string')
-  t.throws(map('string'), TypeError, 'throws with truthy string')
-  t.throws(map(false), TypeError, 'throws with false')
-  t.throws(map(true), TypeError, 'throws with true')
-  t.throws(map([]), TypeError, 'throws with an array')
-  t.throws(map({}), TypeError, 'throws with an object')
+  const err = /Star\( MockCrock \).map: Function required/
+  t.throws(map(undefined), err, 'throws with undefined')
+  t.throws(map(null), err, 'throws with null')
+  t.throws(map(0), err, 'throws with falsey number')
+  t.throws(map(1), err, 'throws with truthy number')
+  t.throws(map(''), err, 'throws with falsey string')
+  t.throws(map('string'), err, 'throws with truthy string')
+  t.throws(map(false), err, 'throws with false')
+  t.throws(map(true), err, 'throws with true')
+  t.throws(map([]), err, 'throws with an array')
+  t.throws(map({}), err, 'throws with an object')
 
   t.doesNotThrow(map(unit), 'allows functions')
 
   const runWith = bindFunc(Star(identity).map(identity).runWith)
 
-  t.throws(runWith('silly'), TypeError, 'throws when inner function does not return a Functor')
+  const noMonad = /Star\( MockCrock \).map: Computations must return a type of MockCrock/
+  t.throws(runWith('silly'), noMonad, 'throws when inner function does not return a Functor')
 
   t.end()
 })
@@ -192,7 +261,7 @@ test('Star map functionality', t => {
 
   const m = Star(MockCrock).map(spy)
 
-  t.equal(m.type(), 'Star', 'returns a Star')
+  t.ok(isSameType(Star, m), 'returns a Star')
   t.notOk(spy.called, 'does not call mapping function initially')
 
   const result = m.runWith(x)
@@ -227,16 +296,17 @@ test('Star map properties (Functor)', t => {
 test('Star contramap errors', t => {
   const cmap = bindFunc(Star(unit).contramap)
 
-  t.throws(cmap(undefined), TypeError, 'throws with undefined')
-  t.throws(cmap(null), TypeError, 'throws with null')
-  t.throws(cmap(0), TypeError, 'throws with falsey number')
-  t.throws(cmap(1), TypeError, 'throws with truthy number')
-  t.throws(cmap(''), TypeError, 'throws with falsey string')
-  t.throws(cmap('string'), TypeError, 'throws with truthy string')
-  t.throws(cmap(false), TypeError, 'throws with false')
-  t.throws(cmap(true), TypeError, 'throws with true')
-  t.throws(cmap([]), TypeError, 'throws with an array')
-  t.throws(cmap({}), TypeError, 'throws with an object')
+  const err = /Star\( MockCrock \).contramap: Function required/
+  t.throws(cmap(undefined), err, 'throws with undefined')
+  t.throws(cmap(null), err, 'throws with null')
+  t.throws(cmap(0), err, 'throws with falsey number')
+  t.throws(cmap(1), err, 'throws with truthy number')
+  t.throws(cmap(''), err, 'throws with falsey string')
+  t.throws(cmap('string'), err, 'throws with truthy string')
+  t.throws(cmap(false), err, 'throws with false')
+  t.throws(cmap(true), err, 'throws with true')
+  t.throws(cmap([]), err, 'throws with an array')
+  t.throws(cmap({}), err, 'throws with an object')
 
   t.doesNotThrow(cmap(unit), 'allows functions')
 
@@ -249,7 +319,7 @@ test('Star contramap functionality', t => {
 
   const m = Star(MockCrock).contramap(spy)
 
-  t.equal(m.type(), 'Star', 'returns a Star')
+  t.ok(isSameType(Star, m), 'returns a Star')
   t.notOk(spy.called, 'does not call mapping function initially')
 
   m.runWith(x)
@@ -283,33 +353,35 @@ test('Star contramap properties (Contra Functor)', t => {
 test('Star promap errors', t => {
   const promap = bindFunc(Star(MockCrock).promap)
 
-  t.throws(promap(undefined, unit), TypeError, 'throws with undefined as first argument')
-  t.throws(promap(null, unit), TypeError, 'throws with null as first argument')
-  t.throws(promap(0, unit), TypeError, 'throws with falsey number as first argument')
-  t.throws(promap(1, unit), TypeError, 'throws with truthy number as first argument')
-  t.throws(promap('', unit), TypeError, 'throws with falsey string as first argument')
-  t.throws(promap('string', unit), TypeError, 'throws with truthy string as first argument')
-  t.throws(promap(false, unit), TypeError, 'throws with false as first argument')
-  t.throws(promap(true, unit), TypeError, 'throws with true as first argument')
-  t.throws(promap([], unit), TypeError, 'throws with an array as first argument')
-  t.throws(promap({}, unit), TypeError, 'throws with an object as first argument')
+  const noFuncs = /Star\( MockCrock \).promap: Functions required for both arguments/
+  t.throws(promap(undefined, unit), noFuncs, 'throws with undefined as first argument')
+  t.throws(promap(null, unit), noFuncs, 'throws with null as first argument')
+  t.throws(promap(0, unit), noFuncs, 'throws with falsey number as first argument')
+  t.throws(promap(1, unit), noFuncs, 'throws with truthy number as first argument')
+  t.throws(promap('', unit), noFuncs, 'throws with falsey string as first argument')
+  t.throws(promap('string', unit), noFuncs, 'throws with truthy string as first argument')
+  t.throws(promap(false, unit), noFuncs, 'throws with false as first argument')
+  t.throws(promap(true, unit), noFuncs, 'throws with true as first argument')
+  t.throws(promap([], unit), noFuncs, 'throws with an array as first argument')
+  t.throws(promap({}, unit), noFuncs, 'throws with an object as first argument')
 
-  t.throws(promap(unit, undefined), TypeError, 'throws with undefined as second argument')
-  t.throws(promap(unit, null), TypeError, 'throws with null as second argument')
-  t.throws(promap(unit, 0), TypeError, 'throws with falsey number as second argument')
-  t.throws(promap(unit, 1), TypeError, 'throws with truthy number as second argument')
-  t.throws(promap(unit, ''), TypeError, 'throws with falsey string as second argument')
-  t.throws(promap(unit, 'string'), TypeError, 'throws with truthy string as second argument')
-  t.throws(promap(unit, false), TypeError, 'throws with false as second argument')
-  t.throws(promap(unit, true), TypeError, 'throws with true as second argument')
-  t.throws(promap(unit, []), TypeError, 'throws with an array as second argument')
-  t.throws(promap(unit, {}), TypeError, 'throws with an object as second argument')
+  t.throws(promap(unit, undefined), noFuncs, 'throws with undefined as second argument')
+  t.throws(promap(unit, null), noFuncs, 'throws with null as second argument')
+  t.throws(promap(unit, 0), noFuncs, 'throws with falsey number as second argument')
+  t.throws(promap(unit, 1), noFuncs, 'throws with truthy number as second argument')
+  t.throws(promap(unit, ''), noFuncs, 'throws with falsey string as second argument')
+  t.throws(promap(unit, 'string'), noFuncs, 'throws with truthy string as second argument')
+  t.throws(promap(unit, false), noFuncs, 'throws with false as second argument')
+  t.throws(promap(unit, true), noFuncs, 'throws with true as second argument')
+  t.throws(promap(unit, []), noFuncs, 'throws with an array as second argument')
+  t.throws(promap(unit, {}), noFuncs, 'throws with an object as second argument')
 
   t.doesNotThrow(promap(unit, unit), 'allows functions')
 
   const runWith = bindFunc(Star(identity).promap(identity, identity).runWith)
 
-  t.throws(runWith('silly'), TypeError, 'throws when inner function does not return a Functor')
+  const err = /Star\( MockCrock \).promap: Computation must return a type of MockCrock/
+  t.throws(runWith('silly'), err, 'throws when inner function does not return a Monad')
 
   t.end()
 })
@@ -326,7 +398,7 @@ test('Star promap functionality', t => {
 
   const m = Star(MockCrock).promap(spyLeft, spyRight)
 
-  t.equal(m.type(), 'Star', 'returns a Star')
+  t.ok(isSameType(Star, m), 'returns a Star')
   t.notOk(spyLeft.called, 'does not call left mapping function initially')
   t.notOk(spyRight.called, 'does not call right mapping function initially')
 
@@ -372,34 +444,36 @@ test('Star first', t => {
 
   const runWith = bindFunc(m.first().runWith)
 
-  t.throws(runWith(undefined), TypeError, 'throws with undefined input')
-  t.throws(runWith(null), TypeError, 'throws with null as input')
-  t.throws(runWith(0), TypeError, 'throws with falsey number as input')
-  t.throws(runWith(1), TypeError, 'throws with truthy number as input')
-  t.throws(runWith(''), TypeError, 'throws with falsey string as input')
-  t.throws(runWith('string'), TypeError, 'throws with truthy string as input')
-  t.throws(runWith(false), TypeError, 'throws with false as input')
-  t.throws(runWith(true), TypeError, 'throws with true as input')
-  t.throws(runWith([]), TypeError, 'throws with an array as input')
-  t.throws(runWith({}), TypeError, 'throws with an object as input')
+  const noPair = /Star\( MockCrock \).first: Pair required for computation input/
+  t.throws(runWith(undefined), noPair, 'throws with undefined input')
+  t.throws(runWith(null), noPair, 'throws with null as input')
+  t.throws(runWith(0), noPair, 'throws with falsey number as input')
+  t.throws(runWith(1), noPair, 'throws with truthy number as input')
+  t.throws(runWith(''), noPair, 'throws with falsey string as input')
+  t.throws(runWith('string'), noPair, 'throws with truthy string as input')
+  t.throws(runWith(false), noPair, 'throws with false as input')
+  t.throws(runWith(true), noPair, 'throws with true as input')
+  t.throws(runWith([]), noPair, 'throws with an array as input')
+  t.throws(runWith({}), noPair, 'throws with an object as input')
 
   t.doesNotThrow(runWith(Pair(1, 2)), 'does not throw when inner value is a Pair')
 
   const notValid = bindFunc(x => Star(() => x).first().runWith(Pair(2, 3)))
 
-  t.throws(notValid(undefined), TypeError, 'throws with undefined input')
-  t.throws(notValid(null), TypeError, 'throws with null as input')
-  t.throws(notValid(0), TypeError, 'throws with falsey number as input')
-  t.throws(notValid(1), TypeError, 'throws with truthy number as input')
-  t.throws(notValid(''), TypeError, 'throws with falsey string as input')
-  t.throws(notValid('string'), TypeError, 'throws with truthy string as input')
-  t.throws(notValid(false), TypeError, 'throws with false as input')
-  t.throws(notValid(true), TypeError, 'throws with true as input')
-  t.throws(notValid({}), TypeError, 'throws with an object as input')
+  const err = /Star\( MockCrock \).first: Computation must return a type of MockCrock/
+  t.throws(notValid(undefined), err, 'throws with undefined input')
+  t.throws(notValid(null), err, 'throws with null as input')
+  t.throws(notValid(0), err, 'throws with falsey number as input')
+  t.throws(notValid(1), err, 'throws with truthy number as input')
+  t.throws(notValid(''), err, 'throws with falsey string as input')
+  t.throws(notValid('string'), err, 'throws with truthy string as input')
+  t.throws(notValid(false), err, 'throws with false as input')
+  t.throws(notValid(true), err, 'throws with true as input')
+  t.throws(notValid({}), err, 'throws with an object as input')
 
   const result = m.first().runWith(Pair(10, 10)).value()
 
-  t.equal(result.type(), 'Pair', 'returns a Pair')
+  t.ok(isSameType(Pair, result), 'returns a Pair')
   t.equal(result.fst(), 11, 'applies the function to the fst element of a pair')
   t.equal(result.snd(), 10, 'does not apply the function to the second element of a pair')
 
@@ -413,36 +487,38 @@ test('Star second', t => {
 
   const runWith = bindFunc(m.second().runWith)
 
-  t.throws(runWith(undefined), TypeError, 'throws with undefined as input')
-  t.throws(runWith(null), TypeError, 'throws with null as input')
-  t.throws(runWith(0), TypeError, 'throws with falsey number as input')
-  t.throws(runWith(1), TypeError, 'throws with truthy number as input')
-  t.throws(runWith(''), TypeError, 'throws with falsey string as input')
-  t.throws(runWith('string'), TypeError, 'throws with truthy string as input')
-  t.throws(runWith(false), TypeError, 'throws with false as input')
-  t.throws(runWith(true), TypeError, 'throws with true as input')
-  t.throws(runWith([]), TypeError, 'throws with an array as input')
-  t.throws(runWith({}), TypeError, 'throws with an object as input')
+  const noPair = /Star\( MockCrock \).second: Pair required for computation input/
+  t.throws(runWith(undefined), noPair, 'throws with undefined as input')
+  t.throws(runWith(null), noPair, 'throws with null as input')
+  t.throws(runWith(0), noPair, 'throws with falsey number as input')
+  t.throws(runWith(1), noPair, 'throws with truthy number as input')
+  t.throws(runWith(''), noPair, 'throws with falsey string as input')
+  t.throws(runWith('string'), noPair, 'throws with truthy string as input')
+  t.throws(runWith(false), noPair, 'throws with false as input')
+  t.throws(runWith(true), noPair, 'throws with true as input')
+  t.throws(runWith([]), noPair, 'throws with an array as input')
+  t.throws(runWith({}), noPair, 'throws with an object as input')
 
   t.doesNotThrow(runWith(Pair(1, 2)), 'does not throw when inner value is a Pair')
 
   const notValid = bindFunc(x => Star(() => x).second().runWith(Pair(2, 3)))
 
-  t.throws(notValid(undefined), TypeError, 'throws when computation returns undefined')
-  t.throws(notValid(null), TypeError, 'throws when computation returns null')
-  t.throws(notValid(0), TypeError, 'throws when computation returns falsey number')
-  t.throws(notValid(1), TypeError, 'throws when computation returns truthy number')
-  t.throws(notValid(''), TypeError, 'throws when computation returns falsey string')
-  t.throws(notValid('string'), TypeError, 'throws when computation returns truthy string')
-  t.throws(notValid(false), TypeError, 'throws when computation returns false')
-  t.throws(notValid(true), TypeError, 'throws when computation returns true')
-  t.throws(notValid({}), TypeError, 'throws an when computation returns object')
+  const err = /Star\( MockCrock \).second: Computation must return a type of MockCrock/
+  t.throws(notValid(undefined), err, 'throws when computation returns undefined')
+  t.throws(notValid(null), err, 'throws when computation returns null')
+  t.throws(notValid(0), err, 'throws when computation returns falsey number')
+  t.throws(notValid(1), err, 'throws when computation returns truthy number')
+  t.throws(notValid(''), err, 'throws when computation returns falsey string')
+  t.throws(notValid('string'), err, 'throws when computation returns truthy string')
+  t.throws(notValid(false), err, 'throws when computation returns false')
+  t.throws(notValid(true), err, 'throws when computation returns true')
+  t.throws(notValid({}), err, 'throws an when computation returns object')
 
   t.doesNotThrow(notValid(MockCrock.of(2)), 'does not throw when computation returns a Functor')
 
   const result = m.second().runWith(Pair(10, 10)).value()
 
-  t.equal(result.type(), 'Pair', 'returns a Pair')
+  t.ok(isSameType(Pair, result), 'returns a Pair')
   t.equal(result.snd(), 11, 'applies the function to the snd element of a pair')
   t.equal(result.fst(), 10, 'does not apply the function to the first element of a pair')
 
@@ -456,36 +532,38 @@ test('Star both', t => {
 
   const runWith = bindFunc(m.both().runWith)
 
-  t.throws(runWith(undefined), TypeError, 'throws with undefined as input')
-  t.throws(runWith(null), TypeError, 'throws with null as input')
-  t.throws(runWith(0), TypeError, 'throws with falsey number as input')
-  t.throws(runWith(1), TypeError, 'throws with truthy number as input')
-  t.throws(runWith(''), TypeError, 'throws with falsey string as input')
-  t.throws(runWith('string'), TypeError, 'throws with truthy string as input')
-  t.throws(runWith(false), TypeError, 'throws with false as input')
-  t.throws(runWith(true), TypeError, 'throws with true as input')
-  t.throws(runWith([]), TypeError, 'throws with an array as input')
-  t.throws(runWith({}), TypeError, 'throws with an object as input')
+  const noPair = /Star\( MockCrock \).both: Pair required for computation input/
+  t.throws(runWith(undefined), noPair, 'throws with undefined as input')
+  t.throws(runWith(null), noPair, 'throws with null as input')
+  t.throws(runWith(0), noPair, 'throws with falsey number as input')
+  t.throws(runWith(1), noPair, 'throws with truthy number as input')
+  t.throws(runWith(''), noPair, 'throws with falsey string as input')
+  t.throws(runWith('string'), noPair, 'throws with truthy string as input')
+  t.throws(runWith(false), noPair, 'throws with false as input')
+  t.throws(runWith(true), noPair, 'throws with true as input')
+  t.throws(runWith([]), noPair, 'throws with an array as input')
+  t.throws(runWith({}), noPair, 'throws with an object as input')
 
   t.doesNotThrow(runWith(Pair(1, 2)), 'does not throw when inner value is a Pair')
 
   const notValid = bindFunc(x => Star(() => x).both().runWith(Pair(2, 3)))
 
-  t.throws(notValid(undefined), TypeError, 'throws when computation returns undefined')
-  t.throws(notValid(null), TypeError, 'throws when computation returns null')
-  t.throws(notValid(0), TypeError, 'throws when computation returns falsey number')
-  t.throws(notValid(1), TypeError, 'throws when computation returns truthy number')
-  t.throws(notValid(''), TypeError, 'throws when computation returns falsey string')
-  t.throws(notValid('string'), TypeError, 'throws when computation returns truthy string')
-  t.throws(notValid(false), TypeError, 'throws when computation returns false')
-  t.throws(notValid(true), TypeError, 'throws when computation returns true')
-  t.throws(notValid({}), TypeError, 'throws an when computation returns object')
+  const err = /Star\( MockCrock \).both: Computation must return a type of MockCrock/
+  t.throws(notValid(undefined), err, 'throws when computation returns undefined')
+  t.throws(notValid(null), err, 'throws when computation returns null')
+  t.throws(notValid(0), err, 'throws when computation returns falsey number')
+  t.throws(notValid(1), err, 'throws when computation returns truthy number')
+  t.throws(notValid(''), err, 'throws when computation returns falsey string')
+  t.throws(notValid('string'), err, 'throws when computation returns truthy string')
+  t.throws(notValid(false), err, 'throws when computation returns false')
+  t.throws(notValid(true), err, 'throws when computation returns true')
+  t.throws(notValid({}), err, 'throws an when computation returns object')
 
   t.doesNotThrow(notValid(MockCrock.of(2)), 'does not throw when computation returns a Functor')
 
   const result = m.both().runWith(Pair(10, 10)).value()
 
-  t.equal(result.type(), 'Pair', 'returns a Pair')
+  t.ok(isSameType(Pair, result), 'returns a Pair')
   t.equal(result.fst(), 11, 'applies the function to the first element of a pair')
   t.equal(result.snd(), 11, 'applies the function to the snd element of a pair')
 

--- a/src/Star/index.js
+++ b/src/Star/index.js
@@ -4,13 +4,12 @@
 const _compose = require('../core/compose')
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
-const type = require('../core/types').type('Star')
+const _type = require('../core/types').type('Star')
 
 const Pair = require('../core/Pair')
 
 const array = require('../core/array')
 const isFunction = require('../core/isFunction')
-const isFunctor = require('../core/isFunctor')
 const isMonad = require('../core/isMonad')
 const isSameType = require('../core/isSameType')
 
@@ -20,137 +19,162 @@ const merge =
 const sequence =
   (af, m) => array.sequence(af, m)
 
-function Star(runWith) {
-  if(!isFunction(runWith)) {
-    throw new TypeError('Star: Function in the form (a -> f b) required')
+function _Star(Monad) {
+  if(!isMonad(Monad)) {
+    throw new TypeError('Star: Monad required for construction')
   }
 
-  const inspect =
-    () => `Star${_inspect(runWith)}`
+  const _id =
+    () => Star(Monad.of)
 
-  function compose(s) {
-    if(!isSameType(Star, s)) {
-      throw new TypeError('Star.concat: Star required')
+  const innerType =
+    Monad.type()
+
+  const outerType =
+    `${_type()}( ${innerType} )`
+
+  const type =
+    () => outerType
+
+  function Star(runWith) {
+    if(!isFunction(runWith)) {
+      throw new TypeError(`${outerType}: Function in the form (a -> m b) required`)
     }
 
-    return Star(function(x) {
-      const m = runWith(x)
+    const inspect =
+      () => `${outerType}${_inspect(runWith)}`
 
-      if(!isMonad(m)) {
-        throw new TypeError('Star.concat: Computations must return a Monad')
+    const id =
+      _id
+
+    function compose(s) {
+      if(!isSameType(Star, s)) {
+        throw new TypeError(`${outerType}.compose: ${outerType} required`)
       }
 
-      return m.chain(function(val) {
-        const inner = s.runWith(val)
+      return Star(function(x) {
+        const m = runWith(x)
 
-        if(!isSameType(m, inner)) {
-          throw new TypeError('Star.concat: Computations must return Monads of the same type')
+        if(!isSameType(Monad, m)) {
+          throw new TypeError(`${outerType}.compose: Computations must return a type of ${innerType}`)
         }
 
-        return inner
+        return m.chain(function(val) {
+          const inner = s.runWith(val)
+
+          if(!isSameType(m, inner)) {
+            throw new TypeError(`${outerType}.compose: Both computations must return a type of ${innerType}`)
+          }
+
+          return inner
+        })
       })
-    })
-  }
-
-  function map(fn) {
-    if(!isFunction(fn)) {
-      throw new TypeError('Star.map: Function required')
     }
 
-    return Star(function(x) {
-      const m = runWith(x)
-
-      if(!isFunctor(m)) {
-        throw new TypeError('Star.map: Computation must return a Functor')
+    function map(fn) {
+      if(!isFunction(fn)) {
+        throw new TypeError(`${outerType}.map: Function required`)
       }
 
-      return m.map(fn)
-    })
-  }
+      return Star(function(x) {
+        const m = runWith(x)
 
-  function contramap(fn) {
-    if(!isFunction(fn)) {
-      throw new TypeError('Star.contramap: Function required')
+        if(!isSameType(Monad, m)) {
+          throw new TypeError(`${outerType}.map: Computations must return a type of ${innerType}`)
+        }
+
+        return m.map(fn)
+      })
     }
 
-    return Star(_compose(runWith, fn))
-  }
+    function contramap(fn) {
+      if(!isFunction(fn)) {
+        throw new TypeError(`${outerType}.contramap: Function required`)
+      }
 
-  function promap(l, r) {
-    if(!isFunction(l) || !isFunction(r)) {
-      throw new TypeError('Star.promap: Functions required for both arguments')
+      return Star(_compose(runWith, fn))
     }
 
-    return Star(function(x) {
-      const m = runWith(l(x))
-
-      if(!isFunctor(m)) {
-        throw new TypeError('Star.promap: Computation must return a Functor')
+    function promap(l, r) {
+      if(!isFunction(l) || !isFunction(r)) {
+        throw new TypeError(`${outerType}.promap: Functions required for both arguments`)
       }
 
-      return m.map(r)
-    })
+      return Star(function(x) {
+        const m = runWith(l(x))
+
+        if(!isSameType(Monad, m)) {
+          throw new TypeError(`${outerType}.promap: Computation must return a type of ${innerType}`)
+        }
+
+        return m.map(r)
+      })
+    }
+
+    function first() {
+      return Star(function(x) {
+        if(!isSameType(Pair, x)) {
+          throw TypeError(`${outerType}.first: Pair required for computation input`)
+        }
+
+        const m = runWith(x.fst())
+
+        if(!isSameType(Monad, m)) {
+          throw new TypeError(`${outerType}.first: Computation must return a type of ${innerType}`)
+        }
+
+        return m.map(l => Pair(l, x.snd()))
+      })
+    }
+
+    function second() {
+      return Star(function(x) {
+        if(!isSameType(Pair, x)) {
+          throw TypeError(`${outerType}.second: Pair required for computation input`)
+        }
+
+        const m = runWith(x.snd())
+
+        if(!isSameType(Monad, m)) {
+          throw new TypeError(`${outerType}.second: Computation must return a type of ${innerType}`)
+        }
+
+        return m.map(r => Pair(x.fst(), r))
+      })
+    }
+
+    function both() {
+      return Star(function(x) {
+        if(!isSameType(Pair, x)) {
+          throw TypeError(`${outerType}.both: Pair required for computation input`)
+        }
+
+        const p = x.bimap(runWith, runWith)
+        const m = p.fst()
+
+        if(!isSameType(Monad, m)) {
+          throw new TypeError(`${outerType}.both: Computation must return a type of ${innerType}`)
+        }
+
+        return sequence(m.of, merge((x, y) => [ x, y ], p)).map(x => Pair(x[0], x[1]))
+      })
+    }
+
+    return {
+      inspect, type, runWith,
+      id, compose, map, contramap,
+      promap, first, second, both
+    }
   }
 
-  function first() {
-    return Star(function(x) {
-      if(!isSameType(Pair, x)) {
-        throw TypeError('Star.first: Pair required for computation input')
-      }
+  Star.id = _id
+  Star.type = type
 
-      const m = runWith(x.fst())
+  Star['@@implements'] = _implements(
+    [ 'compose', 'contramap', 'id', 'map', 'promap' ]
+  )
 
-      if(!isFunctor(m)) {
-        throw new TypeError('Star.first: Computaion must return a Functor')
-      }
-
-      return m.map(l => Pair(l, x.snd()))
-    })
-  }
-
-  function second() {
-    return Star(function(x) {
-      if(!isSameType(Pair, x)) {
-        throw TypeError('Star.second: Pair required for computation input')
-      }
-
-      const m = runWith(x.snd())
-
-      if(!isFunctor(m)) {
-        throw new TypeError('Star.second: Computation must return a Functor')
-      }
-
-      return m.map(r => Pair(x.fst(), r))
-    })
-  }
-
-  function both() {
-    return Star(function(x) {
-      if(!isSameType(Pair, x)) {
-        throw TypeError('Star.both: Pair required for computation input')
-      }
-
-      const p = x.bimap(runWith, runWith)
-      const m = p.fst()
-
-      if(!isMonad(m)) {
-        throw new TypeError('Star.both: Computaion must return a Monad')
-      }
-
-      return sequence(m.of, merge((x, y) => [ x, y ], p)).map(x => Pair(x[0], x[1]))
-    })
-  }
-
-  return {
-    inspect, type, runWith, compose, map,
-    contramap, promap, first, second, both
-  }
+  return Star
 }
 
-Star.type = type
-
-Star['@@implements'] = _implements(
-  [ 'compose', 'contramap', 'map', 'promap' ]
-)
-
-module.exports = Star
+module.exports = _Star

--- a/src/helpers/fanout.js
+++ b/src/helpers/fanout.js
@@ -1,17 +1,20 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const Arrow = require('../core/types').proxy('Arrow')
-const Star = require('../core/types').proxy('Star')
 const Pair = require('../core/Pair')
 
 const curry = require('../core/curry')
+const isContravariant = require('../core/isContravariant')
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
+const isSemigroupoid = require('../core/isSemigroupoid')
 
 const valid = (x, y) =>
-  (isSameType(Arrow, x) || isSameType(Star, y))
-    && isSameType(x, y)
+  isSameType(x, y)
+    && isSemigroupoid(x)
+    && isContravariant(x)
+    && isFunction(x.first)
+    && isFunction(x.second)
 
 // fanout : m a b -> m a c -> m a (b, c)
 function fanout(fst, snd) {

--- a/src/helpers/fanout.spec.js
+++ b/src/helpers/fanout.spec.js
@@ -6,11 +6,14 @@ const bindFunc = helpers.bindFunc
 
 const Arrow = require('../Arrow')
 const Pair = require('../core/Pair')
-const Star = require('../Star')
+const _Star = require('../Star')
+
 const identity = require('../core/identity')
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
 const unit = require('../core/_unit')
+
+const Star = _Star(MockCrock)
 
 const fanout = require('./fanout')
 

--- a/test/MockCrock.js
+++ b/test/MockCrock.js
@@ -1,5 +1,6 @@
 const constant = require('../src/core/constant')
 const isSameType = require('../src/core/isSameType')
+const _implements = require('../src/core/implements')
 
 const _type = constant('MockCrock')
 const _of   = x => MockCrock(x)
@@ -26,5 +27,9 @@ function MockCrock(x) {
 
 MockCrock.type  = _type
 MockCrock.of    = _of
+
+MockCrock['@@implements'] = _implements(
+  [ 'ap', 'chain', 'equals', 'map', 'of', 'traverse' ]
+)
 
 module.exports = MockCrock


### PR DESCRIPTION
## A new Category of Star
![image](https://user-images.githubusercontent.com/3665793/28605749-33dd6114-7188-11e7-8651-c3acdce1b981.png)

This is a breaking change on `Star` that now requires a `Monad` constructor to get back the actual constructor to use.
```js
const MaybeStar = Star(Maybe)

// isValid : a -> Maybe a
const isValid = 
  safe(isNumber)

const m = 
  MaybeStar(isValid)
    .map(add(10))
    .map(multiply(2))

m.runWith(5)   // Just 30
m.runWith('a') // Nothing

// now with `id`
const left =
  MaybeStar.id().compose(m)

const right =
  m.compose(MaybeStar.id())

left.runWith(10)  // Just 40
right.runWith(10) // Just 40

```

Doing this allows for implementation of `id` making this `Star` a `Category`.