### PR TITLE
Clean up Docs/Readme and Implement all-collaborators 

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,70 @@
+{
+  "projectName": "crocks",
+  "projectOwner": "evilsoft",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "contributors": [
+    {
+      "login": "evilsoft",
+      "name": "Ian Hofmann-Hicks",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/3665793?v=4",
+      "profile": "https://github.com/evilsoft",
+      "contributions": [
+        "code",
+        "doc",
+        "video"
+      ]
+    },
+    {
+      "login": "rstegg",
+      "name": "Ryan",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/19234385?v=4",
+      "profile": "https://github.com/rstegg",
+      "contributions": [
+        "code",
+        "bug"
+      ]
+    },
+    {
+      "login": "avanslaars",
+      "name": "Andrew Van Slaars",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1271181?v=4",
+      "profile": "http://vanslaars.io",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "HenriqueLimas",
+      "name": "Henrique Limas",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/2222191?v=4",
+      "profile": "https://github.com/HenriqueLimas",
+      "contributions": [
+        "code",
+        "doc"
+      ]
+    },
+    {
+      "login": "rpearce",
+      "name": "Robert Pearce",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/592876?v=4",
+      "profile": "https://robertwpearce.com",
+      "contributions": [
+        "bug",
+        "code"
+      ]
+    },
+    {
+      "login": "flintinatux",
+      "name": "Scott McCormack",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/888052?v=4",
+      "profile": "https://github.com/flintinatux",
+      "contributions": [
+        "bug"
+      ]
+    }
+  ]
+}

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,3 @@ node_modules
 build
 coverage
 docs
-
-README.md
-!src/**/README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: node_js
 
 node_js:
   - '8'
-  - '7'
   - '6'
