### PR TITLE
Return `Pair` for `Writer`'s `read` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,7 +774,7 @@ These functions provide a very clean way to build out very simple functions and 
 | `merge` | `(a -> b -> c) -> m a b -> c` | `crocks/Pair` |
 | `option` | `a -> m a -> a` | `crocks/pointfree` |
 | `promap` | `(c -> a) -> (b -> d) -> m a b -> m c d` | `crocks/pointfree` |
-| `read` | `m a b -> a` | `crocks/Writer` |
+| `read` | `m a b -> Pair a b` | `crocks/Writer` |
 | `reduce` | `(b -> a -> b) -> b -> m a -> b` | `crocks/pointfree` |
 | `reject` | <code>((a -> Boolean) &#124; Pred a) -> m a -> m a</code> | `crocks/pointfree` |
 | `run` | `m a -> b` | `crocks/pointfree` |

--- a/src/Pair/writerToPair.js
+++ b/src/Pair/writerToPair.js
@@ -1,7 +1,6 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const Pair = require('../core/Pair')
 const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
 
@@ -9,7 +8,7 @@ const isWriter =
   x => !!x && isFunction(x.read)
 
 const applyTransform = w =>
-  Pair(w.log(), w.value())
+  w.read()
 
 // writerToPair : Monoid m => Writer m a -> Pair m a
 // writerToPair : Monoid m => (a -> Writer m a) -> Pair m b

--- a/src/Writer/Writer.spec.js
+++ b/src/Writer/Writer.spec.js
@@ -5,10 +5,12 @@ const Last = require('../test/LastMonoid')
 
 const bindFunc = helpers.bindFunc
 
+const Pair = require('../core/Pair')
 const curry = require('../core/curry')
 const compose = curry(require('../core/compose'))
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isSameType = require('../core/isSameType')
 const unit = require('../core/_unit')
 
 const identity = x => x
@@ -90,10 +92,10 @@ test('Writer read', t => {
   const m = Writer(l, x)
 
   t.ok(isFunction(m.read), 'is a function')
-  t.ok(isObject(m.read()), 'returns an object')
+  t.ok(isSameType(Pair, m.read()), 'returns a Pair')
 
-  t.equal(m.read().value, x, 'returns the wrapped value on the value key')
-  t.same(m.read().log, l, 'returns unwrapped log value')
+  t.equal(m.read().snd(), x, 'returns the value on the value snd')
+  t.same(m.read().fst().value(), l, 'returns log Monoid')
 
   t.end()
 })

--- a/src/Writer/index.js
+++ b/src/Writer/index.js
@@ -4,6 +4,7 @@
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const __type = require('../core/types').type('Writer')
+const Pair = require('../core/Pair')
 
 const isFunction = require('../core/isFunction')
 const isMonoid = require('../core/isMonoid')
@@ -45,10 +46,8 @@ function _Writer(Monoid) {
     const inspect =
       constant(`Writer(${_inspect(log())}${_inspect(value())} )`)
 
-    const read = constant({
-      log: log().value(),
-      value: value()
-    })
+    const read = () =>
+      Pair(log(), val)
 
     function map(fn) {
       if(!isFunction(fn)) {


### PR DESCRIPTION
## A bit more flexible
![image](https://user-images.githubusercontent.com/3665793/32422010-4df5f406-c252-11e7-8cd9-730b09b3292d.png)

I really hate the lack of usability with the `Writer`'s `read` function. I also not like how it removed the Monoid from the `log` value. This PR now returns a `Pair` for `w.read()` with the Monoid wrapped `log` in the `fst` and the `value` in the `snd`.

With this change we now get the power of a `Pair` when we are done with the writing. Also it makes more sense as `Pair` is the canonical Product type.

This is a BREAKING change, will not depreciate, just changing straight away.