### PR TITLE
Index and Cross Reference Function Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ mapProps(mapping, {
 #### mapReduce
 `crocks/helpers/mapReduce`
 ```haskell
-mapReduce :: Foldable f => (a -> b) -> (c -> b -> c) -> c -> f a
+mapReduce :: Foldable f => (a -> b) -> (c -> b -> c) -> f a -> c
 ```
 Sometimes you need the power provided by [`mreduceMap`](#mreducemap) but you do
 not have a `Monoid` to lift into. `mapReduce` provides the same power, but with

--- a/docs/src/pages/docs/functions/combinators.md
+++ b/docs/src/pages/docs/functions/combinators.md
@@ -12,6 +12,7 @@ weight: 1
 ```haskell
 applyTo :: (a -> b) -> a -> b
 ```
+
 Seems really silly, but is quite useful for a lot of things. It takes a function
 and a value and then returns the result of that function with the argument
 applied.
@@ -23,6 +24,7 @@ applied.
 ```haskell
 composeB :: (b -> c) -> (a -> b) -> a -> c
 ```
+
 Provides a means to describe a composition between two functions. it takes two
 functions and a value. Given `composeB(f, g)`, which is read `f` after `g`, it
 will return a function that will take value `a` and apply it to `g`, passing the
@@ -36,8 +38,9 @@ allows only two functions, if you want to avoid things like:
 `crocks/combinators/constant`
 
 ```haskell
-constant :: a -> _ -> a
+constant :: a -> () -> a
 ```
+
 This is a very handy dandy function, used a lot. Pass it any value and it will
 give you back a function that will return that same value no matter what you
 pass it.
@@ -49,6 +52,7 @@ pass it.
 ```haskell
 flip :: (a -> b -> c) -> b -> a -> c
 ```
+
 This little function just takes a function and returns a function that takes
 the first two parameters in reverse. One can compose flip calls down the line to
 flip all, or some of the other parameters if there are more than two. Mix and
@@ -61,6 +65,7 @@ match to your heart's desire.
 ```haskell
 identity ::  a -> a
 ```
+
 This function and [`constant`](#constant) are the workhorses of writing code
 with this library. It quite simply is just a function that when you pass it
 something, it returns that thing right back to you. So simple, I will leave it
@@ -73,6 +78,7 @@ as an exercise to reason about why this is so powerful and important.
 ```haskell
 reverseApply :: a -> (a -> b) -> b
 ```
+
 Ever run into a situation where you have a value but do not have a function to
 apply it to? Well this little bird, named Thrush, is there to help out. Just
 give it a value and it will give you back a function ready to take a function.
@@ -86,6 +92,7 @@ to that function.
 ```haskell
 substitution :: (a -> b -> c) -> (a -> b) -> a -> c
 ```
+
 While it a complicated little bugger, it can come in very handy from time to
 time. In it's first two arguments it takes functions. The first must be binary
 and the second unary. That will return you a function that is ready to take some

--- a/docs/src/pages/docs/functions/helpers.md
+++ b/docs/src/pages/docs/functions/helpers.md
@@ -78,7 +78,7 @@ values into a single value.
 `crocks/helpers/compose`
 
 ```haskell
-compose :: ((y -> z), (x -> y), ..., (a -> b)) -> a -> z
+compose :: ((y -> z), ..., (a -> b)) -> a -> z
 ```
 While the [`composeB`](combinators.html#composeb) can be used to create a
 composition of two functions, there are times when you want to compose an entire
@@ -92,7 +92,7 @@ then, I would recommend reaching for [`pipe`](#pipe).
 `crocks/helpers/composeK`
 
 ```haskell
-composeK :: Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> a -> m z
+composeK :: Chain m => ((y -> m z), ..., (a -> m b)) -> a -> m z
 ```
 There are many times that, when working with the various `crocks`, our flows are
 just a series of `chain`s. Due to some neat properties with types that provide a
@@ -150,6 +150,7 @@ const flow = composeK(
 flow(data)
 // => Just 'fa'
 ```
+
 As demonstrated in the above example, this function more closely resembles flows
 that are using a more pointfree style of coding. As with the other composition
 functions in `crocks`, a [`pipeK`](#pipek) function is provided for flows that
@@ -160,7 +161,7 @@ make more sense expressed in a left-to-right style.
 `crocks/helpers/composeP`
 
 ```haskell
-composeP :: Promise p => ((y -> p z c), (x -> p y c), ..., (a -> p b c)) -> a -> p z c
+composeP :: Promise p => ((y -> p z c), ..., (a -> p b c)) -> a -> p z c
 ```
 
 When working with `Promise`s, it is common place to create chains on a
@@ -184,6 +185,7 @@ const { composeP } = crocks
 const promFunc =
   composeP(doAnother, doSomething, promiseSomething)
 ```
+
 Due to the nature of the `then` function, only the head of your composition
 needs to return a `Promise`. This will create a function that takes a value,
 which is passed through your chain, returning a `Promise` which can be extended.
@@ -196,8 +198,9 @@ If you would like to provide your functions in a left-to-right manner, check out
 `crocks/helpers/composeS`
 
 ```haskell
-composeS :: Semigroupoid s => (s y z, s x y, ..., s a b) -> s a z
+composeS :: Semigroupoid s => (s y z, ..., s a b) -> s a z
 ```
+
 When working with things like `Arrow` and `Star` there will come a point when
 you would like to compose them like you would any `Function`. That is where
 `composeS` comes in handy. Just pass it the `Semigroupoid`s you want to compose
@@ -240,6 +243,7 @@ composeS(double, avg)
 ```haskell
 curry :: ((a, b, ...) -> z) -> a -> b -> ... -> z
 ```
+
 Pass this function a function and it will return you a function that can be
 called in any form that you require until all arguments have been provided. For
 example if you pass a function: `f : (a, b, c) -> d` you get back a function
@@ -254,6 +258,7 @@ on functions for maximum re-usability.
 ```haskell
 defaultProps :: Object -> Object -> Object
 ```
+
 Picture this, you have an `Object` and you want to make sure that some
 properties are set with a given default value. When the need for this type of
 operation presents itself, `defaultProps` can come to your aid. Just pass it an
@@ -274,6 +279,7 @@ in either `Object`.
 ```haskell
 defaultTo :: a -> b -> a
 ```
+
 With things like `null`, `undefined` and `NaN` showing up all over the place, it
 can be hard to keep your expected types inline without resorting to nesting in a
 `Maybe` with functions like [`safe`](#safe). If you want to specifically guard
@@ -292,6 +298,7 @@ As a `b` can be an `a` as well.
 ```haskell
 dissoc :: String -> Object -> Object
 ```
+
 While [`assoc`](#assoc) can be used to associate a given key-value pair to a
 given `Object`, `dissoc` does the opposite. Just pass `dissoc` a `String` key
 and the `Object` you wish to dissociate that key from and you will get back a
@@ -307,6 +314,7 @@ fanout :: (a -> b) -> (a -> c) -> (a -> Pair b c)
 fanout :: Arrow a b -> Arrow a c -> Arrow a (Pair b c)
 fanout :: Monad m => Star a (m b) -> Star a (m c) -> Star a (m (Pair b c))
 ```
+
 There are may times that you need to keep some running or persistent state while
 performing a given computation. A common way to do this is to take the input to
 the computation and branch it into a `Pair` and perform different operations on
@@ -322,8 +330,9 @@ to the first portion of the underlying `Pair` and the second on the second.
 `crocks/helpers/fromPairs`
 
 ```haskell
-fromPairs :: [ (Pair String a) ] | List (Pair String a) -> Object
+fromPairs :: Foldable f => f (Pair String a) -> Object
 ```
+
 As an inverse to [`toPairs`](#topairs), `fromPairs` takes either an `Array` or
 `List` of key-value `Pair`s and constructs an `Object` from it. The `Pair` must
 contain a `String` in the `fst` and any type of value in the `snd`. The `fst`
@@ -348,6 +357,7 @@ liftA2 :: Applicative m => (a -> b -> c) -> m a -> m b -> m c
 ```haskell
 liftA3 :: Applicative m => (a -> b -> c -> d) -> m a -> m b -> m c -> m d
 ```
+
 Ever see yourself wanting to `map` a binary or trinary function, but `map` only
 allows unary functions? Both of these functions allow you to pass in your
 function as well as the number of `Applicatives` (containers that provide both
@@ -360,6 +370,7 @@ function as well as the number of `Applicatives` (containers that provide both
 ```haskell
 mapProps :: { (* -> *) } -> Object -> Object
 ```
+
 Would like to map specific keys in an Object with a specific function? Just
 bring in `mapProps` and pass it an `Object` with the functions you want to apply
 on the keys you want them associated to. When the resulting function receives an
@@ -412,8 +423,9 @@ mapProps(mapping, {
 `crocks/helpers/mapReduce`
 
 ```haskell
-mapReduce :: Foldable f => (a -> b) -> (c -> b -> c) -> c -> f a
+mapReduce :: Foldable f => (a -> b) -> (c -> b -> c) -> f a -> c
 ```
+
 Sometimes you need the power provided by [`mreduceMap`](#mreducemap) but you do
 not have a `Monoid` to lift into. `mapReduce` provides the same power, but with
 the flexibility of using functions to lift and combine. `mapReduce` takes a
@@ -449,7 +461,7 @@ safeMax(data)
 `crocks/helpers/mconcat`
 
 ```haskell
-mconcat :: Monoid m => m -> ([ a ] | List a) -> m a
+mconcat :: Monoid m, Foldable f => m -> f a -> m a
 ```
 
 #### mreduce
@@ -457,8 +469,9 @@ mconcat :: Monoid m => m -> ([ a ] | List a) -> m a
 `crocks/helpers/mreduce`
 
 ```haskell
-mreduce :: Monoid m => m -> ([ a ] | List a) -> a
+mreduce :: Monoid m, Foldable f => m -> f a -> a
 ```
+
 These two functions are very handy for combining an entire `List` or `Array` of
 values by providing a [`Monoid`](../monoids/index.html) and your collection of
 values. The difference between the two is that `mconcat` returns the result
@@ -470,7 +483,7 @@ inside the [`Monoid`](../monoids/index.html) used to combine them. Where
 `crocks/helpers/mconcatMap`
 
 ```haskell
-mconcatMap :: Monoid m => m -> (b -> a) -> ([ b ] | List b) -> m a
+mconcatMap :: Monoid m, Foldable f => m -> (b -> a) -> f b -> m a
 ```
 
 #### mreduceMap
@@ -478,8 +491,9 @@ mconcatMap :: Monoid m => m -> (b -> a) -> ([ b ] | List b) -> m a
 `crocks/helpers/mreduceMap`
 
 ```haskell
-mreduceMap :: Monoid m => m -> (b -> a) -> ([ b ] | List b) -> a
+mreduceMap :: Monoid m, Foldable f => m -> (b -> a) -> f b -> a
 ```
+
 There comes a time where the values you have in a `List` or an `Array` are not
 in the type that is needed for the [`Monoid`](../monoids/index.html) you want to
 combine with. These two functions can be used to `map` some transforming
@@ -496,8 +510,9 @@ returns the bare value itself.
 `crocks/helpers/nAry`
 
 ```haskell
-nAry :: Number -> (* -> a) -> * -> * -> a
+nAry :: Number -> (* -> a) -> * -> a
 ```
+
 When using functions like `Math.max` or `Object.assign` that take as many
 arguments as you can throw at them, it makes it hard to `curry` them in a
 reasonable manner. `nAry` can make things a little nicer for functions like
@@ -517,6 +532,7 @@ arguments to the inner function. Unary and binary functions are so common that
 ```haskell
 objOf :: String -> a -> Object
 ```
+
 If you ever find yourself in a situation where you have a key and a value and
 just want to combine the two into an `Object`, then it sounds like `objOf` is
 the function for you. Just pass it a `String` for the key and any type of value,
@@ -529,8 +545,9 @@ yourself constantly concatenating the result of this function into another
 `crocks/helpers/omit`
 
 ```haskell
-omit :: ([ String ] | List String) -> Object -> Object
+omit :: Foldable f => f String -> Object -> Object
 ```
+
 Sometimes you just want to strip `Object`s of unwanted properties by key. Using
 `omit` will help you get that done. Just pass it a `Foldable` structure with a
 series of `String`s as keys and then pass it an `Object` and you will get back
@@ -547,6 +564,7 @@ white-list properties rather than reject them, take a look at [`pick`](#pick).
 ```haskell
 once :: ((*) -> a) -> ((*) -> a)
 ```
+
 There are times in Javascript development where you only want to call a function
 once and memo-ize the first result for every subsequent call to that function.
 Just pass the function you want guarded to `once` and you will get back a
@@ -559,6 +577,7 @@ function with the expected guarantees.
 ```haskell
 partial :: ((* -> c), *) -> * -> c
 ```
+
 There are many times when using functions from non-functional libraries or from
 built-in JS functions, where it does not make sense to wrap it in a
 [`curry`](#curry). You just want to partially apply some arguments to it and get
@@ -585,8 +604,9 @@ map(max10, data)
 `crocks/helpers/pick`
 
 ```haskell
-pick :: ([ String ] | List String) -> Object -> Object
+pick :: Foldable f => f String -> Object -> Object
 ```
+
 When dealing with `Object`s, sometimes it is necessary to only let some of the
 key-value pairs on an object through. Think of `pick` as a sort of white-list or
 filter for `Object` properties. Pass it a `Foldable` structure of `String`s that
@@ -601,8 +621,9 @@ black-listing properties, have a look at [`omit`](#omit).
 `crocks/helpers/pipe`
 
 ```haskell
-pipe :: ((a -> b), (b -> c), ..., (y -> z)) -> a -> z
+pipe :: ((a -> b), ..., (y -> z)) -> a -> z
 ```
+
 If you find yourself not able to come to terms with doing the typical
 right-to-left composition, then `crocks` provides a means to accommodate you.
 This function does the same thing as [`compose`](#compose), the only difference
@@ -613,8 +634,9 @@ is it allows you define your flows in a left-to-right manner.
 `crocks/helpers/pipeK`
 
 ```haskell
-pipeK :: Chain m => ((a -> m b), (b -> m c), ..., (y -> m z)) -> a -> m z
+pipeK :: Chain m => ((a -> m b), ..., (y -> m z)) -> a -> m z
 ```
+
 Like [`composeK`](#composek), you can remove much of the boilerplate when
 chaining together a series of functions with the signature:
 `Chain m => a -> m b`. The difference between the two functions is, while
@@ -657,8 +679,9 @@ chainPipe(0).log()
 `crocks/helpers/pipeP`
 
 ```haskell
-pipeP :: Promise p => ((a -> p b d), (b -> p c d), ..., (y -> p z d)) -> a -> p z d
+pipeP :: Promise p => ((a -> p b d), ..., (y -> p z d)) -> a -> p z d
 ```
+
 Like the [`composeP`](#composep) function, `pipeP` will let you remove the
 standard boilerplate that comes with working with `Promise` chains. The only
 difference between `pipeP` and [`composeP`](#composep) is that it takes its
@@ -681,8 +704,9 @@ const promPipe =
 `crocks/helpers/pipeS`
 
 ```haskell
-pipeS :: Semigroupoid s => (s a b, s b c, ..., s y z) -> s a z
+pipeS :: Semigroupoid s => (s a b, ..., s y z) -> s a z
 ```
+
 While `Star`s and `Arrow`s come in very handy at times, the only thing that
 could make them better is to compose them . With `pipeS` you can do just that
 with any `Semigroupoid`. Just like with [`composeS`](#composes), you just pass
@@ -730,6 +754,7 @@ flow('string', 100).runWith(data)
 ```haskell
 prop :: (String | Integer) -> a -> Maybe b
 ```
+
 If you want some safety around pulling a value out of an Object or Array with a
 single key or index, you can always reach for `prop`. Well, as long as you are
 working with non-nested data that is. Just tell `prop` either the key or index
@@ -772,8 +797,9 @@ get()
 `crocks/Maybe/propPath`
 
 ```haskell
-propPath :: [ String | Integer ] -> a -> Maybe b
+propPath :: Foldable f => f (String | Integer) -> a -> Maybe b
 ```
+
 While [`prop`](#prop) is good for simple, single-level structures, there may
 come a time when you have to work with nested POJOs or Arrays. When you run into
 this situation, just pull in `propPath` and pass it a left-to-right traversal
@@ -788,8 +814,9 @@ But if at any point that path "breaks" it will give you back a `Nothing`.
 `crocks/helpers/propPathOr`
 
 ```haskell
-propPathOr :: a -> [ String | Integer ] -> b -> c
+propPathOr :: Foldable f => a -> f (String | Integer) -> b -> c
 ```
+
 While [`propOr`](#propor) is good for simple, single-level structures, there may
 come a time when you have to work with nested POJOs or Arrays. When you run into
 this situation, just pull in `propPathOr` and pass it a left-to-right traversal
@@ -821,6 +848,7 @@ get()
 ```haskell
 safe :: ((a -> Boolean) | Pred) -> a -> Maybe a
 ```
+
 When using a `Maybe`, it is a common practice to lift into a `Just` or a
 `Nothing` depending on a condition on the value to be lifted.  It is so common
 that it warrants a function, and that function is called `safe`. Provide a
@@ -835,6 +863,7 @@ true and a `Nothing` if false.
 ```haskell
 safeLift :: ((a -> Boolean) | Pred) -> (a -> b) -> a -> Maybe b
 ```
+
 While [`safe`](#safe) is used to lift a value into a `Maybe`, you can reach for
 `safeLift` when you want to run a function in the safety of the `Maybe` context.
 Just like [`safe`](#safe), you pass it either a `Pred` or a predicate function
@@ -850,6 +879,7 @@ function over the result.
 ```haskell
 tap :: (a -> b) -> a -> a
 ```
+
 It is hard knowing what is going on inside of some of these ADTs or your
 wonderful function compositions. Debugging can get messy when you need to insert
 a side-effect into your flow for introspection purposes. With `tap`, you can
@@ -865,6 +895,7 @@ exercise some discipline here to not mutate.
 ```haskell
 toPairs :: Object -> List (Pair String a)
 ```
+
 When dealing with `Object`s, sometimes it makes more sense to work in a
 `Foldable` structure like a `List` of key-value `Pair`s. `toPairs` provides a
 means to take an object and give you back a `List` of `Pairs` that have a
@@ -881,6 +912,7 @@ to this function named [`fromPairs`](#frompairs).
 ```haskell
 tryCatch :: (a -> b) -> a -> Result e b
 ```
+
 Typical try-catch blocks are very imperative in their usage. This `tryCatch`
 function provides a means of capturing that imperative nature in a simple
 declarative style. Pass it a function that could fail and it will return you
@@ -895,6 +927,7 @@ wrapped in an `Result.Err` if it fails.
 ```haskell
 unary :: (* -> b) -> a -> b
 ```
+
 If you every need to lock down a given function to just one argument, then look
 no further than `unary`. Just pass it a function of any arity, and you will get
 back another function that will only apply (1) argument to given function, no

--- a/docs/src/pages/docs/functions/index.md
+++ b/docs/src/pages/docs/functions/index.md
@@ -8,28 +8,29 @@ weight: 4
 
 There are (6) function classifications included in this library:
 
-* [Combinators](combinators.html): A collection of functions that are used for
+* [Combinators](#combinators): A collection of functions that are used for
 working with other functions. These do things like compose (2) functions
 together, or flip arguments on a function. They typically either take a
 function, return a function or a bit a both. These are considered the glue that
 holds the mighty house of `crocks` together and a valuable aid in writing
 reusable code.
 
-* [Helper Functions](helpers.html): All other support functions that are
+* [Helper Functions](#helpers): All other support functions that are
 either convenient versions of combinators or not even combinators at all cover
 this group.
 
-* [Logic Functions](logic-functions.html): A helpful collection of Logic based
+* [Logic Functions](#logic): A helpful collection of Logic based
 combinators. All of these functions work with predicate functions and let you
 combine them in some very interesting ways.
 
 * [Predicate Functions](predicate-functions.html): A helpful collection of predicate
 functions to get you started.
 
-* [Point-free Functions](pointfree-functions.html): Wanna use these ADTs in a way
-that you never have to reference the actual data being worked on? Well here is
-where you will find all of these functions to do that. For every algebra
-available on both the `Crocks` and `Monoids` there is a function here.
+* [Point-free Functions](pointfree-functions.html): Wanna use these ADTs in a
+way that you never have to reference the actual data being worked on? Well here
+is where you will find all of these functions to do that. For every algebra
+available on both the [Crocks][crocks] and [Monoids][monoids] there is a
+function here.
 
 * [Transformation Functions](transformation-functions.html): All the functions found
 here are used to transform from one type to another, naturally. These come are
@@ -37,3 +38,144 @@ handy in situations where you have functions that return one type (like an
 `Either`), but are working in a context of another (say `Maybe`). You would
 like to compose these, but in doing so will result in a nesting that you will
 need to account for for the rest of your flow.
+
+## Combinators
+
+| Function | Signature | Location |
+|:---|:---|:---|
+| [`applyTo`][applyto] | `(a -> b) -> a -> b` | `crocks/combinators/applyTo` |
+| [`composeB`][composeb] | `(b -> c) -> (a -> b) -> a -> c` | `crocks/combinators/composeB` |
+| [`constant`][constant] | `a -> () -> a` | `crocks/combinators/constant` |
+| [`flip`][flip] | `(a -> b -> c) -> b -> a -> c` | `crocks/combinators/flip` |
+| [`identity`][identity] | `a -> a` | `crocks/combinators/identity` |
+| [`reverseApply`][reverseapply] | `a -> (a -> b) -> b` | `crocks/combinators/reverseApply` |
+| [`substitution`][substitution] | `(a -> b -> c) -> (a -> b) -> a -> c` | `crocks/combinators/substitution` |
+
+## Helpers
+
+| Function | Signature | Location |
+|:---|:---|:---|
+| [`assign`][assign] | `Object -> Object -> Object` | `crocks/helpers/assign` |
+| [`assoc`][assoc] | `String -> a -> Object -> Object` | `crocks/helpers/assoc` |
+| [`binary`][binary] | `(* -> c) -> a -> b -> c` | `crocks/helpers/binary` |
+| [`branch`][branch] | `a -> Pair a a` | `crocks/Pair/branch` |
+| [`compose`][compose] | `((y -> z), ..., (a -> b)) -> a -> z` | `crocks/helpers/compose` |
+| [`composeK`][composek] | `Chain m => ((y -> m z), ..., (a -> m b)) -> a -> m z` | `crocks/helpers/composeK` |
+| [`composeP`][composep] | `Promise p => ((y -> p z c), ..., (a -> p b c)) -> a -> p z c` | `crocks/helpers/composeP` |
+| [`composeS`][composes] | `Semigroupoid s => (s y z, ..., s a b) -> s a z` | `crocks/helpers/composeS` |
+| [`curry`][curry] | `((a, b, ...) -> z) -> a -> b -> ... -> z` | `crocks/helpers/curry` |
+| [`defaultProps`][defaultprops] | `Object -> Object -> Object` | `crocks/helpers/defaultProps` |
+| [`defaultTo`][defaultto] | `a -> b -> a` | `crocks/helpers/defaultTo` |
+| [`dissoc`][dissoc] | `String -> Object -> Object` | `crocks/helpers/dissoc` |
+| [`fanout`][fanout] | `(a -> b) -> (a -> c) -> (a -> Pair b c)` | `crocks/helpers/fanout` |
+| [`fromPairs`][frompairs] | `Foldable f => f (Pair String a) -> Object` | `crocks/helpers/fromPairs` |
+| [`liftA2`][lifta2] | `Applicative m => (a -> b -> c) -> m a -> m b -> m c` | `crocks/helpers/liftA2` |
+| [`liftA3`][lifta3] | `Applicative m => (a -> b -> c -> d) -> m a -> m b -> m c -> m d` | `crocks/helpers/liftA3` |
+| [`mapProps`][mapprops] | `Object -> Object -> Object` | `crocks/helpers/mapProps` |
+| [`mapReduce`][mapreduce] | `Foldable f => (a -> b) -> (c -> b -> c) -> f a -> c` | `crocks/helpers/mapReduce` |
+| [`mconcat`][mconcat] | `Monoid m, Foldable f => m -> f a -> m a` | `crocks/helpers/mconcat` |
+| [`mconcatMap`][mconcatmap] | `Monoid m, Foldable f => m -> (b -> a) -> f b -> m a` | `crocks/helpers/mconcatMap` |
+| [`mreduce`][mreduce] | `Monoid m, Foldable f => m -> f a -> a` | `crocks/helpers/mreduce` |
+| [`mreduceMap`][mreducemap] | `Monoid m, Foldable f => m -> (b -> a) -> f b -> a` | `crocks/helpers/mreduceMap` |
+| [`nAry`][nary] | `Number -> (* -> a) -> * -> a` | `crocks/helpers/nAry` |
+| [`objOf`][objof] | `String -> a -> Object` | `crocks/helpers/objOf` |
+| [`omit`][omit] | `Foldable f => f String -> Object -> Object` | `crocks/helpers/omit` |
+| [`once`][once] | `((*) -> a) -> ((*) -> a)` | `crocks/helpers/once` |
+| [`partial`][partial] | `((* -> c), *) -> * -> c` | `crocks/helpers/partial` |
+| [`pick`][pick] | `Foldable f => f String -> Object -> Object` | `crocks/helpers/pick` |
+| [`pipe`][pipe] | `((a -> b), ..., (y -> z)) -> a -> z` | `crocks/helpers/pipe` |
+| [`pipeK`][pipek] | `Chain m => ((a -> m b), ..., (y -> m z)) -> a -> m z` | `crocks/helpers/pipeK` |
+| [`pipeP`][pipep] | `Promise p => ((a -> p b d), ..., (y -> p z d)) -> a -> p z d` | `crocks/helpers/pipeP` |
+| [`pipeS`][pipes] | `Semigroupoid s => (s a b, ..., s y z) -> s a z` | `crocks/helpers/pipeS` |
+| [`prop`][prop] | <code>(String &#124; Integer) -> a -> Maybe b</code> | `crocks/Maybe/prop` |
+| [`propOr`][propor] | <code>a -> (String &#124; Integer) -> b -> c</code> | `crocks/helpers/propOr` |
+| [`propPath`][proppath] | <code>Foldable f => f (String &#124; Integer) -> a -> Maybe b</code> | `crocks/Maybe/propPath` |
+| [`propPathOr`][proppathor] | <code>Foldable f => a -> f (String &#124; Integer) -> b -> c</code> | `crocks/helpers/propPathOr` |
+| [`safe`][safe] | <code>((a -> Boolean) &#124; Pred) -> a -> Maybe a</code> | `crocks/Maybe/safe` |
+| [`safeLift`][safelift] | <code>((a -> Boolean) &#124; Pred) -> (a -> b) -> a -> Maybe b</code> | `crocks/Maybe/safeLift` |
+| [`tap`][tap] | `(a -> b) -> a -> a` | `crocks/helpers/tap` |
+| [`toPairs`][topairs] | `Object -> List (Pair String a)` | `crocks/Pair/toPairs` |
+| [`tryCatch`][trycatch] | `(a -> b) -> a -> Result e b` | `crocks/Result/tryCatch` |
+| [`unary`][unary] | `(* -> b) -> a -> b` | `crocks/helpers/unary` |
+| [`unit`][unit] | `() -> undefined` | `crocks/helpers/unit` |
+
+## Logic
+
+Every function in `crocks`, that takes a predicate function of the
+form `a -> Boolean`, can be replaced with a [Pred][pred] instance of the
+type: `Pred a` and vice-versa
+
+
+| Function | Signature | Location |
+|:---|:---|:---|
+| [`and`][and] | `(a -> Boolean) -> (a -> Boolean) -> a -> Boolean` | `crocks/logic/and` |
+| [`ifElse`][ifelse] | `(a -> Boolean) -> (a -> b) -> (a -> b) -> a -> b` | `crocks/logic/ifElse` |
+| [`not`][not] | `(a -> Boolean) -> a -> Boolean` | `crocks/logic/not` |
+| [`or`][or] | `(a -> Boolean) -> (a -> Boolean) -> a -> Boolean` | `crocks/logic/or` |
+| [`unless`][unless] | `(a -> Boolean) -> (a -> a) -> a -> a` | `crocks/logic/unless` |
+| [`when`][when] | `(a -> Boolean) -> (a -> a) -> a -> a` | `crocks/logic/when` |
+
+
+[monoids]: ../monoids/index.html
+[crocks]: ../crocks/index.html
+[pred]: ../crocks/Pred.html
+
+
+[applyto]: combinators.html#applyto
+[composeb]: combinators.html#composeb
+[constant]: combinators.html#constant
+[flip]: combinators.html#flip
+[identity]: combinators.html#identity
+[reverseapply]: combinators.html#reverseapply
+[substitution]: combinators.html#substitution
+
+[assign]: helpers.html#assign
+[assoc]: helpers.html#assoc
+[binary]: helpers.html#binary
+[branch]: helpers.html#branch
+[compose]: helpers.html#compose
+[composek]: helpers.html#composek
+[composep]: helpers.html#composep
+[composes]: helpers.html#composes
+[curry]: helpers.html#curry
+[defaultprops]: helpers.html#defaultprops
+[defaultto]: helpers.html#defaultto
+[dissoc]: helpers.html#dissoc
+[fanout]: helpers.html#fanout
+[frompairs]: helpers.html#frompairs
+[lifta2]: helpers.html#lifta2
+[lifta3]: helpers.html#lifta3
+[mapprops]: helpers.html#mapprops
+[mapreduce]: helpers.html#mapreduce
+[mconcat]: helpers.html#mconcat
+[mconcatmap]: helpers.html#mconcatmap
+[mreduce]: helpers.html#mreduce
+[mreducemap]: helpers.html#mreducemap
+[nary]: helpers.html#nary
+[objof]: helpers.html#objof
+[omit]: helpers.html#omit
+[once]: helpers.html#once
+[partial]: helpers.html#partial
+[pick]: helpers.html#pick
+[pipe]: helpers.html#pipe
+[pipek]: helpers.html#pipek
+[pipep]: helpers.html#pipep
+[pipes]: helpers.html#pipes
+[prop]: helpers.html#prop
+[propor]: helpers.html#propor
+[proppath]: helpers.html#proppath
+[proppathor]: helpers.html#proppathor
+[safe]: helpers.html#safe
+[safelift]: helpers.html#safelift
+[tap]: helpers.html#tap
+[topairs]: helpers.html#topairs
+[trycatch]: helpers.html#trycatch
+[unary]: helpers.html#unary
+[unit]: helpers.html#unit
+
+[and]: logic-functions.html#and
+[ifelse]: logic-functions.html#ifelse
+[not]: logic-functions.html#not
+[or]: logic-functions.html#or
+[unless]: logic-functions.html#unless
+[when]: logic-functions.html#when

--- a/docs/src/pages/docs/functions/logic-functions.md
+++ b/docs/src/pages/docs/functions/logic-functions.md
@@ -12,9 +12,11 @@ functions, rather than values, this allows for composeable, "lazy" evaluation.
 All logic functions can be referenced from `crocks/logic`
 
 #### and
+
 ```haskell
-and :: ((a -> Boolean) | Pred) -> ((a -> Boolean) | Pred) -> a -> Boolean
+and :: ((a -> Boolean) | Pred a) -> ((a -> Boolean) | Pred a) -> a -> Boolean
 ```
+
 Say you have two predicate functions or `Pred`s and would like to combine them
 into one predicate over conjunction, well you came to the right place, `and`
 accepts either predicate functions or `Pred`s and will return you a function
@@ -25,9 +27,11 @@ predicates. As they follow the general form of `(a -> Boolean)` they are easily
 combined with other logic functions.
 
 #### ifElse
+
 ```haskell
-ifElse :: ((a -> Boolean) | Pred) -> (* -> a) -> (* -> a) -> * -> a
+ifElse :: ((a -> Boolean) | Pred a) -> (a -> b) -> (a -> b) -> a -> b
 ```
+
 Whenever you need to modify a value based some condition and want a functional
 way to do it without some imperative `if` statement, then reach for `ifElse`.
 This function take a predicate (some function that returns a Boolean) and two
@@ -42,6 +46,7 @@ comes in really handy when creating lifting functions for Sum Types (like
 ```haskell
 not :: ((a -> Boolean) | Pred) -> a -> Boolean
 ```
+
 When you need to negate a predicate function or a `Pred`, but want a new
 predicate function that does the negation, then `not` is going to get you what
 you need. Using `not` will allow you to stay as declarative as possible. Just
@@ -51,9 +56,11 @@ functions in `crocks` take either a `Pred` or predicate function, so it should
 be easy to swap between the two.
 
 #### or
+
 ```haskell
 or :: ((a -> Boolean) | Pred) -> ((a -> Boolean) | Pred) -> a -> Boolean
 ```
+
 Say you have two predicate functions or `Pred`s and would like to combine them
 into one predicate over disjunction, look no further, `or` accepts either
 predicate functions or `Pred`s and will return you a function ready to take a
@@ -64,9 +71,11 @@ follow the general form of `(a -> Boolean)` they are easily combined with other
 logic functions.
 
 #### unless
+
 ```haskell
 unless :: ((a -> Boolean) | Pred) -> (a -> a) -> a -> a
 ```
+
 There may come a time when you need to adjust a value when a condition is false,
 that is where `unless` can come into play. Just provide a predicate function (a
 function that returns a Boolean) and a function to apply your desired
@@ -77,9 +86,11 @@ the result of the predicate. Check out [`when`](#when) for a negated version of
 this function.
 
 #### when
+
 ```haskell
 when :: ((a -> Boolean) | Pred) -> (a -> a) -> a -> a
 ```
+
 There may come a time when you need to adjust a value when a condition is true,
 that is where `when` can come into play. Just provide a predicate function (a
 function that returns a Boolean) and a function to apply your desired


### PR DESCRIPTION
## Give'n ❤️ to dem Funcs
![image](https://user-images.githubusercontent.com/3665793/34510188-8186ccdc-f006-11e7-80c9-8321df0a5a5f.png)

The functions were a bit difficult to navigate in the docs. This PR lays the ground work for how functions and other bits should be xref. It is very (e)manual (lewis), but it is a start. Once we get the pattern down, we can see about using something like `markdown-toc` or use some build state to track links. But it all starts with the horrible, tedious manual process.