-  - '5'
   - '4.2'
 
 install:

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,5 @@
+Ian Hofmann-Hicks <evilsoft@aol.com> (https://github.com/evilsoft)
+Ryan Stegmann (https://github.com/rstegg)
+Andrew Van Slaars (https://github.com/avanslaars)
+Henrique Limas (https://github.com/HenriqueLimas)
+Robert Pearce <me@robertwpearce.com> (http://robertwpearce.com/)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,7 +15,7 @@ you so desire.
 Once everything is pulled down, you will want to install the development
 dependencies by running the following in the project folder:
 
-```bash
+```
 $ npm run setup
 ```
 
@@ -81,3 +81,38 @@ following in the project folder:
 ```
 $ npm test
 ```
+
+### Working on Documentation
+The system used by `crocks` to build the documentation
+is [`electric.js`][electric]. The src for the documentation can be
+found [in this folder][docs-loc]. To add documentation just add a markdown or
+soy file within that directory structure where the file should reside.
+
+When linking between files, make sure to match the case of the files in your
+links. While case does not matter on OSX or Windows, the documentation runs on
+a linux instance in it's production environment.
+
+While putting together the documentation you plan to submit for review, it can
+be helpful to use the built in build system to verify your work as you go. In
+order to use the included build system, the latest JavaSDK needs to be available
+on your system.
+
+By running the following command, you can access a server that will build out the
+documentation as you make changes, available
+at [http://localhost:8888](http://localhost:8888):
+
+```
+$ npm run docs:dev
+```
+
+### Building TOC for README.md
+When updates are done to the main `README.md` file, then the Table of Contents for
+that file needs to be updated. Anytime changes are made to the `README.md` file
+make sure to run the following before committing changes:
+
+```
+$ npm run doctoc
+```
+
+[electric]: https://electricjs.com/
+[docs-loc]: https://github.com/evilsoft/crocks/tree/master/docs/src/pages/docs

--- a/README.md
+++ b/README.md
@@ -2,13 +2,31 @@
 [![Join the chat at https://gitter.im/crocksjs/crocks](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/crocksjs/crocks?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![NPM version](https://badge.fury.io/js/crocks.svg)](https://www.npmjs.com/package/crocks)
 
-# crocks.js
 `crocks` is a collection of popular *Algebraic Data Types (ADTs)* that are all
 the rage in functional programming. You have heard of things like `Maybe` and
 `Either` and heck maybe even `IO`, that is what these are. The main goal of
 `crocks` is to curate and provide not only a common interface between each type
-(where possible of course), but also all of the helper functions needed to hit
-the ground running.
+(where possible of course), but also provide all of the helper functions needed
+to hit the ground running.
+
+## Table of Contents
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Entire `crocks` library (CommonJS)](#entire-crocks-library-commonjs)
+  - [Entire `crocks` library (JS Modules)](#entire-crocks-library-js-modules)
+  - [Single entities (CommonJS)](#single-entities-commonjs)
+  - [Single entities (JS Modules)](#single-entities-js-modules)
+- [Documentation](#documentation)
+- [What is Included?](#what-is-included)
+- [Contributors](#contributors)
+  - [Course/Videos](#coursevideos)
+    - [Video Evilsoft](#video-evilsoft)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Installation
 `crocks` is available from `npm` and is just a shell command away. All you need
@@ -19,1469 +37,248 @@ folder:
 $ npm install crocks -S
 ```
 
-This will pull down `crocks` into your project's `node_modules` folder and can
-be accessed by adding something like the following in the file that needs it:
+## Usage
+
+There are many options to use `crocks` to suit the needs of your, projects. When
+used on the backend or in an environment where size is not a big concern, the
+entire lib can be brought in and the various elements can be either be plucked
+off of or referenced by the namespace.
+
+For those cases where size matters, like in the case of frontend bundle
+building, the individual entities can be brought in. This will ensure that
+your finished bundles include only what is needed for your application/program.
+
+For using the latter case, refer to the desired function's documentation to
+find the path in which it resides.
+
+### Entire `crocks` library (CommonJS)
 
 ```javascript
-// node require syntax
+// namespace entire suite to crocks variable
 const crocks = require('crocks')
 
-// Javascript modules (if you are transpiling)
-import crocks from 'crocks'
+// pluck anything that does not require name-spacing
+const { safe, isNumber } = crocks
+
+// still requires entire object, but removes name-spacing
+const { and, liftA2 } = require('crocks')
+
+// divide :: Number -> Number
+const divide =
+  x => y => x / y
+
+// safeNumber :: a -> Maybe Number
+const safeNumber =
+  safe(isNumber)
+
+// notZero :: a -> Maybe Number
+const notZero = safe(
+  and(isNumber, x => x !== 0)
+)
+
+// safeDivide:: a -> Maybe Number
+const safeDivide = crocks.curry(
+  (x, y) => liftA2(divide, safeNumber(x), notZero(y))
+)
+
+safeDivide(20, 0)
+//=> Nothing
+
+safeDivide(20, 5)
+//=> Just 4
+
+safeDivide('number', 5)
+//=> Nothing
 ```
 
-This lib *should* work, with no additional compilation in all current browsers
-(Edge, Safari, Chrome, Firefox), if it does not, please file an issue as I
-really, really want it to. :smile_cat:.
-
-There is a lot to this library, and as such it may not be desired to bring in
-the entire library when bundling for a library or a frontend application. If
-this is the case, the code is organized in a manner groups all types in
-functions that construct those type in their own folders. The general purpose
-functions are spread across the following folders: `combinators`, `helpers`,
-`logic`, `pointfree` and `predicates`.
-
-To access the types, just reference the folder like: `crocks/Maybe`, or
-`crocks/Result`. If you want to access a function that constructs a given type,
-reference it by name, like: `crocks/Maybe/safe` or `crocks/Result/tryCatch`.
-This organization helps ensure that you only include what you need.
-
-Another thing to note is, if you are transpiling, then destructuring in your
-`import` statement is not going to work as you are thinking (maybe if you are
-using `babel`, but this will be broken once modules are available in node, so
-be careful). Basically you should not do this, as `crocks` will not be set up
-for it until modules are available in node:
+### Entire `crocks` library (JS Modules)
 
 ```javascript
-// Nope! Nope! Nope!:
-import { Maybe, compose, curry, map } from 'crocks'
-
-// instead do something like this:
+// namespace entire suite to crocks variable
 import crocks from 'crocks'
-const { Maybe, compose, curry, map } = crocks
 
-// do not wanna bring all of crocks into your bundle?
-// I feel ya, all try this:
+// still imports entire object, but removes name-spacing
+import { and, liftA2 }  from 'crocks'
 
-import Maybe from 'crocks/Maybe'
-import compose from 'crock/helpers/compose'
-import curry from 'crocks/helpers/curry'
-import map from 'crocks/pointfree/map'
+// pluck anything that does not require name-spacing
+const { safe, isNumber } = crocks
 
-// you can of course do the same with require statements:
-const All = require('crocks/All')
-...
+// divide :: Number -> Number
+const divide =
+  x => y => x / y
+
+// safeNumber :: a -> Maybe Number
+const safeNumber =
+  safe(isNumber)
+
+// notZero :: a -> Maybe Number
+const notZero = safe(
+  and(isNumber, x => x !== 0)
+)
+
+// safeDivide:: a -> Maybe Number
+const safeDivide = crocks.curry(
+  (x, y) => liftA2(divide, safeNumber(x), notZero(y))
+)
+
+safeDivide(20, 0)
+//=> Nothing
+
+safeDivide(20, 5)
+//=> Just 4
+
+safeDivide('number', 5)
+//=> Nothing
 ```
 
-## What is in this?
+### Single entities (CommonJS)
+
+```javascript
+// require in each entity directly
+const and = require('crocks/logic/and')
+const curry = require('crocks/helpers/curry')
+const isNumber = require('crocks/predicates/isNumber')
+const liftA2 = require('crocks/helpers/liftA2')
+const safe = require('crocks/Maybe/safe')
+
+// divide :: Number -> Number
+const divide =
+  x => y => x / y
+
+// safeNumber :: a -> Maybe Number
+const safeNumber =
+  safe(isNumber)
+
+// notZero :: a -> Maybe Number
+const notZero = safe(
+  and(isNumber, x => x !== 0)
+)
+
+// safeDivide:: a -> Maybe Number
+const safeDivide = curry(
+  (x, y) => liftA2(divide, safeNumber(x), notZero(y))
+)
+
+safeDivide(20, 0)
+//=> Nothing
+
+safeDivide(20, 5)
+//=> Just 4
+
+safeDivide('number', 5)
+//=> Nothing
+```
+
+### Single entities (JS Modules)
+
+```javascript
+// import in each entity directly
+import and from 'crocks/logic/and'
+import curry from 'crocks/helpers/curry'
+import isNumber from 'crocks/predicates/isNumber'
+import liftA2 from 'crocks/helpers/liftA2'
+import safe from 'crocks/Maybe/safe'
+
+// divide :: Number -> Number
+const divide =
+  x => y => x / y
+
+// safeNumber :: a -> Maybe Number
+const safeNumber =
+  safe(isNumber)
+
+// notZero :: a -> Maybe Number
+const notZero = safe(
+  and(isNumber, x => x !== 0)
+)
+
+// safeDivide:: a -> Maybe Number
+const safeDivide = curry(
+  (x, y) => liftA2(divide, safeNumber(x), notZero(y))
+)
+
+safeDivide(20, 0)
+//=> Nothing
+
+safeDivide(20, 5)
+//=> Just 4
+
+safeDivide('number', 5)
+//=> Nothing
+```
+
+## Documentation
+
+* [API Documentation](https://evilsoft.github.io/crocks/docs/)
+* [Contributing Information](https://github.com/evilsoft/crocks/blob/master/CONTRIBUTORS.md)
+
+## What is Included?
 There are (8) classifications of "things" included in this library:
 
-* [Crocks](#crocks): These are the ADTs that this library is centered around.
+* [Crocks][crock-docs]: These are the ADTs that this library is centered around.
 They are all `Functor` based Data Types that provide different computational
 contexts for working in a more declarative, functional flow. For the most part,
 a majority of the other bits in `crocks` exist to serve these ADTs.
 
-* [Monoids](#monoids): These helpful ADTs are in a class of their own, not
+* [Monoids][monoid-docs]: These helpful ADTs are in a class of their own, not
 really `Functor`s in their own right (although some can be), they are still very
-useful in our everyday programming needs. Ever need to Sum a list of Numbers or
+useful in our everyday programming needs. Ever need to sum a list of numbers or
 mix a mess of objects together? This is were you will find the ADTs you need to
 do that.
 
-* [Combinators](#combinators): A collection of functions that are used for
+* [Combinators][combinator-docs]: A collection of functions that are used for
 working with other functions. These do things like compose (2) functions
 together, or flip arguments on a function. They typically either take a
 function, return a function or a bit a both. These are considered the glue that
 holds the mighty house of `crocks` together and a valuable aid in writing
 reusable code.
 
-* [Helper Functions](#helper-functions): All other support functions that are
+* [Helper Functions][helper-docs]: All other support functions that are
 either convenient versions of combinators or not even combinators at all cover
 this group.
 
-* [Logic Functions](#logic-functions): A helpful collection of Logic based
-combinators. All of these functions work with predicate functions and let you
-combine them in some very interesting ways.
+* [Logic Functions][logic-docs]: A helpful collection of logic based
+functions. All of these functions work with either predicate functions or
+instances of `Pred` and let you combine them in some very interesting ways.
 
-* [Predicate Functions](#predicate-functions): A helpful collection of predicate
+* [Predicate Functions][predicate-docs]: A helpful collection of predicate
 functions to get you started.
 
-* [Point-free Functions](#point-free-functions): Wanna use these ADTs in a way
+* [Point-free Functions][pointfree-docs]: Wanna use these ADTs in a way
 that you never have to reference the actual data being worked on? Well here is
 where you will find all of these functions to do that. For every algebra
 available on both the `Crocks` and `Monoids` there is a function here.
 
-* [Transformation Functions](#transformation-functions): All the functions found
+* [Transformation Functions][transformation-docs]: All the functions found
 here are used to transform from one type to another, naturally. These come are
 handy in situations where you have functions that return one type (like an
 `Either`), but are working in a context of another (say `Maybe`). You would
 like to compose these, but in doing so will result in a nesting that you will
 need to account for for the rest of your flow.
 
-### Crocks
-The `crocks` are the heart and soul of this library. This is where you will find
-all your favorite ADT's you have grown to :heart:. They include gems such as:
-`Maybe`, `Either` and `IO`, to name a few. The are usually just a simple
-constructor that takes either a function or value (depending on the type)
-and will return you a "container" that wraps whatever you passed it. Each
-container provides a variety of functions that act as the operations you can do
-on the contained value. There are many types that share the same function names,
-but what they do from type to type may vary.  Every Crock provides type function
-on the Constructor and both inspect and type functions on their Instances.
-
-All `Crocks` are Constructor functions of the given type, with `Writer` being an
-exception. The `Writer` function takes a [`Monoid`](#monoids) that will
-represent the `log`. Once you provide the [`Monoid`](#monoids), the function
-will return the `Writer` Constructor for your `Writer` using that specific
-[`Monoid`](#monoids).
-
-| Crock | Constructor | Instance |
-|---|:---|:---|
-| `Arrow` | `id` | `both`, `compose`, `contramap`, `empty`, `first`, `map`, `promap`, `runWith`, `second` |
-| `Async` | `Rejected`, `Resolved`, `all`, `fromNode`, `fromPromise`, `of` | `alt`, `ap`, `bimap`, `chain`, `coalesce`, `fork`, `map`, `of`, `swap`, `toPromise` |
-| `Const` | -- | `ap`, `chain`, `concat`, `equals`, `map`, `valueOf` |
-| `Either` | `Left`, `Right`, `of`| `alt`, `ap`, `bimap`, `chain`, `coalesce`, `concat`, `either`, `equals`, `map`, `of`, `sequence`, `swap`, `traverse` |
-| `Equiv`  | `empty` | `concat`, `contramap`, `empty`, `compareWith`, `valueOf` |
-| `Identity` | `of` | `ap`, `chain`, `concat`, `equals`, `map`, `of`, `sequence`, `traverse`, `valueOf` |
-| `IO` | `of` | `ap`, `chain`, `map`, `of`, `run` |
-| `List` |  `empty`, `fromArray`, `of` | `ap`, `chain`, `concat`, `cons`, `empty`, `equals`, `filter`, `head`, `map`, `of`, `reduce`, `reject`, `sequence`, `tail`, `toArray`, `traverse`, `valueOf` |
-| `Maybe` | `Nothing`, `Just`, `of`, `zero` | `alt`, `ap`, `chain`, `coalesce`, `concat`, `equals`, `either`, `map`, `of`, `option`, `sequence`, `traverse`, `zero` |
-| `Pair` | --- | `ap`, `bimap`, `chain`, `concat`, `equals`, `extend`, `fst`, `map`, `merge`, `of`, `snd`, `swap`, `toArray` |
-| `Pred` * | `empty` | `concat`, `contramap`, `empty`, `runWith`, `valueOf` |
-| `Reader` | `ask`, `of`| `ap`, `chain`, `map`, `of`, `runWith` |
-| `Result` | `Err`, `Ok`, `of`| `alt`, `ap`, `bimap`, `chain`, `coalesce`, `concat`, `either`, `equals`, `map`, `of`, `sequence`, `swap`, `traverse` |
-| `Star` | `id` | `both`, `compose`, `contramap`, `map`, `promap`, `runWith` |
-| `State` | `get`, `modify` `of`, `put`| `ap`, `chain`, `evalWith`, `execWith`, `map`, `of`, `runWith` |
-| `Unit` | `empty`, `of` | `ap`, `chain`, `concat`, `empty`, `equals`, `map`, `of`, `valueOf` |
-| `Writer`| `of` | `ap`, `chain`, `equals`, `log`, `map`, `of`, `read`, `valueOf` |
-
-\* based on [this article](https://medium.com/@drboolean/monoidal-contravariant-functors-are-actually-useful-1032211045c4#.polugsx2a)
-
-### Monoids
-Each `Monoid` provides a means to represent a binary operation and is usually
-locked down to a specific type. These are great when you need to combine a list
-of values down to one value. In this library, any ADT that provides both an
-`empty` and `concat` function can be used as a `Monoid`. There are a few of the
-[`crocks`](#crocks) that are also monoidial, so be on the look out for those as
-well. All `Monoids` work with the point-free functions [`mconcat`](#mconcat),
-[`mreduce`](#mreduce), [`mconcatMap`](#mconcatmap) and
-[`mreduceMap`](#mreducemap).
-
-All `Monoids` provide `empty` and `type` function on their Constructors as well
-as the following Instance Functions: inspect, `type`, `valueOf`, `empty` and
-`concat`.
-
-
-| Monoid | Type | Operation | Empty (Identity) |
-|---|---|---|---|
-| `All` | Boolean | Logical AND | `true` |
-| `Any` | Boolean | Logical OR | `false` |
-| `Assign` | Object | `Object.assign` | `{}` |
-| `Endo` | Function | `compose` | `identity` |
-| `First` | Maybe | First `Just` | `Nothing` |
-| `Last` | Maybe | Last `Just` | `Nothing` |
-| `Max` | Number | `Math.max` | `-Infinity` |
-| `Min` | Number | `Math.min` | `Infinity` |
-| `Prod` | Number | Multiplication | `1` |
-| `Sum` | Number | Addition | `0` |
-
-### Combinators
-#### applyTo
-`crocks/combinators/applyTo`
-```haskell
-applyTo :: (a -> b) -> a -> b
-```
-Seems really silly, but is quite useful for a lot of things. It takes a function
-and a value and then returns the result of that function with the argument
-applied.
-
-#### composeB
-`crocks/combinators/composeB`
-```haskell
-composeB :: (b -> c) -> (a -> b) -> a -> c
-```
-Provides a means to describe a composition between two functions. it takes two
-functions and a value. Given `composeB(f, g)`, which is read `f` after `g`, it
-will return a function that will take value `a` and apply it to `g`, passing the
-result as an argument to `f`, and will finally return the result of `f`. (This
-allows only two functions, if you want to avoid things like:
-`composeB(composeB(f, g), composeB(h, i))` then check out
-[`compose`](#compose).)
-
-#### constant
-`crocks/combinators/constant`
-```haskell
-constant :: a -> _ -> a
-```
-This is a very handy dandy function, used a lot. Pass it any value and it will
-give you back a function that will return that same value no matter what you
-pass it.
-
-#### flip
-`crocks/combinators/flip`
-```haskell
-flip :: (a -> b -> c) -> b -> a -> c
-```
-This little function just takes a function and returns a function that takes the
-first two parameters in reverse. One can compose flip calls down the line to
-flip all, or some of the other parameters if there are more than two. Mix and
-match to your :heart:'s desire.
-
-#### identity
-`crocks/combinators/identity`
-```haskell
-identity ::  a -> a
-```
-This function and [`constant`](#constant) are the workhorses of writing code
-with this library. It quite simply is just a function that when you pass it
-something, it returns that thing right back to you. So simple, I will leave it
-as an exercise to reason about why this is so powerful and important.
-
-#### reverseApply
-`crocks/combinators/reverseApply`
-```haskell
-reverseApply :: a -> (a -> b) -> b
-```
-Ever run into a situation where you have a value but do not have a function to
-apply it to? Well this little bird, named Thrush, is there to help out. Just
-give it a value and it will give you back a function ready to take a function.
-Once that function is provided, it will return the result of applying your value
-to that function.
-
-#### substitution
-`crocks/combinators/substitution`
-```haskell
-substitution :: (a -> b -> c) -> (a -> b) -> a -> c
-```
-While it a complicated little bugger, it can come in very handy from time to
-time. In it's first two arguments it takes functions. The first must be binary
-and the second unary. That will return you a function that is ready to take some
-value. Once supplied the fun starts, it will pass the `a` to the first argument
-of both functions, and the result of the second function to the second parameter
-of the first function. Finally after all that juggling, it will return the
-result of that first function. When used with partial application on that first
-parameter, a whole new world of combinatory madness is presented!
-
-### Helper Functions
-#### assign
-`crocks/helpers/assign`
-```haskell
-assign :: Object -> Object -> Object
-```
-When working with `Object`s, a common operation is to combine (2) of them. This
-can be accomplished in `crocks` by reaching for `assign`. Unlike the
-`Object.assign` that ships with JavaScript, this `assign` will combine your
-`Object`s into a new shallow copy of their merger. `assign` only takes two
-arguments and will overwrite keys present in the second argument with values
-from the first. As with most of the `crocks` `Object` based functions, `assign`
-will omit any key-value pairs that are `undefined`. Check out a related function
-named [`defaultProps`](#defaultprops) that will only assign values that are
-`undefined` in the second argument.
-
-#### assoc
-`crocks/helpers/assoc`
-```haskell
-assoc :: String -> a -> Object -> Object
-```
-There may come a time when you want to add a key-value pair to an `Object` and
-want control over how the key and value are applied. That is where `assoc` can
-come to your aid. Just provide a `String` key and a value of any type to be
-associated to the key. Finally pass it any `Object` and you will get back a
-shallow copy with your key-value pair merged in. This will overwrite any exiting
-keys with new value specified. Used with [`flip`](#flip), you can do some
-interesting things with this function, give it a play! If you just want to
-create an `Object` and not concatenate it to another `Object`, [`objOf`](#objof)
-may be the function for you.
-
-#### binary
-`crocks/helpers/binary`
-```haskell
-binary :: (* -> c) -> a -> b -> c
-```
-With all the different functions out there in the real world, sometimes it is
-nice to restrict them to a specific -arity to work with your all your wonderful
-compositions. When you want to restict any function of any arity to a simple
-binary function. Just pass your function to `binary` and you will get back a
-curried, binary function that will only apply (2) arguments to the inner
-function, ignoring any others. This works very well with functions like
-`Array.prototype.reduce` where you may only care about the first 2 arguments.
-if you need to constrain to more than (2) arguments, then you will want to reach
-for  [`nAry`](#nary). `binary` is basically syntactic sugar for `nAry(2, fn)`.
-Also related is [`unary`](#unary), which constrains to (1) argument.
-
-#### branch
-`crocks/Pair/branch`
-```haskell
-branch :: a -> Pair a a
-```
-When you want to branch a computation into two parts, this is the function you
-want to reach for. All it does is let you pass in any `a` and will return you a
-`Pair` that has your value on both the first and second parameter. This allows
-you to work on the value in two separate computation paths. Be advised that this
-is Javascript and if `a` is an object type (`Object`, `Array`, `Date`, etc) they
-will reference each other.
-
-**Pro-Tip**: `Pair` provides a `merge` function that will let you fold the two
-values into a single value.
-
-#### compose
-`crocks/helpers/compose`
-```haskell
-compose :: ((y -> z), (x -> y), ..., (a -> b)) -> a -> z
-```
-While the [`composeB`](#composeb) can be used to create a composition of two
-functions, there are times when you want to compose an entire flow together.
-That is where `compose` is useful. With `compose` you can create a right-to-left
-composition of functions. It will return you a function that represents your
-flow. Not really sold on writing flows from right-to-left? Well then, I would
-recommend reaching for [`pipe`](#pipe).
-
-#### composeK
-`crocks/helpers/composeK`
-```haskell
-composeK :: Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> a -> m z
-```
-There are many times that, when working with the various `crocks`, our flows are
-just a series of `chain`s. Due to some neat properties with types that provide a
-`chain` function, you can remove some boilerplate by reaching for `composeK`.
-Just pass it the functions you would normally pass to `chain` and it will do all
-the boring hook up for you. Just like `compose`, functions are applied
-right-to-left, so you can turn this:
-
-```js
-const { chain, compose, isObject, prop, safe } = crocks
-
-const data = {
-  do: { re: { mi: 'fa' } }
-}
-
-// fluent :: a -> Maybe b
-const fluent = x =>
-  safe(isObject, x)
-    .chain(prop('do'))
-    .chain(prop('re'))
-    .chain(prop('mi'))
-
-fluent(data)
-// => Just 'fa'
-
-// pointfree :: a -> Maybe b
-const pointfree = compose(
-  chain(prop('mi')),
-  chain(prop('re')),
-  chain(prop('do')),
-  safe(isObject)
-)
-
-pointfree(data)
-// => Just 'fa'
-```
-
-into the more abbreviated form:
-
-```js
-const { composeK, isObject, prop, safe } = crocks
-
-const data = {
-  do: { re: { mi: 'fa' } }
-}
-
-// flow :: a -> Maybe b
-const flow = composeK(
-  prop('mi'),
-  prop('re'),
-  prop('do'),
-  safe(isObject)
-)
-
-flow(data)
-// => Just 'fa'
-```
-As demonstrated in the above example, this function more closely resembles flows
-that are using a more pointfree style of coding. As with the other composition
-functions in `crocks`, a [`pipeK`](#pipek) function is provided for flows that
-make more sense expressed in a left-to-right style.
-
-#### composeP
-`crocks/helpers/composeP`
-```haskell
-composeP :: Promise p => ((y -> p z c), (x -> p y c), ..., (a -> p b c)) -> a -> p z c
-```
-When working with `Promise`s, it is common place to create chains on a
-`Promise`'s `then` function:
-```js
-const promFunc = x =>
-  promiseSomething(x)
-    .then(doSomething)
-    .then(doAnother)
-```
-
-Doing this involves a lot of boilerplate and forces you into a fluent style,
-whether you want to be or not. Using `composeP` you have the option to compose a
-series of `Promise` returning functions like you would any other function
-composition, in a right-to-left fashion. Like so:
-
-```js
-const { composeP } = crocks
-
-const promFunc =
-  composeP(doAnother, doSomething, promiseSomething)
-```
-Due to the nature of the `then` function, only the head of your composition
-needs to return a `Promise`. This will create a function that takes a value,
-which is passed through your chain, returning a `Promise` which can be extended.
-This is only a `then` chain, it does not do anything with the `catch` function.
-If you would like to provide your functions in a left-to-right manner, check out
-[pipeP](#pipep).
-
-#### composeS
-`crocks/helpers/composeS`
-```haskell
-composeS :: Semigroupoid s => (s y z, s x y, ..., s a b) -> s a z
-```
-When working with things like `Arrow` and `Star` there will come a point when
-you would like to compose them like you would any `Function`. That is where
-`composeS` comes in handy. Just pass it the `Semigroupoid`s you want to compose
-and it will give you back a new `Semigroupoid` of the same type with all of the
-underlying functions composed and ready to be run. Like [`compose`](#compose),
-`composeS` composes the functions in a right-to-left fashion. If you would like
-to represent your flow in a more left-to-right manner, then [`pipeS`](#pipes) is
-provided for such things.
-
-```js
-const {
-  Arrow, bimap, branch, composeS, merge, mreduce, Sum
-} = require('crocks')
-
-const length =
-  xs => xs.length
-
-const divide =
-  (x, y) => x / y
-
-const avg =
-  Arrow(bimap(mreduce(Sum), length))
-    .promap(branch, merge(divide))
-
-const double =
-  Arrow(x => x * 2)
-
-const data =
-  [ 34, 198, 3, 43, 92 ]
-
-composeS(double, avg)
-  .runWith(data)
-// => 148
-```
-
-#### curry
-`crocks/helpers/curry`
-```haskell
-curry :: ((a, b, ...) -> z) -> a -> b -> ... -> z
-```
-Pass this function a function and it will return you a function that can be
-called in any form that you require until all arguments have been provided. For
-example if you pass a function: `f : (a, b, c) -> d` you get back a function
-that can be called in any combination, such as: `f(x, y, z)`, `f(x)(y)(z)`,
-`f(x, y)(z)`, or even `f(x)(y, z)`. This is great for doing partial application
-on functions for maximum re-usability.
-
-#### defaultProps
-`crocks/helpers/defaultProps`
-```haskell
-defaultProps :: Object -> Object -> Object
-```
-Picture this, you have an `Object` and you want to make sure that some
-properties are set with a given default value. When the need for this type of
-operation presents itself, `defaultProps` can come to your aid. Just pass it an
-`Object` that defines your defaults and then the `Object` your want to default
-those props on. If a key that is present on the defaults `Object` is not defined
-on your data, then the default value will be used. Otherwise, the value from
-your data will be used instead. You could just apply [`flip`](#flip) to the
-[`assign`](#assign) function and get the same result, but having a function
-named `defaultProps` may be easier to read in code. As with most `Object`
-related functions in `crocks`, `defaultProps` will return you a shallow copy of
-the result and not include any `undefined` values in either `Object`.
-
-#### defaultTo
-`crocks/helpers/defaultTo`
-```haskell
-defaultTo :: a -> b -> a
-```
-With things like `null`, `undefined` and `NaN` showing up all over the place, it
-can be hard to keep your expected types inline without resorting to nesting in a
-`Maybe` with functions like [`safe`](#safe). If you want to specifically guard
-for `null`, `undefined` and `NaN` and get things defaulted into the expected
-type, then `defaultTo` should work for you. Just pass it what you would like
-your default value to be and then the value you want guarded, and you will get
-back either the default or the passed value, depending on if the passed value is
-`null`, `undefined` or `NaN`. While this *is* JavaScript and you can return
-anything, it is suggested to stick to the signature and only let `a`s through.
-As a `b` can be an `a` as well.
-
-#### dissoc
-`crocks/helpers/dissoc`
-```haskell
-dissoc :: String -> Object -> Object
-```
-While [`assoc`](#assoc) can be used to associate a given key-value pair to a
-given `Object`, `dissoc` does the opposite. Just pass `dissoc` a `String` key
-and the `Object` you wish to dissociate that key from and you will get back a
-new, shallow copy of the `Object` sans your key. As with all the `Object`
-functions, `dissoc` will remove any `undefined` values from the result.
-
-#### fanout
-`crocks/helpers/fanout`
-```haskell
-fanout :: (a -> b) -> (a -> c) -> (a -> Pair b c)
-fanout :: Arrow a b -> Arrow a c -> Arrow a (Pair b c)
-fanout :: Monad m => Star a (m b) -> Star a (m c) -> Star a (m (Pair b c))
-```
-There are may times that you need to keep some running or persistent state while
-performing a given computation. A common way to do this is to take the input to
-the computation and branch it into a `Pair` and perform different operations on
-each version of the input. This is such a common pattern that it warrants the
-`fanout` function to take care of the initial split and mapping. Just provide a
-pair of either simple functions or a pair of one of the computation types
-(`Arrow` or `Star`). You will get back something of the same type that is
-configured to split it's input into a pair and than apply the first Function/ADT
-to the first portion of the underlying `Pair` and the second on the second.
-
-#### fromPairs
-`crocks/helpers/fromPairs`
-```haskell
-fromPairs :: [ (Pair String a) ] | List (Pair String a) -> Object
-```
-As an inverse to [`toPairs`](#topairs), `fromPairs` takes either an `Array` or
-`List` of key-value `Pair`s and constructs an `Object` from it. The `Pair` must
-contain a `String` in the `fst` and any type of value in the `snd`. The `fst`
-will become the key for the value in the `snd`. All primitive values are copied
-into the new `Object`, while non-primitives are references to the original. If
-you provide an `undefined` values for the second, that `Pair` will not be
-represented in the resulting `Object`. Also, when if multiple keys share the
-same name, that last value will be moved over.
-
-#### liftA2
-#### liftA3
-`crocks/helpers/liftA2`
-`crocks/helpers/liftA3`
-```haskell
-liftA2 :: Applicative m => (a -> b -> c) -> m a -> m b -> m c
-liftA3 :: Applicative m => (a -> b -> c -> d) -> m a -> m b -> m c -> m d
-```
-Ever see yourself wanting to `map` a binary or trinary function, but `map` only
-allows unary functions? Both of these functions allow you to pass in your
-function as well as the number of `Applicatives` (containers that provide both
-`of` and `ap` functions) you need to get the mapping you are looking for.
-
-#### mapProps
-`crocks/helpers/mapProps`
-```haskell
-mapProps :: { (* -> *) } -> Object -> Object
-```
-Would like to map specific keys in an Object with a specific function? Just
-bring in `mapProps` and pass it an `Object` with the functions you want to apply
-on the keys you want them associated to. When the resulting function receives an
-`Object`, it will return a new `Object` with the keys mapped according to the
-mapping functions. All keys from the original `Object` that do not exist in
-the mapping `Object` will still exist untouched, but the keys with mapping
-functions with now contain the result of applying the original value to the
-provided mapping function.
-
-`mapProps` also allows for mapping on nested `Object`s for times when the shape
-of the original `Object` is know.
-
-```javascript
-const mapProps = require('crocks/helpers/mapProps')
-
-const add =
-  x => y => x + y
-
-const toUpper =
-  x => x.toUpperCase()
-
-const mapping = {
-  entry: toUpper,
-  fauna: {
-    unicorns: add(1),
-    elephants: add(-1)
-  },
-  flora: {
-    nariphon: add(10),
-    birch: add(1)
-  }
-}
-
-mapProps(mapping, {
-  entry: 'legend',
-  fauna: {
-    unicorns: 10,
-    zombies: 3
-  },
-  other: {
-    hat: 2
-  }
-})
-
-//=> { entry: 'LEGEND', fauna: { unicorns: 11, zombies: 3 }, other: { hat: 2} }
-```
-
-#### mapReduce
-`crocks/helpers/mapReduce`
-```haskell
-mapReduce :: Foldable f => (a -> b) -> (c -> b -> c) -> f a -> c
-```
-Sometimes you need the power provided by [`mreduceMap`](#mreducemap) but you do
-not have a `Monoid` to lift into. `mapReduce` provides the same power, but with
-the flexibility of using functions to lift and combine. `mapReduce` takes a
-unary mapping function, a binary reduction function, the initial value and
-finally a `Foldable` structure of data. Once all arguments are provided,
-`mapReduce` folds the provided data, by mapping each value through your mapping
-function, before sending it to the second argument of your reduction function.
-
-```javascript
-const  Max = require('crocks/Max')
-const { Nothing } = require('crocks/Maybe')
-const  isNumber = require('crocks/predicates/isNumber')
-const  mapReduce = require('crocks/helpers/mapReduce')
-const  safeLift = require('crocks/Maybe/safeLift')
-
-
-const data =
-  [ '100', null, 3, true, 1 ]
-
-const safeMax = mapReduce(
-  safeLift(isNumber, Max),
-  (y, x) => y.concat(x).alt(y).alt(x),
-  Nothing()
-)
-
-safeMax(data)
-  .option(Max.empty())
-  .valueOf()
-// => 3
-```
-
-#### mconcat
-#### mreduce
-`crocks/helpers/mconcat`
-`crocks/helpers/mreduce`
-```haskell
-mconcat :: Monoid m => m -> ([ a ] | List a) -> m a
-mreduce :: Monoid m => m -> ([ a ] | List a) -> a
-```
-These two functions are very handy for combining an entire `List` or `Array` of
-values by providing a [`Monoid`](#monoids) and your collection of values. The
-difference between the two is that `mconcat` returns the result inside the
-[`Monoid`](#monoids) used to combine them. Where `mreduce` returns the bare
-value itself.
-
-#### mconcatMap
-#### mreduceMap
-`crocks/helpers/mconcatMap`
-`crocks/helpers/mreduceMap`
-```haskell
-mconcatMap :: Monoid m => m -> (b -> a) -> ([ b ] | List b) -> m a
-mreduceMap :: Monoid m => m -> (b -> a) -> ([ b ] | List b) -> a
-```
-There comes a time where the values you have in a `List` or an `Array` are not
-in the type that is needed for the [`Monoid`](#monoids) you want to combine
-with. These two functions can be used to `map` some transforming function from a
-given type into the type needed for the [`Monoid`](#monoids). In essence, this
-function will run each value through the function before it lifts the value
-into the [`Monoid`](#monoids), before `concat` is applied. The difference
-between the two is that `mconcatMap` returns the result inside the
-[`Monoid`](#monoids) used to combine them. Where `mreduceMap` returns the bare
-value itself.
-
-#### nAry
-`crocks/helpers/nAry`
-```haskell
-nAry :: Number -> (* -> a) -> * -> * -> a
-```
-When using functions like `Math.max` or `Object.assign` that take as many
-arguments as you can throw at them, it makes it hard to `curry` them in a
-reasonable manner. `nAry` can make things a little nicer for functions like
-that. It can also be put to good use to limit a given function to a desired
-number of arguments to avoid accidentally supplying default arguments when you
-do not what them applied. First pass `nAry` the number of arguments you wish to
-limit the function to and then the function you wish to limit. `nAry` will give
-you back a curried function that will only apply the specified number of
-arguments to the inner function. Unary and binary functions are so common that
-`crocks` provides specific functions for those cases: [`unary`](#unary) and
-[`binary`](#binary).
-
-#### objOf
-`crocks/helpers/objOf`
-```haskell
-objOf :: String -> a -> Object
-```
-If you ever find yourself in a situation where you have a key and a value and
-just want to combine the two into an `Object`, then it sounds like `objOf` is
-the function for you. Just pass it a `String` for the key and any type of value,
-and you'll get back an `Object` that is composed of those two. If you find
-yourself constantly concatenating the result of this function into another
-`Object`, you may want to use [`assoc`](#assoc) instead.
-
-#### omit
-`crocks/helpers/omit`
-```haskell
-omit :: ([ String ] | List String) -> Object -> Object
-```
-Sometimes you just want to strip `Object`s of unwanted properties by key. Using
-`omit` will help you get that done. Just pass it a `Foldable` structure with a
-series of `String`s as keys and then pass it an `Object` and you will get back
-not only a shallow copy, but also an `Object` free of any of those pesky
-`undefined` values. You can think of `omit` as a way to black-list or reject
-`Object` properties based on key names. This function ignores inherited
-properties and should only be used with POJOs. If you want to filter or
-white-list properties rather than reject them, take a look at [`pick`](#pick).
-
-#### once
-`crocks/helpers/once`
-```haskell
-once :: ((*) -> a) -> ((*) -> a)
-```
-There are times in Javascript development where you only want to call a function
-once and memo-ize the first result for every subsequent call to that function.
-Just pass the function you want guarded to `once` and you will get back a
-function with the expected guarantees.
-
-#### partial
-`crocks/helpers/partial`
-```haskell
-partial :: ((* -> c), *) -> * -> c
-```
-There are many times when using functions from non-functional libraries or from
-built-in JS functions, where it does not make sense to wrap it in a
-[`curry`](#curry). You just want to partially apply some arguments to it and get
-back a function ready to take the rest. That is a perfect opportunity to use
-`partial`. Just pass a function as the first argument and then apply any other
-arguments to it. You will get back a curried function that is ready to accept
-the rest of the arguments.
-
-```js
-const { map, partial } = require('crocks')
-
-const max10 =
-  partial(Math.min, 10)
-
-const data =
-  [ 13, 5, 13 ]
-
-map(max10, data)
-// => [ 10, 5, 10]
-```
-
-#### pick
-`crocks/helpers/pick`
-```haskell
-pick :: ([ String ] | List String) -> Object -> Object
-```
-When dealing with `Object`s, sometimes it is necessary to only let some of the
-key-value pairs on an object through. Think of `pick` as a sort of white-list or
-filter for `Object` properties. Pass it a `Foldable` structure of `String`s that
-are the keys you would like to pick off of your `Object`. This will give you
-back a shallow copy of the key-value pairs you specified. This function will
-ignore inherited properties and should only be used with POJOs. Any `undefined`
-values will not be copied over, although `null` values are allowed. For
-black-listing properties, have a look at [`omit`](#omit).
-
-#### pipe
-`crocks/helpers/pipe`
-```haskell
-pipe :: ((a -> b), (b -> c), ..., (y -> z)) -> a -> z
-```
-If you find yourself not able to come to terms with doing the typical
-right-to-left composition, then `crocks` provides a means to accommodate you.
-This function does the same thing as [`compose`](#compose), the only difference
-is it allows you define your flows in a left-to-right manner.
-
-#### pipeK
-`crocks/helpers/pipeK`
-```haskell
-pipeK :: Chain m => ((a -> m b), (b -> m c), ..., (y -> m z)) -> a -> m z
-```
-Like [`composeK`](#composek), you can remove much of the boilerplate when
-chaining together a series of functions with the signature:
-`Chain m => a -> m b`. The difference between the two functions is, while
-[`composeK`](#composek) is right-to-left, `pipeK` is the opposite, taking its
-functions left-to-right.
-
-```js
-const { curry, List, Writer } = require('../crocks')
-
-const OpWriter =
-  Writer(List)
-
-const addLog = curry(
-  (x, y) => OpWriter(`adding ${x} to ${y}`, x + y)
-)
-
-const scaleLog = curry(
-  (x, y) => OpWriter(`scaling ${y} by ${x}`, x * y)
-)
-
-const fluent = x =>
-  OpWriter.of(x)
-    .chain(addLog(4))
-    .chain(scaleLog(3))
-
-fluent(0).log()
-// => List [ "adding 4 to 0", "scaling 4 by 3" ]
-
-const chainPipe = pipeK(
-  addLog(4),
-  scaleLog(3)
-)
-
-chainPipe(0).log()
-// => List [ "adding 4 to 0", "scaling 4 by 3" ]
-```
-
-#### pipeP
-`crocks/helpers/pipeP`
-```haskell
-pipeP :: Promise p => ((a -> p b d), (b -> p c d), ..., (y -> p z d)) -> a -> p z d
-```
-Like the [`composeP`](#composep) function, `pipeP` will let you remove the
-standard boilerplate that comes with working with `Promise` chains. The only
-difference between `pipeP` and [`composeP`](#composep) is that it takes its
-functions in a left-to-right order:
-
-```js
-const { pipeP } = crocks
-
-const promFunc = x =>
-  promise(x)
-    .then(doSomething)
-    .then(doAnother)
-
-const promPipe =
-  pipeP(proimse, doSomething, doAnother)
-```
-
-#### pipeS
-`crocks/helpers/pipeS`
-```haskell
-pipeS :: Semigroupoid s => (s a b, s b c, ..., s y z) -> s a z
-```
-While `Star`s and `Arrow`s come in very handy at times, the only thing that
-could make them better is to compose them . With `pipeS` you can do just that
-with any `Semigroupoid`. Just like with [`composeS`](#composes), you just pass
-it `Semigroupoid`s of the same type and you will get back another `Semigroupoid`
-with them all composed together. The only difference between the two, is that
-`pipeS` composes in a left-to-right fashion, while [`composeS`](#composes) does
-the opposite.
-
-```js
-const {
-  curry, isNumber, pipeS, prop, safeLift, Star
-} = require('../crocks')
-
-const add = curry(
-  (x, y) => x + y
-)
-
-const pull =
-  x => Star(prop(x))
-
-const safeAdd =
-  x => Star(safeLift(isNumber, add(x)))
-
-const data = {
-  num: 56,
-  string: '56'
-}
-
-const flow = (key, num) => pipeS(
-  pull(key),
-  safeAdd(num)
-)
-
-flow('num', 10).runWith(data)
-// => Just 66
-
-flow('string', 100).runWith(data)
-// => Nothing
-```
-
-#### prop
-`crocks/Maybe/prop`
-```haskell
-prop :: (String | Integer) -> a -> Maybe b
-```
-If you want some safety around pulling a value out of an Object or Array with a
-single key or index, you can always reach for `prop`. Well, as long as you are
-working with non-nested data that is. Just tell `prop` either the key or index
-you are interested in, and you will get back a function that will take anything
-and return a `Just` with the wrapped value if the key/index exists. If the
-key/index does not exist however, you will get back a `Nothing`.
-
-#### propOr
-`crocks/helpers/propOr`
-```haskell
-propOr :: a -> (String | Integer) -> b -> c
-```
-
-If you want some safety around pulling a value out of an Object or Array with a
-single key or index, you can always reach for `propOr`. Well, as long as you are
-working with non-nested data that is. Just tell `propOr` either the key or index
-you are interested in, and you will get back a function that will take anything
-and return the wrapped value if the key/index exists. If the key/index does not
-exist however, you will get back a default value.
-
-```js
-const { get } = require('crocks/State')
-const propOr = require('crocks/helpers/propOr')
-
-const data = { foo: 'bar' }
-
-get()
-  .map(propOr('default', 'foo'))
-  .evalWith(data) // bar
-
-get()
-  .map(propOr('default', 'baz'))
-  .evalWith(data) // default
-```
-
-#### propPath
-`crocks/Maybe/propPath`
-```haskell
-propPath :: [ String | Integer ] -> a -> Maybe b
-```
-While [`prop`](#prop) is good for simple, single-level structures, there may
-come a time when you have to work with nested POJOs or Arrays. When you run into
-this situation, just pull in `propPath` and pass it a left-to-right traversal
-path of keys, indices or a combination of both (gross...but possible). This will
-kick you back a function that behaves just like [`prop`](#prop). You pass it
-some data, and it will attempt to resolve your provided path. If the path is
-valid, it will return the value residing there (`null` included!) in a `Just`.
-But if at any point that path "breaks" it will give you back a `Nothing`.
-
-#### propPathOr
-`crocks/helpers/propPathOr`
-```haskell
-propPathOr :: a -> [ String | Integer ] -> b -> c
-```
-While [`propOr`](#propor) is good for simple, single-level structures, there may
-come a time when you have to work with nested POJOs or Arrays. When you run into
-this situation, just pull in `propPathOr` and pass it a left-to-right traversal
-path of keys, indices or a combination of both (gross...but possible). This will
-kick you back a function that behaves just like [`propOr`](#propor). You pass it
-some data, and it will attempt to resolve your provided path. If the path is
-valid, it will return the value. But if at any point that path "breaks" it will
-give you back the default value.
-
-```js
-const { get } = require('crocks/State')
-const propPathOr = require('crocks/helpers/propPathOr')
-
-const data = { foo: { bar: 'bar' }, baz: null }
-
-get()
-  .map(propPathOr('default', ['foo', 'bar']))
-  .evalWith(data) // bar
-
-get()
-  .map(propPathOr('default', ['baz', 'tommy']))
-  .evalWith(data) // default
-```
-
-#### safe
-`crocks/Maybe/safe`
-```haskell
-safe :: ((a -> Boolean) | Pred) -> a -> Maybe a
-```
-When using a `Maybe`, it is a common practice to lift into a `Just` or a
-`Nothing` depending on a condition on the value to be lifted.  It is so common
-that it warrants a function, and that function is called `safe`. Provide a
-predicate (a function that returns a Boolean) and a value to be lifted. The
-value will be evaluated against the predicate, and will lift it into a `Just` if
-true and a `Nothing` if false.
-
-#### safeLift
-`crocks/Maybe/safeLift`
-```haskell
-safeLift :: ((a -> Boolean) | Pred) -> (a -> b) -> a -> Maybe b
-```
-While [`safe`](#safe) is used to lift a value into a `Maybe`, you can reach for
-`safeLift` when you want to run a function in the safety of the `Maybe` context.
-Just like [`safe`](#safe), you pass it either a `Pred` or a predicate function
-to determine if you get a `Just` or a `Nothing`, but then instead of a value,
-you pass it a unary function. `safeLift` will then give you back a new function
-that will first lift its argument into a `Maybe` and then maps your original
-function over the result.
-
-#### tap
-`crocks/helpers/tap`
-```haskell
-tap :: (a -> b) -> a -> a
-```
-It is hard knowing what is going on inside of some of these ADTs or your
-wonderful function compositions. Debugging can get messy when you need to insert
-a side-effect into your flow for introspection purposes. With `tap`, you can
-intervene in your otherwise pristine flow and make sure that the original value
-is passed along to the next step of your flow. This function does not guarantee
-immutability for reference types (`Objects`, `Arrays`, etc), you will need to
-exercise some discipline here to not mutate.
-
-#### toPairs
-`crocks/Pair/toPairs`
-```haskell
-toPairs :: Object -> List (Pair String a)
-```
-When dealing with `Object`s, sometimes it makes more sense to work in a
-`Foldable` structure like a `List` of key-value `Pair`s. `toPairs` provides a
-means to take an object and give you back a `List` of `Pairs` that have a
-`String` that represents the key in the `fst` and the value for that key in the
-`snd`. The primitive values are copied, while non-primitive values are
-references. Like most of the `Object` functions in `crocks`, any keys with
-`undefined` values will be omitted from the result. `crocks` provides an inverse
-to this function named [`fromPairs`](#frompairs).
-
-#### tryCatch
-`crocks/Result/tryCatch`
-```haskell
-tryCatch :: (a -> b) -> a -> Result e b
-```
-Typical try-catch blocks are very imperative in their usage. This `tryCatch`
-function provides a means of capturing that imperative nature in a simple
-declarative style. Pass it a function that could fail and it will return you
-another function wrapping the first function. When called, the new function will
-either return the result in a `Result.Ok` if everything was good, or an error
-wrapped in an `Result.Err` if it fails.
-
-#### unary
-`crocks/helpers/unary`
-```haskell
-unary :: (* -> b) -> a -> b
-```
-If you every need to lock down a given function to just one argument, then look
-no further than `unary`. Just pass it a function of any arity, and you will get
-back another function that will only apply (1) argument to given function, no
-matter what is passed to it. `unary` is just syntactic sugar around
-[`nAry`](#nary) in the form of `nAry(1, fn)` as it is such a common case.
-Another common case is [`binary`](#binary) which, as the name implies, only
-applies (2) arguments to a given function.
-
-#### unit
-`crocks/helpers/unit`
-```haskell
-unit :: () -> undefined
-```
-While it seems like just a simple function, `unit` can be used for a number of
-things. A common use for it is as a default `noop` as it is a function that does
-nothing and returns `undefined`. You can also use it in a pointed fashion to
-represent some special value for a given type. This pointed use is the heart and
-soul of the infamous `Maybe` type.
-
-### Logic Functions
-The functions in this section are used to represent logical branching in a
-declarative manner. Each of these functions require either `Pred`s or predicate
-functions in their input. Since these functions work with `Pred`s and predicate
-functions, rather than values, this allows for composeable, "lazy" evaluation.
-All logic functions can be referenced from `crocks/logic`
-
-#### and
-```haskell
-and :: ((a -> Boolean) | Pred) -> ((a -> Boolean) | Pred) -> a -> Boolean
-```
-Say you have two predicate functions or `Pred`s and would like to combine them
-into one predicate over conjunction, well you came to the right place, `and`
-accepts either predicate functions or `Pred`s and will return you a function
-ready to take a value. Once that value is passed, it will run it through both of
-the predicates and return the result of combining it over a `logical and`. This
-is super helpful combined with `or` for putting together reusable, complex
-predicates. As they follow the general form of `(a -> Boolean)` they are easily
-combined with other logic functions.
-
-#### ifElse
-```haskell
-ifElse :: ((a -> Boolean) | Pred) -> (* -> a) -> (* -> a) -> * -> a
-```
-Whenever you need to modify a value based some condition and want a functional
-way to do it without some imperative `if` statement, then reach for `ifElse`.
-This function take a predicate (some function that returns a Boolean) and two
-functions. The first is what is executed when the predicate is true, the second
-on a false condition. This will return a function ready to take a value to run
-through the predicate. After the value is evaluated, it will be ran through it's
-corresponding function, returning the result as the final result. This function
-comes in really handy when creating lifting functions for Sum Types (like
-`Either` or `Maybe`).
-
-#### not
-```haskell
-not :: ((a -> Boolean) | Pred) -> a -> Boolean
-```
-When you need to negate a predicate function or a `Pred`, but want a new
-predicate function that does the negation, then `not` is going to get you what
-you need. Using `not` will allow you to stay as declarative as possible. Just
-pass `not` your predicate function or a `Pred`, and it will give you back a
-predicate function ready for insertion into your flow. All predicate based
-functions in `crocks` take either a `Pred` or predicate function, so it should
-be easy to swap between the two.
-
-#### or
-```haskell
-or :: ((a -> Boolean) | Pred) -> ((a -> Boolean) | Pred) -> a -> Boolean
-```
-Say you have two predicate functions or `Pred`s and would like to combine them
-into one predicate over disjunction, look no further, `or` accepts either
-predicate functions or `Pred`s and will return you a function ready to take a
-value. Once that value is passed, it will run it through both of the predicates
-and return the result of combining it over a `logical or`. This is super helpful
-combined with `and` for putting together reusable, complex predicates. As they
-follow the general form of `(a -> Boolean)` they are easily combined with other
-logic functions.
-
-#### unless
-```haskell
-unless :: ((a -> Boolean) | Pred) -> (a -> a) -> a -> a
-```
-There may come a time when you need to adjust a value when a condition is false,
-that is where `unless` can come into play. Just provide a predicate function (a
-function that returns a Boolean) and a function to apply your desired
-modification. This will get you back a function that when you pass it a value,
-it will evaluate it and if false, will run your value through the provided
-function. Either the original or modified value will be returned depending on
-the result of the predicate. Check out [`when`](#when) for a negated version of
-this function.
-
-#### when
-```haskell
-when :: ((a -> Boolean) | Pred) -> (a -> a) -> a -> a
-```
-There may come a time when you need to adjust a value when a condition is true,
-that is where `when` can come into play. Just provide a predicate function (a
-function that returns a Boolean) and a function to apply your desired
-modification. This will get you back a function that when you pass it a value,
-it will evaluate it and if true, will run your value through the provided
-function. Either the original or modified value will be returned depending on
-the result of the predicate. Check out [`unless`](#unless) for a negated version
-of this function.
-
-### Predicate Functions
-All functions in this group have a signature of `* -> Boolean` and are used with
-the many predicate based functions that ship with `crocks`, like
-[`safe`](#safe), [`ifElse`](#ifelse) and `filter` to name a few. They also fit
-naturally with the `Pred` ADT. All predicate functions can be referenced from
-`crocks/predicates` Below is a list of all the current predicates that are
-included with a description of their truth:
-
-* `hasProp :: (String | Number) -> a -> Boolean`: An Array or Object that contains the provided index or key
-* `isAlt :: a -> Boolean`: an ADT that provides `map` and `alt` functions
-* `isAlternative :: a -> Boolean`: an ADT that provides `alt`, `zero`, `map`, `ap`, `chain` and `of` functions
-* `isApplicative :: a -> Boolean`: an ADT that provides `map`, `ap` and `of` functions
-* `isApply :: a -> Boolean`: an ADT that provides `map` and `ap` functions
-* `isArray :: a -> Boolean`: Array
-* `isBifunctor :: a -> Boolean`: an ADT that provides `map` and `bimap` functions
-* `isBoolean :: a -> Boolean`: Boolean
-* `isCategory :: a -> Boolean`: an ADT that provides `id` and `compose` functions
-* `isChain :: a -> Boolean`: an ADT that provides `map`, `ap` and `chain` functions
-* `isContravariant : a -> Boolean`: an ADT that provides `contramap` function
-* `isDefined :: a -> Boolean`: Every value that is not `undefined`, `null` included
-* `isEmpty :: a -> Boolean`: Empty Object, Array or String
-* `isExtend :: a -> Boolean`: an ADT that provides `map` and `extend` functions
-* `isFoldable :: a -> Boolean`: Array, List or any structure with a `reduce` function
-* `isFunction :: a -> Boolean`: Function
-* `isFunctor :: a -> Boolean`: an ADT that provides a `map` function
-* `isInteger :: a -> Boolean`: Integer
-* `isMonad :: a -> Boolean`: an ADT that provides `map`, `ap`, `chain` and `of` functions
-* `isMonoid :: a -> Boolean`: an ADT that provides `concat` and `empty` functions
-* `isNil :: a -> Boolean`: `undefined` or `null` or `NaN`
-* `isNumber :: a -> Boolean`: `Number` that is not a `NaN` value, `Infinity` included
-* `isObject :: a -> Boolean`: Plain Old Javascript Object (POJO)
-* `isPlus :: a -> Boolean`: an ADT that provides `map`, `alt` and `zero` functions
-* `isProfunctor : a -> Boolean`: an ADT that provides `map`, `contramap` and `promap` functions
-* `isPromise :: a -> Boolean`: an object implementing `then` and `catch`
-* `isSame :: a -> b -> Boolean`: same value or reference, use `equals` for value equality
-* `isSameType :: a -> b -> Boolean`: Constructor matches a values type, or two values types match
-* `isSemigroup :: a -> Boolean`: an ADT that provides a `concat` function
-* `isSemigroupoid :: a -> Boolean`: an ADT that provides a `compose` function
-* `isSetoid :: a -> Boolean`: an ADT that provides an `equals` function
-* `isString :: a -> Boolean`: String
-* `isTraversable :: a -> Boolean`: an ADT that provides `map` and `traverse` functions
-
-### Point-free Functions
-While it can seem natural to work with all these containers in a fluent fashion,
-it can get cumbersome and hard to get a lot of reuse out of. A way to really get
-the most out of reusability in Javascript is to take what is called a point-free
-approach. Below is a small code same to contrast the difference between the two
-calling styles:
-
-```javascript
-const crocks = require('crocks')
-
-const {
-  compose, map, safe, isInteger
-} = crocks // map is the point-free function
-
-// isEven :: Integer -> Boolean
-const isEven =
-  x => (x % 2) === 0
-
-// maybeInt :: a -> Maybe Integer
-const maybeInt =
-  safe(isInteger)
-
-// fluentIsEven :: a -> Maybe Boolean
-const fluentIsEven = data =>
-  maybeInt(data)
-    .map(isEven)
-
-// pointfreeIsEven :: a -> Maybe Boolean
-const pointfreeIsEven =
-  compose(map(isEven), maybeInt)
-```
-
-These functions provide a very clean way to build out very simple functions and
-compose them all together to compose a more complicated flow. Each point-free
-function provided in `crocks` is "auto-curried" and follows a "data-last"
-pattern in the order of how it receives it's arguments. Typically the most
-stable of the arguments comes first, moving all the way to the least stable
-argument (which usually is the data flowing through your composition). Below
-lists the provided functions and the data types they work with (`m` refers to an
-accepted Datatype):
-
-##### Signatures
-| Function | Signature | Location |
-|---|:---|:---|
-| `alt` | `m a -> m a -> m a` | `crocks/pointfree` |
-| `ap` | `m a -> m (a -> b) -> m b` | `crocks/pointfree` |
-| `bimap` | `(a -> c) -> (b -> d) -> m a b -> m c d` | `crocks/pointfree` |
-| `both` | `m (a -> b) -> m (Pair a a -> Pair b b)` | `crocks/pointfree` |
-| `chain` | `(a -> m b) -> m a -> m b` | `crocks/pointfree` |
-| `coalesce` | `(a -> c) -> (b -> c) -> m a b -> m _ c` | `crocks/pointfree` |
-| `compareWith` | `a -> a -> m a -> Boolean` | `crocks/pointfree` |
-| `concat` | `m a -> m a -> m a` | `crocks/pointfree` |
-| `cons` | `a -> m a -> m a` | `crocks/pointfree` |
-| `contramap` | `(b -> a) -> m a -> m b` | `crocks/pointfree` |
-| `either` | `(a -> c) -> (b -> c) -> m a b -> c` | `crocks/pointfree` |
-| `empty` | `m -> m` | `crocks/pointfree` |
-| `equals` | `m -> m -> Boolean` | `crocks/pointfree` |
-| `evalWith` | `a -> m -> b` | `crocks/State` |
-| `execWith` | `a -> m -> b` | `crocks/State` |
-| `extend` | `(m a -> b) -> m a -> m b` | `crocks/pointfree` |
-| `filter` | <code>((a -> Boolean) &#124; Pred a) -> m a -> m a</code> | `crocks/pointfree` |
-| `first` | `m (a -> b) -> m (Pair a c -> Pair b c)` | `crocks/pointfree` |
-| `fold` | `Semigroup s => m s -> s` | `crocks/pointfree` |
-| `fst` | `m a b -> a` | `crocks/Pair` |
-| `head` | `m a -> Maybe a` | `crocks/pointfree` |
-| `log` | `m a b -> a` | `crocks/Writer` |
-| `map` | `(a -> b) -> m a -> m b` | `crocks/pointfree` |
-| `merge` | `(a -> b -> c) -> m a b -> c` | `crocks/Pair` |
-| `option` | `a -> m a -> a` | `crocks/pointfree` |
-| `promap` | `(c -> a) -> (b -> d) -> m a b -> m c d` | `crocks/pointfree` |
-| `read` | `m a b -> Pair a b` | `crocks/Writer` |
-| `reduce` | `(b -> a -> b) -> b -> m a -> b` | `crocks/pointfree` |
-| `reject` | <code>((a -> Boolean) &#124; Pred a) -> m a -> m a</code> | `crocks/pointfree` |
-| `run` | `m a -> b` | `crocks/pointfree` |
-| `runWith` | `a -> m -> b` | `crocks/pointfree` |
-| `second` | `m (a -> b) -> m (Pair c a -> Pair c b)` | `crocks/pointfree` |
-| `sequence` | `Applicative f => (b -> f b) -> m (f a) -> f (m a)` | `crocks/pointfree` |
-| `snd` | `m a b -> b` | `crocks/Pair` |
-| `swap` | `(c -> d) -> (a -> b) -> m c a -> m b d` | `crocks/pointfree` |
-| `tail` | `m a -> Maybe (m a)` | `crocks/pointfree` |
-| `traverse` | `Applicative f => (c -> f c) -> (a -> f b) -> m (f a) -> f (m b)` | `crocks/pointfree` |
-| `valueOf` | `m a -> a` | `crocks/pointfree` |
-
-##### Datatypes
-| Function | Datatypes |
-|---|:---|
-| `alt` | `Async`, `Either`, `Maybe`, `Result` |
-| `ap` | `Array`, `Async`, `Const`, `Either`, `Identity`, `IO`, `List`, `Maybe`, `Pair`, `Reader`, `Result`, `State`, `Unit`, `Writer` |
-| `bimap` | `Async`, `Either`, `Pair`, `Result` |
-| `both` | `Arrow`, `Function`, `Star` |
-| `chain` | `Array`, `Async`, `Const`, `Either`, `Identity`, `IO`, `List`, `Maybe`, `Pair`, `Reader`, `Result`, `State`, `Unit`, `Writer` |
-| `coalesce` | `Async`, `Either`, `Maybe`, `Result` |
-| `concat` | `All`, `Any`, `Array`, `Assign`, `Const`, `Either`, `Endo`, `First`, `Identity`, `Last`, `List`, `Max`, `Maybe`, `Min`, `Pair`, `Pred`, `Prod`, `Result`, `String`, `Sum`, `Unit` |
-| `cons` | `Array`, `List` |
-| `contramap` | `Arrow`, `Pred`, `Star` |
-| `either` | `Either`, `Maybe`, `Result` |
-| `empty` | `All`, `Any`, `Array`, `Assign`, `Endo`, `First`, `Last`, `List`, `Max`, `Min`, `Object`, `Pred`, `Prod`, `String`, `Sum`, `Unit` |
-| `evalWith` | `State` |
-| `execWith` | `State` |
-| `extend` | `Pair` |
-| `filter` | `Array`, `List`, `Object` |
-| `first` | `Arrow`, `Function`, `Star` |
-| `fold` | `Array`, `List` |
-| `fst` | `Pair` |
-| `head` | `Array`, `List`, `String` |
-| `log` | `Writer` |
-| `map` | `Async`, `Array`, `Arrow`, `Const`, `Either`, `Function`, `Identity`, `IO`, `List`, `Maybe`, `Object`, `Pair`, `Reader`, `Result`, `Star`, `State`, `Unit`, `Writer` |
-| `merge` | `Pair` |
-| `option` | `First`, `Last`, `Maybe` |
-| `promap` | `Arrow`, `Star` |
-| `read` | `Writer` |
-| `reduce` | `Array`, `List` |
-| `reject` | `Array`, `List`, `Object` |
-| `run` | `IO` |
-| `runWith` | `Arrow`, `Endo`, `Pred`, `Reader`, `Star`, `State` |
-| `second` | `Arrow`, `Function`, `Star` |
-| `sequence` | `Array`, `Either`, `Identity`, `List`, `Maybe`, `Result` |
-| `snd` | `Pair` |
-| `swap` | `Async`, `Either`, `Pair`, `Result` |
-| `tail` | `Array`, `List`, `String` |
-| `traverse` | `Array`, `Either`, `Identity`, `List`, `Maybe`, `Result` |
-| `valueOf` | `All`, `Any`, `Assign`, `Const`, `Endo`, `First`, `Identity`, `Last`, `Max`, `Min`, `Pred`, `Prod`, `Sum`, `Unit`, `Writer` |
-
-### Transformation Functions
-Transformation functions are mostly used to reduce unwanted nesting of similar
-types. Take for example the following structure:
-
-```javascript
-const data =
-  Either.of(Maybe.of(3))  // Right Just 3
-
-// mapping on the inner Maybe is tedious at best
-data
-  .map(map(x => x + 1))   // Right Just 4
-  .map(map(x => x * 10))  // Right Just 40
-
-// and extraction...super gross
-data
-  .either(identity, identity)  // Just 3
-  .option(0)                   // 3
-
-// or
-data
-  .either(option(0), option(0))  // 3
-```
-
-The transformation functions, that ship with `crocks`, provide a means for
-dealing with this. Using them effectively, can turn the above code into
-something more like this:
-
-```javascript
-const data =
-  Either.of(Maybe.of(3))      // Right Just 3
-    .chain(maybeToEither(0))  // Right 3
-
-// mapping on a single Either, much better
-data
-  .map(x => x + 1)  // Right 4
-  .map(x => x * 10) // Right 40
-
-// no need to default the Left case anymore
-data
-  .either(identity, identity) // 3
-
-// effects of the inner type are applied immediately
-const nested =
-  Either.of(Maybe.Nothing) // Right Nothing
-
-const unnested =
-  nested
-    .chain(maybeToEither(0))  // Left 0
-
-// Always maps, although the inner Maybe skips
-nested
-  .map(map(x => x + 1))        // Right Nothing (runs mapping)
-  .map(map(x => x * 10))       // Right Nothing (runs mapping)
-  .either(identity, identity)  // Nothing
-  .option(0)                   // 0
-
-// Never maps on a Left, just skips it
-unnested
-  .map(x => x + 1)             // Left 0 (skips mapping)
-  .map(x => x * 10)            // Left 0 (skips mapping)
-  .either(identity, identity)  // 0
-```
-
-Not all types can be transformed to and from each other. Some of them are lazy
-and/or asynchronous, or are just too far removed. Also, some transformations
-will result in a loss of information. Moving from an `Either` to a `Maybe`, for
-instance, would lose the `Left` value of `Either` as a `Maybe`'s first parameter
-(`Nothing`) is fixed at `Unit`. Conversely, if you move the other way around,
-from a `Maybe` to an `Either` you must provide a default `Left` value. Which
-means, if the inner `Maybe` results in a `Nothing`, it will map to `Left` of
-your provided value. As such, not all of these functions are guaranteed
-isomorphic. With some types you just cannot go back and forth and expect to
-retain information.
-
-Each function provides two signatures, one for if a Function is used for the
-second argument and another if the source ADT is passed instead. Although it may
-seem strange, this provides some flexibility on how to apply the transformation.
-The ADT version is great for squishing an already nested type or to perform the
-transformation in a composition. While the Function version can be used to
-extend an existing function without having to explicitly compose it. Both
-versions can be seen here:
-
-```javascript
-// Avoid nesting
-// inc :: a -> Maybe Number
-const inc =
-  safeLift(isNumber, x => x + 1)
-
-// using Function signature
-// asyncInc :: a -> Async Number Number
-const asyncInc =
-  maybeToAsync(0, inc)
-
-// using ADT signature to compose (extending functions)
-// asyncInc :: a -> Async Number Number
-const anotherInc =
-  compose(maybeToAsync(0), inc)
-
-// resolveValue :: a -> Async _ a
-const resolveValue =
-  Async.Resolved
-
-resolveValue(3)                          // Resolved 3
-  .chain(asyncInc)                       // Resolved 4
-  .chain(anotherInc)                     // Resolved 5
-  .chain(compose(maybeToAsync(20), inc)) // Resolved 6
-
-resolveValue('oops')                     // Resolved 'oops'
-  .chain(asyncInc)                       // Rejected 0
-  .chain(anotherInc)                     // Rejected 0
-  .chain(compose(maybeToAsync(20), inc)) // Rejected 0
-
-// Squash existing nesting
-// Just Right 'nice'
-const good =
-  Maybe.of(Either.Right('nice'))
-
-// Just Left 'not so nice'
-const bad =
-  Maybe.of(Either.Left('not so nice'))
-
-good
-  .chain(eitherToMaybe) // Just 'nice'
-
-bad
-  .chain(eitherToMaybe) // Nothing
-```
-
-#### Transformation Signatures
-| Transform | ADT signature | Function Signature | Location |
-|---|:---|:---|:---|
-| `arrayToList` | `[ a ] -> List a` | `(a -> [ b ]) -> a -> List b` | `crocks/List` |
-| `eitherToAsync` | `Either e a -> Async e a` | `(a -> Either e b) -> a -> Async e b` | `crocks/Async` |
-| `eitherToFirst` | `Either b a -> First a` | `(a -> Either c b) -> a -> First b` | `crocks/First` |
-| `eitherToLast` | `Either b a -> Last a` | `(a -> Either c b) -> a -> Last b` | `crocks/Last` |
-| `eitherToMaybe` | `Either b a -> Maybe a` | `(a -> Either c b) -> a -> Maybe b` | `crocks/Maybe` |
-| `eitherToResult` | `Either e a -> Result e a` | `(a -> Either e b) -> a -> Result e b` | `crocks/Result` |
-| `firstToAsync` | `e -> First a -> Async e a` | `e -> (a -> First b) -> a -> Async e b` | `crocks/Async` |
-| `firstToEither` | `c -> First a -> Either c a` | `c -> (a -> First b) -> a -> Either c b` | `crocks/Either` |
-| `firstToLast` | `First a -> Last a` | `(a -> First b) -> a -> Last b` | `crocks/Last` |
-| `firstToMaybe` | `First a -> Maybe a` | `(a -> First b) -> a -> Maybe b` | `crocks/Maybe` |
-| `firstToResult` | `c -> First a -> Result c a` | `c -> (a -> First b) -> a -> Result c b` | `crocks/Result` |
-| `lastToAsync` | `e -> Last a -> Async e a` | `e -> (a -> Last b) -> a -> Async e b` | `crocks/Async` |
-| `lastToEither` | `c -> Last a -> Either c a` | `c -> (a -> Last b) -> a -> Either c b` | `crocks/Either` |
-| `lastToFirst` | `Last a -> First a` | `(a -> Last b) -> a -> First b` | `crocks/First` |
-| `lastToMaybe` | `Last a -> Maybe a` | `(a -> Last b) -> a -> Maybe b` | `crocks/Maybe` |
-| `lastToResult` | `c -> Last a -> Result c a` | `c -> (a -> Last b) -> a -> Result c b` | `crocks/Result` |
-| `listToArray` | `List a -> [ a ]` | `(a -> List b) -> a -> [ b ]` | `crocks/List` |
-| `maybeToAsync` | `e -> Maybe a -> Async e a` | `e -> (a -> Maybe b) -> a -> Async e b` | `crocks/Async` |
-| `maybeToEither` | `c -> Maybe a -> Either c a` | `c -> (a -> Maybe b) -> a -> Either c b` | `crocks/Either` |
-| `maybeToFirst` | `Maybe a -> First a` | `(a -> Maybe b) -> a -> First b` | `crocks/First` |
-| `maybeToLast` | `Maybe a -> Last a` | `(a -> Maybe b) -> a -> Last b` | `crocks/Last` |
-| `maybeToResult` | `c -> Maybe a -> Result c a` | `c -> (a -> Maybe b) -> a -> Result c b` | `crocks/Result` |
-| `resultToAsync` | `Result e a -> Async e a` | `(a -> Result e b) -> a -> Async e b` | `crocks/Async` |
-| `resultToEither` | `Result e a -> Either e a` | `(a -> Result e b) -> a -> Either e b` | `crocks/Either` |
-| `resultToFirst` | `Result e a -> First a` | `(a -> Result e b) -> a -> First b` | `crocks/First` |
-| `resultToLast` | `Result e a -> Last a` | `(a -> Result e b) -> a -> Last b` | `crocks/Last` |
-| `resultToMaybe` | `Result e a -> Maybe a` | `(a -> Result e b) -> a -> Maybe b` | `crocks/Maybe` |
-| `writerToPair` | `Writer m a -> Pair m a` | `(a -> Writer m b) -> a -> Pair m b` | `crocks/Pair` |
+## Contributors
+
+Thanks goes to these wonderful people ([emoji key][emojis]):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore -->
+| [<img src="https://avatars1.githubusercontent.com/u/3665793?v=4" width="100px;"/><br /><sub><b>Ian Hofmann-Hicks</b></sub>](https://github.com/evilsoft)<br />[💻](https://github.com/evilsoft/crocks/commits?author=evilsoft "Code") [📖](https://github.com/evilsoft/crocks/commits?author=evilsoft "Documentation") [📹](#video-evilsoft "Videos") | [<img src="https://avatars0.githubusercontent.com/u/19234385?v=4" width="100px;"/><br /><sub><b>Ryan</b></sub>](https://github.com/rstegg)<br />[💻](https://github.com/evilsoft/crocks/commits?author=rstegg "Code") [🐛](https://github.com/evilsoft/crocks/issues?q=author%3Arstegg "Bug reports") | [<img src="https://avatars0.githubusercontent.com/u/1271181?v=4" width="100px;"/><br /><sub><b>Andrew Van Slaars</b></sub>](http://vanslaars.io)<br />[📖](https://github.com/evilsoft/crocks/commits?author=avanslaars "Documentation") | [<img src="https://avatars0.githubusercontent.com/u/2222191?v=4" width="100px;"/><br /><sub><b>Henrique Limas</b></sub>](https://github.com/HenriqueLimas)<br />[💻](https://github.com/evilsoft/crocks/commits?author=HenriqueLimas "Code") [📖](https://github.com/evilsoft/crocks/commits?author=HenriqueLimas "Documentation") | [<img src="https://avatars2.githubusercontent.com/u/592876?v=4" width="100px;"/><br /><sub><b>Robert Pearce</b></sub>](https://robertwpearce.com)<br />[🐛](https://github.com/evilsoft/crocks/issues?q=author%3Arpearce "Bug reports") [💻](https://github.com/evilsoft/crocks/commits?author=rpearce "Code") | [<img src="https://avatars1.githubusercontent.com/u/888052?v=4" width="100px;"/><br /><sub><b>Scott McCormack</b></sub>](https://github.com/flintinatux)<br />[🐛](https://github.com/evilsoft/crocks/issues?q=author%3Aflintinatux "Bug reports") |
+| :---: | :---: | :---: | :---: | :---: | :---: |
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+### Course/Videos
+
+#### Video Evilsoft
+* [State Monad In Javascript (egghead.io)](https://egghead.io/courses/state-monad-in-javascript)
+* [Working With ADTs (YouTube)](https://www.youtube.com/playlist?list=PLjvgv-FpMo7XRVFZjZsWXJ5nVmRJ5a5Hv)
+* [Functional JS (YouTube)](https://www.youtube.com/playlist?list=PLjvgv-FpMo7XvlfO8YKiz4_onf8WonhiA)
+
+[crock-docs]: https://evilsoft.github.io/crocks/docs/crocks/
+[monoid-docs]: https://evilsoft.github.io/crocks/docs/monoids/
+[combinator-docs]: https://evilsoft.github.io/crocks/docs/functions/#combinators
+[helper-docs]: https://evilsoft.github.io/crocks/docs/functions/#helpers
+[logic-docs]: https://evilsoft.github.io/crocks/docs/functions/#logic
+[predicate-docs]: https://evilsoft.github.io/crocks/docs/functions/predicate-functions.html
+[pointfree-docs]: https://evilsoft.github.io/crocks/docs/functions/pointfree-functions.html
+[transformation-docs]: https://evilsoft.github.io/crocks/docs/functions/transformation-functions.html
+[emojis]:https://github.com/kentcdodds/all-contributors#emoji-key

--- a/bin/publish
+++ b/bin/publish
@@ -5,6 +5,8 @@ BUILD_DIR=build
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 
-cp ../{.npmignore,package.json,LICENSE,README.md} .
+cp ../{.npmignore,package.json,AUTHORS,LICENSE,README.md} .
 
 npm publish
+
+cd ..

--- a/docs/src/pages/docs/getting-started.md
+++ b/docs/src/pages/docs/getting-started.md
@@ -32,49 +32,174 @@ import crocks from 'crocks'
 
 <article id="import-only-what-you-need">
 
-## Import only what you need
-
-This lib *should* work, with no additional compilation in all current browsers
-(Edge, Safari, Chrome, Firefox), if it does not, please file an issue as I
-really, really want it to. 
+## Import only what's needed
 
 There is a lot to this library, and as such it may not be desired to bring in
-the entire library when bundling for a library or a frontend application. If
-this is the case, the code is organized in a manner groups all types in
-functions that construct those type in their own folders. The general purpose
-functions are spread across the following folders: `combinators`, `helpers`,
-`logic`, `pointfree` and `predicates`.
+the whole thing when bundling for a library or frontend application. If
+this is the case, the code is organized in a manner that groups all functions
+that return or construct a given ADT into their respective folders. While
+general purpose functions are spread across the following
+folders: `combinators`, `helpers`, `logic`, `pointfree` and `predicates`.
 
 To access the types, just reference the folder like: `crocks/Maybe`, or
 `crocks/Result`. If you want to access a function that constructs a given type,
 reference it by name, like: `crocks/Maybe/safe` or `crocks/Result/tryCatch`.
 This organization helps ensure that you only include what you need.
 
-Another thing to note is, if you are transpiling, then destructuring in your
-`import` statement is not going to work as you are thinking (maybe if you are
-using `babel`, but this will be broken once modules are available in node, so
-be careful). Basically you should not do this, as `crocks` will not be set up
-for it until modules are available in node:
+### Entire library (CommonJS)
 
 ```javascript
-// Nope! Nope! Nope!:
-import { Maybe, compose, curry, map } from 'crocks'
+// namespace entire suite to crocks variable
+const crocks = require('crocks')
 
-// instead do something like this:
+// pluck anything that does not require name-spacing
+const { safe, isNumber } = crocks
+
+// still requires entire object, but removes name-spacing
+const { and, liftA2 } = require('crocks')
+
+// divide :: Number -> Number
+const divide =
+  x => y => x / y
+
+// safeNumber :: a -> Maybe Number
+const safeNumber =
+  safe(isNumber)
+
+// notZero :: a -> Maybe Number
+const notZero = safe(
+  and(isNumber, x => x !== 0)
+)
+
+// safeDivide:: a -> Maybe Number
+const safeDivide = crocks.curry(
+  (x, y) => liftA2(divide, safeNumber(x), notZero(y))
+)
+
+safeDivide(20, 0)
+//=> Nothing
+
+safeDivide(20, 5)
+//=> Just 4
+
+safeDivide('number', 5)
+//=> Nothing
+```
+
+### Entire library (JS Modules)
+
+```javascript
+// namespace entire suite to crocks variable
 import crocks from 'crocks'
-const { Maybe, compose, curry, map } = crocks
 
-// do not wanna bring all of crocks into your bundle?
-// I feel ya, all try this:
+// still imports entire object, but removes name-spacing
+import { and, liftA2 }  from 'crocks'
 
-import Maybe from 'crocks/Maybe'
-import compose from 'crock/helpers/compose'
+// pluck anything that does not require name-spacing
+const { safe, isNumber } = crocks
+
+// divide :: Number -> Number
+const divide =
+  x => y => x / y
+
+// safeNumber :: a -> Maybe Number
+const safeNumber =
+  safe(isNumber)
+
+// notZero :: a -> Maybe Number
+const notZero = safe(
+  and(isNumber, x => x !== 0)
+)
+
+// safeDivide:: a -> Maybe Number
+const safeDivide = crocks.curry(
+  (x, y) => liftA2(divide, safeNumber(x), notZero(y))
+)
+
+safeDivide(20, 0)
+//=> Nothing
+
+safeDivide(20, 5)
+//=> Just 4
+
+safeDivide('number', 5)
+//=> Nothing
+```
+
+### Single entities (CommonJS)
+
+```javascript
+// require in each entity directly
+const and = require('crocks/logic/and')
+const curry = require('crocks/helpers/curry')
+const isNumber = require('crocks/predicates/isNumber')
+const liftA2 = require('crocks/helpers/liftA2')
+const safe = require('crocks/Maybe/safe')
+
+// divide :: Number -> Number
+const divide =
+  x => y => x / y
+
+// safeNumber :: a -> Maybe Number
+const safeNumber =
+  safe(isNumber)
+
+// notZero :: a -> Maybe Number
+const notZero = safe(
+  and(isNumber, x => x !== 0)
+)
+
+// safeDivide:: a -> Maybe Number
+const safeDivide = curry(
+  (x, y) => liftA2(divide, safeNumber(x), notZero(y))
+)
+
+safeDivide(20, 0)
+//=> Nothing
+
+safeDivide(20, 5)
+//=> Just 4
+
+safeDivide('number', 5)
+//=> Nothing
+```
+
+### Single entities (JS Modules)
+
+```javascript
+// import in each entity directly
+import and from 'crocks/logic/and'
 import curry from 'crocks/helpers/curry'
-import map from 'crocks/pointfree/map'
+import isNumber from 'crocks/predicates/isNumber'
+import liftA2 from 'crocks/helpers/liftA2'
+import safe from 'crocks/Maybe/safe'
 
-// you can of course do the same with require statements:
-const All = require('crocks/All')
-...
+// divide :: Number -> Number
+const divide =
+  x => y => x / y
+
+// safeNumber :: a -> Maybe Number
+const safeNumber =
+  safe(isNumber)
+
+// notZero :: a -> Maybe Number
+const notZero = safe(
+  and(isNumber, x => x !== 0)
+)
+
+// safeDivide:: a -> Maybe Number
+const safeDivide = curry(
+  (x, y) => liftA2(divide, safeNumber(x), notZero(y))
+)
+
+safeDivide(20, 0)
+//=> Nothing
+
+safeDivide(20, 5)
+//=> Just 4
+
+safeDivide('number', 5)
+//=> Nothing
 ```
 
 </article>

--- a/docs/src/pages/index.soy
+++ b/docs/src/pages/index.soy
@@ -1,6 +1,6 @@
 ---
 title: "Home"
-description: "A collection of well known Monadic Containers for your utter enjoyment."
+description: "A collection of well known Algebraic Data Types for your utter enjoyment."
 ---
 
 {namespace pageIndex}
@@ -48,7 +48,7 @@ description: "A collection of well known Monadic Containers for your utter enjoy
       <div class="row">
         <div class="col-md-12 col-md-offset-2">
           <h3 class="about-title">Why?</h3>
-          <p class="about-description">Because Functional Programming matters and Crocks make that world simplier curating and providing not only a common interface between each type (where possible of course), but also all of the helper functions needed to hit the ground running.</p>
+          <p class="about-description"> Functional Programming matters and Crocks makes that world simplier by both curating and providing not only a common interface between each type (where possible of course), but also all of the helper functions needed to hit the ground running.</p>
         </div>
       </div>
     </div>
@@ -97,7 +97,7 @@ description: "A collection of well known Monadic Containers for your utter enjoy
       <section class="highlight row">
         <div class="col-md-6 col-md-offset-2">
           <h4 class="highlight-title">Work in a more declarative, functional flow.</h4>
-          <p class="highlight-description">Crocks implements all Functor based Data Types that provide different computational contexts for working in a more declarative, functional flow</p>
+          <p class="highlight-description">The data types provided in Crocks allow you to remove large swaths of imparative boilerplate, allowing you to think of your code in terms of what it does and not how it does it.</p>
         </div>
         <div class="col-md-5 col-md-offset-1">
           <div class="highlight-graphic">
@@ -119,7 +119,7 @@ description: "A collection of well known Monadic Containers for your utter enjoy
       <section class="highlight row">
         <div class="col-md-6 col-md-offset-2">
           <h4 class="highlight-title">Combine a list of values down to one value</h4>
-          <p class="highlight-description">Crocks provides Monoid, where you can represent a binary operation and usually locked down it to a specific type. These are great when you need to combine a list of values down to one value.</p>
+          <p class="highlight-description">Crocks provides a large variety of Monoids, which are ADTs that represent a binary operation and are usually locked down it to a specific type. These are great when you need to combine two things into one under a specific operation.</p>
         </div>
         <div class="col-md-5 col-md-offset-1">
           <div class="highlight-graphic">

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,131 @@
         "repeat-string": "1.6.1"
       }
     },
+    "all-contributors-cli": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/all-contributors-cli/-/all-contributors-cli-4.10.1.tgz",
+      "integrity": "sha512-3gCRCbSovqKahPMa0cyuV6/NNTgcOC6WXGP1k2F3keKyZYyJ6gaMi8MKpO7+/csO31lx3+Azqx9xatubVWNqrA==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "chalk": "2.3.0",
+        "inquirer": "4.0.2",
+        "lodash": "4.17.4",
+        "pify": "3.0.0",
+        "request": "2.83.0",
+        "yargs": "10.0.3"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-4.0.2.tgz",
+          "integrity": "sha512-+f3qDNeZpkhFJ61NBA9jXDrGGhoQuqfEum9A681c9oHoIbGgVqjogKynjB/vNVP+nVu9w3FbFQ35c0ibU0MaIQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.0.0",
+            "chalk": "2.3.0",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.1.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.4",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx-lite": "4.0.8",
+            "rx-lite-aggregates": "4.0.8",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+          "dev": true,
+          "requires": {
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
+    "anchor-markdown-header": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz",
+      "integrity": "sha1-BFBj125qH5zTJ6V6ASaqD97Dcac=",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "6.1.3"
+      }
+    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -346,6 +471,12 @@
         "hoek": "4.2.0"
       }
     },
+    "boundary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
+      "integrity": "sha1-TWfcJgLAzBbdm85+v4fpSCkPWBI=",
+      "dev": true
+    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -536,6 +667,12 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "ccount": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
+      "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok=",
+      "dev": true
+    },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -561,6 +698,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
       "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco=",
+      "dev": true
+    },
+    "character-entities-html4": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
+      "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA=",
       "dev": true
     },
     "character-entities-legacy": {
@@ -589,6 +732,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -988,6 +1132,20 @@
         "randombytes": "2.0.5"
       }
     },
+    "doctoc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/doctoc/-/doctoc-1.3.0.tgz",
+      "integrity": "sha1-fwg5hR3VjICKLK5V2VBOAS0I7jA=",
+      "dev": true,
+      "requires": {
+        "anchor-markdown-header": "0.5.7",
+        "htmlparser2": "3.9.2",
+        "markdown-to-ast": "3.4.0",
+        "minimist": "1.2.0",
+        "underscore": "1.8.3",
+        "update-section": "0.3.3"
+      }
+    },
     "doctrine": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
@@ -997,11 +1155,54 @@
         "esutils": "2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        }
+      }
+    },
     "domain-browser": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz",
+      "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
     },
     "dot-prop": {
       "version": "4.2.0",
@@ -1049,6 +1250,12 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
+    "emoji-regex": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.3.tgz",
+      "integrity": "sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI=",
+      "dev": true
+    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -1066,6 +1273,12 @@
         "object-assign": "4.1.1",
         "tapable": "0.2.8"
       }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "dev": true
     },
     "errno": {
       "version": "0.1.6",
@@ -1567,6 +1780,910 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -1781,6 +2898,20 @@
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.1",
+        "domutils": "1.6.2",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1796,6 +2927,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+      "dev": true
+    },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
       "dev": true
     },
     "iconv-lite": {
@@ -2381,6 +3518,12 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
+    "longest-streak": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
+      "integrity": "sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU=",
+      "dev": true
+    },
     "lowercase-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
@@ -2434,6 +3577,35 @@
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.1.tgz",
       "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg=",
       "dev": true
+    },
+    "markdown-table": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
+      "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE=",
+      "dev": true
+    },
+    "markdown-to-ast": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-to-ast/-/markdown-to-ast-3.4.0.tgz",
+      "integrity": "sha1-Diy6gTkLBUmpFT7DsNkVthwWS+c=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "remark": "5.1.0",
+        "structured-source": "3.0.2",
+        "traverse": "0.6.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "md5.js": {
       "version": "1.3.4",
@@ -2583,6 +3755,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true,
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4887,6 +6066,56 @@
         "rc": "1.2.2"
       }
     },
+    "remark": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-5.1.0.tgz",
+      "integrity": "sha1-y0Y709vLS5l5STXu4c9x16jjBow=",
+      "dev": true,
+      "requires": {
+        "remark-parse": "1.1.0",
+        "remark-stringify": "1.1.0",
+        "unified": "4.2.1"
+      },
+      "dependencies": {
+        "remark-parse": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-1.1.0.tgz",
+          "integrity": "sha1-w8oQ+ajaBGFcKPCapOMEUQUm7CE=",
+          "dev": true,
+          "requires": {
+            "collapse-white-space": "1.0.3",
+            "extend": "3.0.1",
+            "parse-entities": "1.1.1",
+            "repeat-string": "1.6.1",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "1.1.0",
+            "unherit": "1.1.0",
+            "unist-util-remove-position": "1.1.1",
+            "vfile-location": "2.0.2"
+          }
+        },
+        "unified": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-4.2.1.tgz",
+          "integrity": "sha1-dv9Dqo2kMPbn5KVchOusKtLPzS4=",
+          "dev": true,
+          "requires": {
+            "bail": "1.0.2",
+            "extend": "3.0.1",
+            "has": "1.0.1",
+            "once": "1.4.0",
+            "trough": "1.0.1",
+            "vfile": "1.4.0"
+          }
+        },
+        "vfile": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz",
+          "integrity": "sha1-wP1vpIT43r23cfaMMe112I2pf+c=",
+          "dev": true
+        }
+      }
+    },
     "remark-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-3.0.1.tgz",
@@ -4909,6 +6138,22 @@
         "unist-util-remove-position": "1.1.1",
         "vfile-location": "2.0.2",
         "xtend": "4.0.1"
+      }
+    },
+    "remark-stringify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-1.1.0.tgz",
+      "integrity": "sha1-pxBeJbnuK/mkm3XSxCPxGwauIJI=",
+      "dev": true,
+      "requires": {
+        "ccount": "1.0.2",
+        "extend": "3.0.1",
+        "longest-streak": "1.0.0",
+        "markdown-table": "0.4.0",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "stringify-entities": "1.3.1",
+        "unherit": "1.1.0"
       }
     },
     "remove-trailing-separator": {
@@ -5314,6 +6559,18 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "stringify-entities": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
+      "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
+      "dev": true,
+      "requires": {
+        "character-entities-html4": "1.1.1",
+        "character-entities-legacy": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-hexadecimal": "1.0.1"
+      }
+    },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -5354,6 +6611,15 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "structured-source": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
+      "integrity": "sha1-3YAkJeD1PcSm56yjdSkBoczaevU=",
+      "dev": true,
+      "requires": {
+        "boundary": "1.0.1"
+      }
     },
     "supports-color": {
       "version": "4.5.0",
@@ -5581,6 +6847,12 @@
         "punycode": "1.4.1"
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -5713,6 +6985,12 @@
       "integrity": "sha1-7Mo6A+VrmvFzhbqsgSrIO5lKli8=",
       "dev": true
     },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
+    },
     "unherit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
@@ -5799,6 +7077,12 @@
         "semver-diff": "2.1.0",
         "xdg-basedir": "3.0.0"
       }
+    },
+    "update-section": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/update-section/-/update-section-0.3.3.tgz",
+      "integrity": "sha1-RY8Xgg03gg3GDiC4bZQ5GwASMVg=",
+      "dev": true
     },
     "url": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "description": "A collection of well known Monadic Containers for your utter enjoyment.",
   "main": "./index.js",
   "scripts": {
+    "contributors:add": "all-contributors add",
+    "contributors:generate": "all-contributors generate",
     "setup": "./bin/setup",
     "preversion": "npm run build",
     "postpublish": "npm run docs:deploy",
     "build:publish": "npm test && ./bin/publish",
     "build:dist": "webpack && uglifyjs build/dist/crocks.js -c \"warnings=false\" -m -o build/dist/crocks.min.js",
-    "build": "rm -rf build && buble -i src -o build && npm run build:dist",
+    "build": "doctoc && rm -rf build && buble -i src -o build && npm run build:dist",
+    "doctoc": "doctoc README.md",
     "docs:dev": "cd docs && npm start",
     "docs:deploy": "cd docs && npm run docs:deploy",
     "lint": "eslint --ext .md,.js .",
@@ -33,7 +36,7 @@
     "Applicative",
     "Functor"
   ],
-  "author": "Ian Hofmann-Hicks <evilsoft@aol.com> (evil)",
+  "author": "Ian Hofmann-Hicks <evilsoft@aol.com> (https://github.com/evilsoft)",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/evilsoft/crocks/issues"
@@ -52,10 +55,13 @@
     ]
   },
   "devDependencies": {
+    "all-contributors-cli": "^4.10.1",
     "buble": "^0.18.0",
     "coveralls": "^3.0.0",
+    "doctoc": "^1.3.0",
     "eslint": "^4.13.1",
     "eslint-plugin-markdown": "^1.0.0-beta.6",
+    "i": "^0.3.6",
     "nodemon": "^1.9.2",
     "nyc": "^11.4.1",
     "sinon": "^4.1.3",


### PR DESCRIPTION
## Clearing some space for some Collaborator ❤️
![image](https://user-images.githubusercontent.com/3665793/34750761-c2483a4c-f55d-11e7-808c-6c03ac665035.png)

This is another push to make the lib a little less frightening and give credit where credit is due.
Now that we have these docs in play, no need for that horrible, hard to navigate README. And now that the README is cleaned up, we have space for showing what matters most, the people working to make this project a thing.

So this PRs main focus is to implement all-collaborators and provide credit in the npm module for the people who have subbmitted code. All in all this is what this does:
* Add `all-collaborators` and two scripts to manage that. 
* Remove all the documentation from the README and only show usage and install.
* Add a Collaborators section with the output of `all-collaborators`.
* Add a TOC to the main README (and a script for executing it).
* Remove the ignore for the main README lint-ing, we are good now.
* Document the TOC script, (will get to the other two in there later, still thinking that flow through)
* Include new AUTHORS file in the published bits to npm for it's parsing.
* Fix up some copy on the existing docs.
* Only run specs against LTS node versions.
  