### PR TITLE
add constructor to instances to comply

### DIFF
--- a/src/All/All.spec.js
+++ b/src/All/All.spec.js
@@ -15,7 +15,9 @@ test('All', t => {
   const m = bindFunc(All)
 
   t.ok(isFunction(All), 'is a function')
-  t.ok(isObject(All(0)), 'returns an object')
+  t.ok(isObject(All(false)), 'returns an object')
+
+  t.equals(All(true).constructor, All, 'provides TypeRep on constructor')
 
   t.ok(isFunction(All.empty), 'provides an empty function')
   t.ok(isFunction(All.type), 'provides a type function')

--- a/src/All/index.js
+++ b/src/All/index.js
@@ -36,7 +36,11 @@ function All(b) {
     return All(m.valueOf() && valueOf())
   }
 
-  return { inspect, valueOf, type, concat, empty }
+  return {
+    inspect, valueOf,
+    type, concat, empty,
+    constructor: All
+  }
 }
 
 All['@@implements'] = _implements(

--- a/src/Any/Any.spec.js
+++ b/src/Any/Any.spec.js
@@ -15,7 +15,9 @@ test('Any', t => {
   const a = bindFunc(Any)
 
   t.ok(isFunction(Any), 'is a function')
-  t.ok(isObject(Any(0)), 'returns an object')
+  t.ok(isObject(Any(false)), 'returns an object')
+
+  t.equals(Any(true).constructor, Any, 'provides TypeRep on constructor')
 
   t.ok(isFunction(Any.empty), 'provides an empty function')
   t.ok(isFunction(Any.type), 'provides a type function')

--- a/src/Any/index.js
+++ b/src/Any/index.js
@@ -36,7 +36,11 @@ function Any(b) {
     return Any(m.valueOf() || valueOf())
   }
 
-  return { inspect, valueOf, type, concat, empty }
+  return {
+    inspect, valueOf, type,
+    concat, empty,
+    constructor: Any
+  }
 }
 
 Any['@@implements'] = _implements(

--- a/src/Arrow/Arrow.spec.js
+++ b/src/Arrow/Arrow.spec.js
@@ -28,6 +28,8 @@ test('Arrow', t => {
 
   t.ok(isObject(Arrow(unit)), 'returns an object')
 
+  t.equals(Arrow(unit).constructor, Arrow, 'provides TypeRep on constructor')
+
   const err = /Arrow: Function required/
   t.throws(Arrow, err, 'throws with nothing')
   t.throws(a(undefined), err, 'throws with undefined')

--- a/src/Arrow/index.js
+++ b/src/Arrow/index.js
@@ -87,7 +87,8 @@ function Arrow(runWith) {
   return {
     inspect, type, runWith,
     id, compose, map, contramap,
-    promap, first, second, both
+    promap, first, second, both,
+    constructor: Arrow
   }
 }
 

--- a/src/Assign/Assign.spec.js
+++ b/src/Assign/Assign.spec.js
@@ -17,6 +17,8 @@ test('Assign', t => {
   t.ok(isFunction(Assign), 'is a function')
   t.ok(isObject(Assign({})), 'returns an object')
 
+  t.equals(Assign({}).constructor, Assign, 'provides TypeRep on constructor')
+
   t.ok(isFunction(Assign.empty), 'provides an empty function')
   t.ok(isFunction(Assign.type), 'provides a type function')
 

--- a/src/Assign/index.js
+++ b/src/Assign/index.js
@@ -37,7 +37,11 @@ function Assign(o) {
     return Assign(_object.assign(m.valueOf(), x))
   }
 
-  return { inspect, valueOf, type, concat, empty }
+  return {
+    inspect, valueOf,
+    type, concat, empty,
+    constructor: Assign
+  }
 }
 
 Assign['@@implements'] = _implements(

--- a/src/Async/Async.spec.js
+++ b/src/Async/Async.spec.js
@@ -29,6 +29,9 @@ test('Async', t => {
   t.ok(isFunction(Async.of), 'provides an of function')
   t.ok(isFunction(Async.type), 'provides a type function')
 
+  t.equals(Async.Resolved(3).constructor, Async, 'provides TypeRep on constructor on Resolved')
+  t.equals(Async.Rejected(3).constructor, Async, 'provides TypeRep on constructor on Rejected')
+
   t.ok(isFunction(Async.Resolved), 'provides a Resolved function')
   t.ok(isFunction(Async.Rejected), 'provides a Rejected function')
 

--- a/src/Async/index.js
+++ b/src/Async/index.js
@@ -238,7 +238,8 @@ function Async(fn, parentCancel) {
   return {
     fork, toPromise, inspect, type,
     swap, coalesce, map, bimap, alt,
-    ap, chain, of
+    ap, chain, of,
+    constructor: Async
   }
 }
 

--- a/src/Const/Const.spec.js
+++ b/src/Const/Const.spec.js
@@ -23,6 +23,8 @@ test('Const', t => {
 
   t.ok(isFunction(Const.type), 'provides a type function')
 
+  t.equals(Const(true).constructor, Const, 'provides TypeRep on constructor')
+
   t.throws(Const, TypeError, 'throws with no parameters')
 
   t.end()

--- a/src/Const/index.js
+++ b/src/Const/index.js
@@ -58,9 +58,11 @@ function Const(x) {
 
   return {
     inspect, valueOf, type, equals,
-    concat, map, ap, chain
+    concat, map, ap, chain,
+    constructor: Const
   }
 }
+
 Const.type =
   type
 

--- a/src/Either/Either.spec.js
+++ b/src/Either/Either.spec.js
@@ -30,6 +30,9 @@ test('Either', t => {
   t.ok(isFunction(Either), 'is a function')
   t.ok(isObject(m), 'returns an object')
 
+  t.equals(Either.Right(0).constructor, Either, 'provides TypeRep on constructor for Right')
+  t.equals(Either.Left(0).constructor, Either, 'provides TypeRep on constructor for Left')
+
   t.ok(isFunction(Either.of), 'provides an of function')
   t.ok(isFunction(Either.type), 'provides a type function')
   t.ok(isFunction(Either.Left), 'provides a Left function')

--- a/src/Either/index.js
+++ b/src/Either/index.js
@@ -189,7 +189,8 @@ function Either(u) {
   return {
     inspect, either, type, concat,
     swap, coalesce, equals, map, bimap,
-    alt, ap, of, chain, sequence, traverse
+    alt, ap, of, chain, sequence, traverse,
+    constructor: Either
   }
 }
 

--- a/src/Endo/Endo.spec.js
+++ b/src/Endo/Endo.spec.js
@@ -20,6 +20,8 @@ test('Endo', t => {
   t.ok(isFunction(Endo), 'is a function')
   t.ok(isObject(Endo(identity)), 'returns an object')
 
+  t.equals(Endo(identity).constructor, Endo, 'provides TypeRep on constructor')
+
   t.ok(isFunction(Endo.empty), 'provides an empty function')
   t.ok(isFunction(Endo.type), 'provides a type function')
 

--- a/src/Endo/index.js
+++ b/src/Endo/index.js
@@ -34,7 +34,11 @@ function Endo(runWith) {
     return Endo(compose(m.valueOf(), valueOf()))
   }
 
-  return { inspect, valueOf, type, concat, empty, runWith }
+  return {
+    inspect, valueOf, type,
+    concat, empty, runWith,
+    constructor: Endo
+  }
 }
 
 Endo['@@implements'] = _implements(

--- a/src/Equiv/Equiv.spec.js
+++ b/src/Equiv/Equiv.spec.js
@@ -27,6 +27,8 @@ test('Equiv', t => {
 
   t.ok(isObject(Equiv(isSame)), 'returns an object')
 
+  t.equals(Equiv(isSame).constructor, Equiv, 'provides TypeRep on constructor')
+
   const err = /Equiv: Comparison function required/
   t.throws(Equiv, err, 'throws with nothing')
   t.throws(e(undefined), err, 'throws with undefined')

--- a/src/Equiv/index.js
+++ b/src/Equiv/index.js
@@ -53,7 +53,8 @@ function Equiv(compare) {
 
   return {
     inspect, type, compareWith, valueOf,
-    contramap, concat, empty
+    contramap, concat, empty,
+    constructor: Equiv
   }
 }
 

--- a/src/First/First.spec.js
+++ b/src/First/First.spec.js
@@ -19,6 +19,8 @@ test('First', t => {
   t.ok(isFunction(First), 'is a function')
   t.ok(isObject(First(0)), 'returns an object')
 
+  t.equals(First(0).constructor, First, 'provides TypeRep on constructor')
+
   t.ok(isFunction(First.empty), 'provides an empty function')
   t.ok(isFunction(First.type), 'provides a type function')
 

--- a/src/First/index.js
+++ b/src/First/index.js
@@ -47,7 +47,8 @@ function First(x) {
 
   return {
     concat, empty, inspect,
-    option, type, valueOf
+    option, type, valueOf,
+    constructor: First
   }
 }
 

--- a/src/IO/IO.spec.js
+++ b/src/IO/IO.spec.js
@@ -25,6 +25,8 @@ test('IO', t => {
   t.ok(isFunction(IO), 'is a function')
   t.ok(isObject(m), 'returns an object')
 
+  t.equals(IO(unit).constructor, IO, 'provides TypeRep on constructor')
+
   t.ok(isFunction(IO.of), 'provides an of function')
   t.ok(isFunction(IO.type), 'provides a type function')
 

--- a/src/IO/index.js
+++ b/src/IO/index.js
@@ -57,7 +57,8 @@ function IO(run) {
 
   return {
     inspect, run, type,
-    map, ap, of, chain
+    map, ap, of, chain,
+    constructor: IO
   }
 }
 

--- a/src/Identity/Identity.spec.js
+++ b/src/Identity/Identity.spec.js
@@ -26,6 +26,8 @@ test('Identity', t => {
   t.ok(isFunction(Identity), 'is a function')
   t.ok(isObject(m), 'returns an object')
 
+  t.equals(Identity(true).constructor, Identity, 'provides TypeRep on constructor')
+
   t.ok(isFunction(Identity.of), 'provides an of function')
   t.ok(isFunction(Identity.type), 'provides a type function')
 

--- a/src/Identity/index.js
+++ b/src/Identity/index.js
@@ -101,7 +101,8 @@ function Identity(x) {
   return {
     inspect, valueOf, type, equals,
     concat, map, ap, of, chain,
-    sequence, traverse
+    sequence, traverse,
+    constructor: Identity
   }
 }
 

--- a/src/Last/Last.spec.js
+++ b/src/Last/Last.spec.js
@@ -17,6 +17,8 @@ test('Last', t => {
   t.ok(isFunction(Last), 'is a function')
   t.ok(isObject(Last(0)), 'returns an object')
 
+  t.equals(Last(0).constructor, Last, 'provides TypeRep on constructor')
+
   t.ok(isFunction(Last.empty), 'provides an empty function')
   t.ok(isFunction(Last.type), 'provides a type function')
 

--- a/src/Last/index.js
+++ b/src/Last/index.js
@@ -49,7 +49,9 @@ function Last(x) {
   }
 
   return {
-    concat, empty, inspect, option, type, valueOf
+    concat, empty, inspect,
+    option, type, valueOf,
+    constructor: Last
   }
 }
 

--- a/src/Max/Max.spec.js
+++ b/src/Max/Max.spec.js
@@ -20,6 +20,8 @@ test('Max', t => {
   t.ok(isFunction(Max.type), 'provides a type function')
   t.ok(isObject(Max(0)), 'returns an object')
 
+  t.equals(Max(0).constructor, Max, 'provides TypeRep on constructor')
+
   t.throws(Max, TypeError, 'throws with nothing')
   t.throws(m(identity), TypeError, 'throws with a function')
   t.throws(m(''), TypeError, 'throws with falsey string')

--- a/src/Max/index.js
+++ b/src/Max/index.js
@@ -36,7 +36,11 @@ function Max(n) {
     return Max(Math.max(x, m.valueOf()))
   }
 
-  return { inspect, valueOf, type, concat, empty }
+  return {
+    inspect, valueOf, type,
+    concat, empty,
+    constructor: Max
+  }
 }
 
 Max['@@implements'] = _implements(

--- a/src/Min/Min.spec.js
+++ b/src/Min/Min.spec.js
@@ -20,6 +20,8 @@ test('Min', t => {
   t.ok(isFunction(Min.type), 'provides a type function')
   t.ok(isObject(Min(0)), 'returns an object')
 
+  t.equals(Min(0).constructor, Min, 'provides TypeRep on constructor')
+
   t.throws(Min, TypeError, 'throws with nothing')
   t.throws(m(identity), TypeError, 'throws with a function')
   t.throws(m(''), TypeError, 'throws with falsey string')

--- a/src/Min/index.js
+++ b/src/Min/index.js
@@ -36,7 +36,11 @@ function Min(n) {
     return Min(Math.min(x, m.valueOf()))
   }
 
-  return { inspect, valueOf, type, concat, empty }
+  return {
+    inspect, valueOf, type,
+    concat, empty,
+    constructor: Min
+  }
 }
 
 Min['@@implements'] = _implements(

--- a/src/Pred/Pred.spec.js
+++ b/src/Pred/Pred.spec.js
@@ -24,6 +24,8 @@ test('Pred', t => {
 
   t.ok(isObject(Pred(unit)), 'returns an object')
 
+  t.equals(Pred(unit).constructor, Pred, 'provides TypeRep on constructor')
+
   const err = /Pred: Predicate function required/
   t.throws(Pred, err, 'throws with nothing')
   t.throws(p(undefined), err, 'throws with undefined')

--- a/src/Pred/index.js
+++ b/src/Pred/index.js
@@ -46,9 +46,9 @@ function Pred(pred) {
   }
 
   return {
-    runWith, inspect, type,
-    valueOf, empty, concat,
-    contramap
+    runWith, inspect, type, valueOf,
+    empty, concat, contramap,
+    constructor: Pred
   }
 }
 

--- a/src/Prod/Prod.spec.js
+++ b/src/Prod/Prod.spec.js
@@ -17,6 +17,8 @@ test('Prod', t => {
   t.ok(isFunction(Prod), 'is a function')
   t.ok(isObject(Prod(0)), 'returns an object')
 
+  t.equals(Prod(0).constructor, Prod, 'provides TypeRep on constructor')
+
   t.ok(isFunction(Prod.empty), 'provides an empty function')
   t.ok(isFunction(Prod.type), 'provides a type function')
 

--- a/src/Prod/index.js
+++ b/src/Prod/index.js
@@ -36,7 +36,11 @@ function Prod(n) {
     return Prod(x * m.valueOf())
   }
 
-  return { inspect, valueOf, type, concat, empty }
+  return {
+    inspect, valueOf, type,
+    concat, empty,
+    constructor: Prod
+  }
 }
 
 Prod['@@implements'] = _implements(

--- a/src/Reader/Reader.spec.js
+++ b/src/Reader/Reader.spec.js
@@ -26,6 +26,8 @@ test('Reader', t => {
   t.ok(isFunction(Reader), 'is a function')
   t.ok(isObject(m), 'returns an object')
 
+  t.equals(Reader(unit).constructor, Reader, 'provides TypeRep on constructor')
+
   t.ok(isFunction(Reader.of), 'provides an of function')
   t.ok(isFunction(Reader.type), 'provides a type function')
   t.ok(isFunction(Reader.ask), 'provides an ask function')

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -76,8 +76,9 @@ function Reader(runWith) {
   }
 
   return {
-    inspect, runWith, type,
-    map, ap, chain, of
+    inspect, runWith, type, map,
+    ap, chain, of,
+    constructor: Reader
   }
 }
 

--- a/src/Result/Result.spec.js
+++ b/src/Result/Result.spec.js
@@ -30,6 +30,9 @@ test('Result', t => {
   t.ok(isFunction(Result), 'is a function')
   t.ok(isObject(m), 'returns an object')
 
+  t.equals(Result.Ok(true).constructor, Result, 'provides TypeRep on constructor for Ok')
+  t.equals(Result.Err(true).constructor, Result, 'provides TypeRep on constructor for Err')
+
   t.ok(isFunction(Result.of), 'provides an of function')
   t.ok(isFunction(Result.type), 'provides a type function')
   t.ok(isFunction(Result.Err), 'provides an Err function')

--- a/src/Result/index.js
+++ b/src/Result/index.js
@@ -203,7 +203,8 @@ function Result(u) {
   return {
     inspect, equals, type, either, concat,
     swap, coalesce, map, bimap, alt, ap,
-    chain, of, sequence, traverse
+    chain, of, sequence, traverse,
+    constructor: Result
   }
 }
 

--- a/src/Star/Star.spec.js
+++ b/src/Star/Star.spec.js
@@ -27,6 +27,8 @@ test('Star', t => {
 
   t.ok(isFunction(Star.type), 'provides a type function')
 
+  t.equals(Star(unit).constructor, Star, 'provides TypeRep on constructor')
+
   t.ok(isObject(Star(unit)), 'returns an object')
 
   const err = /Star: Monad required for construction/

--- a/src/Star/index.js
+++ b/src/Star/index.js
@@ -162,7 +162,8 @@ function _Star(Monad) {
     return {
       inspect, type, runWith,
       id, compose, map, contramap,
-      promap, first, second, both
+      promap, first, second, both,
+      constructor: Star
     }
   }
 

--- a/src/State/State.spec.js
+++ b/src/State/State.spec.js
@@ -23,6 +23,8 @@ test('State', t => {
   t.ok(isFunction(State), 'is a function')
   t.ok(isObject(m), 'returns an object')
 
+  t.equals(State(unit).constructor, State, 'provides TypeRep on constructor')
+
   t.ok(isFunction(State.of), 'provides an of function')
   t.ok(isFunction(State.type), 'provides a type function')
   t.ok(isFunction(State.get), 'provides a get function')

--- a/src/State/index.js
+++ b/src/State/index.js
@@ -112,9 +112,9 @@ function State(fn) {
   }
 
   return {
-    runWith, execWith, evalWith,
-    inspect, type, map, ap, chain,
-    of
+    runWith, execWith, evalWith, inspect,
+    type, map, ap, chain, of,
+    constructor: State
   }
 }
 

--- a/src/Sum/Sum.spec.js
+++ b/src/Sum/Sum.spec.js
@@ -17,6 +17,8 @@ test('Sum', t => {
   t.ok(isFunction(Sum), 'is a function')
   t.ok(isObject(Sum(0)), 'returns an object')
 
+  t.equals(Sum(0).constructor, Sum, 'provides TypeRep on constructor')
+
   t.ok(isFunction(Sum.empty), 'provides an empty function')
   t.ok(isFunction(Sum.type), 'provides a type function')
 

--- a/src/Sum/index.js
+++ b/src/Sum/index.js
@@ -36,7 +36,11 @@ function Sum(n) {
     return Sum(x + m.valueOf())
   }
 
-  return { inspect, valueOf, type, concat, empty }
+  return {
+    inspect, valueOf, type,
+    concat, empty,
+    constructor: Sum
+  }
 }
 
 Sum['@@implements'] = _implements(

--- a/src/Writer/Writer.spec.js
+++ b/src/Writer/Writer.spec.js
@@ -47,6 +47,8 @@ test('Writer', t => {
   t.ok(isFunction(Writer), 'is a function')
   t.ok(isObject(w), 'returns an object')
 
+  t.equals(Writer(0, 0).constructor, Writer, 'provides TypeRep on constructor')
+
   t.ok(isFunction(Writer.of), 'provides an of function')
   t.ok(isFunction(Writer.type), 'provides a type function')
 

--- a/src/Writer/index.js
+++ b/src/Writer/index.js
@@ -87,7 +87,8 @@ function _Writer(Monoid) {
     return {
       inspect, read, valueOf,
       log, type, equals, map,
-      ap, of, chain
+      ap, of, chain,
+      constructor: Writer
     }
   }
 
@@ -103,6 +104,5 @@ function _Writer(Monoid) {
 
   return Writer
 }
-
 
 module.exports = _Writer

--- a/src/core/List.js
+++ b/src/core/List.js
@@ -226,7 +226,8 @@ function List(x) {
     inspect, valueOf, toArray, head, tail, cons,
     type, equals, concat, empty, reduce, fold,
     filter, reject, map, ap, of, chain,
-    sequence, traverse
+    sequence, traverse,
+    constructor: List
   }
 }
 

--- a/src/core/List.spec.js
+++ b/src/core/List.spec.js
@@ -28,6 +28,8 @@ test('List', t => {
   t.ok(isFunction(List), 'is a function')
   t.ok(isObject(List([])), 'returns an object')
 
+  t.equals(List([]).constructor, List, 'provides TypeRep on constructor')
+
   t.ok(isFunction(List.of), 'provides an of function')
   t.ok(isFunction(List.fromArray), 'provides a fromArray function')
   t.ok(isFunction(List.type), 'provides a type function')

--- a/src/core/Maybe.js
+++ b/src/core/Maybe.js
@@ -187,8 +187,8 @@ function Maybe(u) {
   return {
     inspect, either, option, type,
     concat, equals, coalesce, map, alt,
-    zero, ap, of, chain, sequence,
-    traverse
+    zero, ap, of, chain, sequence, traverse,
+    constructor: Maybe
   }
 }
 

--- a/src/core/Maybe.spec.js
+++ b/src/core/Maybe.spec.js
@@ -30,6 +30,9 @@ test('Maybe', t => {
   t.ok(isFunction(Maybe), 'is a function')
   t.ok(isObject(m), 'returns an object')
 
+  t.equals(Maybe.Just(2).constructor, Maybe, 'provides TypeRep on constructor for Just')
+  t.equals(Maybe.Nothing().constructor, Maybe, 'provides TypeRep on constructor for Nothing')
+
   t.ok(isFunction(Maybe.of), 'provides an of function')
   t.ok(isFunction(Maybe.type), 'provides a type function')
   t.ok(isFunction(Maybe.zero), 'provides a zero function')

--- a/src/core/Pair.js
+++ b/src/core/Pair.js
@@ -148,10 +148,10 @@ function Pair(l, r) {
   }
 
   return {
-    inspect, fst, snd, toArray,
-    type, merge, equals, concat,
-    swap, map, bimap, ap, chain,
-    extend
+    inspect, fst, snd, toArray, type,
+    merge, equals, concat, swap, map,
+    bimap, ap, chain, extend,
+    constructor: Pair
   }
 }
 

--- a/src/core/Pair.spec.js
+++ b/src/core/Pair.spec.js
@@ -24,6 +24,8 @@ test('Pair core', t => {
   t.ok(isFunction(Pair), 'is a function')
   t.ok(isObject(x), 'returns an object')
 
+  t.equals(Pair(0, 0).constructor, Pair, 'provides TypeRep on constructor')
+
   t.ok(isFunction(Pair.type), 'provides a type function')
 
   const err = /Pair: Must provide a first and second value/

--- a/src/core/Unit.js
+++ b/src/core/Unit.js
@@ -63,7 +63,8 @@ function Unit() {
 
   return {
     inspect, valueOf, type, equals,
-    concat, empty, map, ap, of, chain
+    concat, empty, map, ap, of, chain,
+    constructor: Unit
   }
 }
 

--- a/src/core/Unit.spec.js
+++ b/src/core/Unit.spec.js
@@ -25,6 +25,8 @@ test('Unit', t => {
   t.ok(isFunction(Unit), 'is a function')
   t.ok(isObject(m), 'returns an object')
 
+  t.equals(Unit(false).constructor, Unit, 'provides TypeRep on constructor')
+
   t.ok(isFunction(Unit.type), 'provides a type function')
   t.ok(isFunction(Unit.empty), 'provides an empty function')
 


### PR DESCRIPTION
## Kompliance is Key
![image](https://user-images.githubusercontent.com/3665793/34318478-7ed438b2-e77d-11e7-81e7-f0756bec8e26.png)

This is the first non-breaking step in [this issue](https://github.com/evilsoft/crocks/issues/162) bringing us started on the path to fantasy-land compliance. As these are very large, sweeping changes, each step will be implemented in its own PR.

This adds a reference to the `TypeRep` on the `constructor` property of the ADT instances.