### PR TITLE
Accumulate `Err` on `Alt` for `Result` type

### DIFF
--- a/src/Result/Result.spec.js
+++ b/src/Result/Result.spec.js
@@ -522,17 +522,32 @@ test('Result alt errors', t => {
   t.end()
 })
 
-test('Result alt functionality', t => {
+test('Result alt functionality with Semigroup Err', t => {
   const right = Result.of('Ok')
   const anotherOk = Result.of('Another Ok')
 
-  const left = Result.Err('Err')
-  const anotherErr = Result.Err('Another Err')
+  const left = Result.Err([ 'Err' ])
+  const anotherErr = Result.Err([ 'Another Err' ])
 
   const f = either(identity, identity)
 
   t.equals(f(right.alt(left).alt(anotherOk)), 'Ok', 'retains first Ok success')
-  t.equals(f(left.alt(anotherErr)), 'Another Err', 'provdes last Err when all Errs')
+  t.same(f(left.alt(anotherErr)), [ 'Err', 'Another Err' ], 'provdes accumulated Err when all Errs')
+
+  t.end()
+})
+
+test('Result alt functionality without Semigroup Err', t => {
+  const right = Result.of('Ok')
+  const anotherOk = Result.of('Another Ok')
+
+  const left = Result.Err(3)
+  const anotherErr = Result.Err(13)
+
+  const f = either(identity, identity)
+
+  t.equals(f(right.alt(left).alt(anotherOk)), 'Ok', 'retains first Ok success')
+  t.same(f(left.alt(anotherErr)), 13, 'provdes last Err when all Errs')
 
   t.end()
 })


### PR DESCRIPTION
## Best Laid Plans
![image](https://user-images.githubusercontent.com/3665793/28723889-1a4ba0b2-736d-11e7-83eb-c9679bb01881.png)

After messing about with `Alt` and trying to come up with helpers for `Alternative` and `Alt`, I was really sad that `Result` did not accumulate `Err` like it does with `ap`. It would be very useful and does not ***seem*** to break any laws.

So that is what this is. Now if you use a `Semigroup` for your `Err` and use `alt` it will concat your Errs. If you do not use a `Semigroup`, then `alt` behaves in a manner that works like `Either.alt`, in which it return the first `Ok`, but the last `Err`. Like so:

```js
const withSemi =
  Err([ 3 ])
    .alt(Err([ 13 ]))
    .alt(Err([ 42 ]))

const noSemi =
  Err(3)
    .alt(Err(13))
    .alt(Err(42))

withSemi
// > Err [ 3, 13, 42 ]

withSemi
  .alt(Ok('yep'))
// > Ok 'yep'

noSemi
// > Err 42

noSemi
  .alt(Ok('yep'))
// > Ok 'yep'
```