### PR TITLE
Accept Array as the Applicative for Traversable Types

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-rm -rf node_modules && npm i
-cd docs && rm -rf node_modules && npm i
+rm -rf node_modules && npm i --no-save
+cd docs && rm -rf node_modules && npm i --no-save
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crocks",
   "version": "0.8.3",
-  "description": "A collection of well known Monadic Containers for your utter enjoyment.",
+  "description": "A collection of well known Algebraic Datatypes for your utter enjoyment.",
   "main": "./index.js",
   "scripts": {
     "contributors:add": "all-contributors add",

--- a/src/Either/Either.spec.js
+++ b/src/Either/Either.spec.js
@@ -807,6 +807,17 @@ test('Either sequence functionality', t => {
   t.equal(l.valueOf().type(), 'Either', 'Provides an inner type of Either')
   t.equal(l.valueOf().either(identity, constant(0)), 'Left', 'Either contains original Left value')
 
+  const arR = Right([ x ]).sequence(x => [ x ])
+  const arL = Left('Left').sequence(x => [ x ])
+
+  t.ok(isSameType(Array, arR), 'Provides an outer type of Array')
+  t.ok(isSameType(Either, arR[0]), 'Provides an inner type of Either')
+  t.equal(arR[0].either(constant(0), identity), x, 'Either contains original inner value')
+
+  t.ok(isSameType(Array, arL), 'Provides an outer type of Array')
+  t.ok(isSameType(Either, arL[0]), 'Provides an inner type of Either')
+  t.equal(arL[0].either(identity, constant(0)), 'Left', 'Either contains original Left value')
+
   t.end()
 })
 
@@ -889,6 +900,18 @@ test('Either traverse functionality', t => {
   t.equal(l.type(), 'MockCrock', 'Provides an outer type of MockCrock')
   t.equal(l.valueOf().type(), 'Either', 'Provides an inner type of Either')
   t.equal(l.valueOf().either(identity, constant(0)), 'Left', 'Either contains original Left value')
+
+  const ar = x => [ x ]
+  const arR = Right(x).traverse(ar, ar)
+  const arL = Left('Left').traverse(ar, ar)
+
+  t.ok(isSameType(Array, arR), 'Provides an outer type of Array')
+  t.ok(isSameType(Either, arR[0]), 'Provides an inner type of Either')
+  t.equal(arR[0].either(constant(0), identity), x, 'Either contains original inner value')
+
+  t.ok(isSameType(Array, arL), 'Provides an outer type of Array')
+  t.ok(isSameType(Either, arL[0]), 'Provides an inner type of Either')
+  t.equal(arL[0].either(identity, constant(0)), 'Left', 'Either contains original Left value')
 
   t.end()
 })

--- a/src/Either/index.js
+++ b/src/Either/index.js
@@ -9,7 +9,8 @@ const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Either')
 
 const compose = require('../core/compose')
-const isApplicative = require('../core/isApplicative')
+const isArray = require('../core/isArray')
+const isApply = require('../core/isApply')
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
 
@@ -30,11 +31,11 @@ const _of =
   Either.Right
 
 function runSequence(x) {
-  if(!isApplicative(x)) {
+  if(!(isApply(x) || isArray(x))) {
     throw new TypeError('Either.sequence: Must wrap an Applicative')
   }
 
-  return x.map(Either.of)
+  return x.map(v => Either.of(v))
 }
 
 function Either(u) {
@@ -180,13 +181,13 @@ function Either(u) {
 
     const m = either(compose(af, Either.Left), f)
 
-    if(!isApplicative(m)) {
+    if(!(isApply(m) || isArray(m))) {
       throw new TypeError('Either.traverse: Both functions must return an Applicative')
     }
 
     return either(
       constant(m),
-      constant(m.map(Either.of))
+      constant(m.map(v => Either.of(v)))
     )
   }
 

--- a/src/Identity/Identity.spec.js
+++ b/src/Identity/Identity.spec.js
@@ -373,12 +373,19 @@ test('Identity sequence errors', t => {
 })
 
 test('Identity sequence functionality', t => {
-  const x = true
+  const x = 97
   const m = Identity(MockCrock(x)).sequence(MockCrock.of)
 
   t.equal(m.type(), 'MockCrock', 'Provides an outer type of MockCrock')
   t.equal(m.valueOf().type(), 'Identity', 'Provides an inner type of Identity')
   t.equal(m.valueOf().valueOf(), x, 'Identity contains original inner value')
+
+  const ar = x => [ x ]
+  const arM = Identity([ x ]).sequence(ar)
+
+  t.ok(isSameType(Array, arM), 'Provides an outer type of Array')
+  t.ok(isSameType(Identity, arM[0]), 'Provides an inner type of Identity')
+  t.equal(arM[0].valueOf(), x, 'Identity contains original inner value')
 
   t.end()
 })
@@ -421,7 +428,6 @@ test('Identity traverse errors', t => {
   t.throws(noApply(false), noAp, 'throws when second argument returns false')
   t.throws(noApply(true), noAp, 'throws when second argument returns true')
   t.throws(noApply({}), noAp, 'throws when second argument returns an object')
-  t.throws(noApply([]), noAp, 'throws when second argument returns an array')
   t.throws(noApply(unit), noAp, 'throws when second argument returns function')
 
   t.doesNotThrow(trav(unit, MockCrock), 'requires an Applicative returning function in second arg and function in first arg')
@@ -437,6 +443,13 @@ test('Identity traverse functionality', t => {
   t.equal(m.type(), 'MockCrock', 'Provides an outer type of MockCrock')
   t.equal(m.valueOf().type(), 'Identity', 'Provides an inner type of Identity')
   t.equal(m.valueOf().valueOf(), x, 'Identity contains original inner value')
+
+  const ar = x => [ x ]
+  const arM = Identity(x).traverse(ar, ar)
+
+  t.ok(isSameType(Array, arM), 'Provides an outer type of Array')
+  t.ok(isSameType(Identity, arM[0]), 'Provides an inner type of Identity')
+  t.equal(arM[0].valueOf(), x, 'Identity contains original inner value')
 
   t.end()
 })

--- a/src/Identity/index.js
+++ b/src/Identity/index.js
@@ -7,7 +7,8 @@ const _innerConcat = require('../core/innerConcat')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Identity')
 
-const isApplicative = require('../core/isApplicative')
+const isArray = require('../core/isArray')
+const isApply = require('../core/isApply')
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
 
@@ -79,11 +80,11 @@ function Identity(x) {
       throw new TypeError('Identity.sequence: Applicative Function required')
     }
 
-    else if(!isApplicative(x)) {
+    else if(!(isApply(x) || isArray(x))) {
       throw new TypeError('Identity.sequence: Must wrap an Applicative')
     }
 
-    return x.map(Identity)
+    return x.map(v => Identity(v))
   }
 
   function traverse(af, f) {
@@ -93,11 +94,11 @@ function Identity(x) {
 
     const m = f(x)
 
-    if(!isApplicative(m)) {
+    if(!(isApply(m) || isArray(m))) {
       throw new TypeError('Identity.traverse: Both functions must return an Applicative')
     }
 
-    return m.map(Identity)
+    return m.map(v => Identity(v))
   }
 
   return {

--- a/src/Result/Result.spec.js
+++ b/src/Result/Result.spec.js
@@ -818,12 +818,24 @@ test('Result sequence functionality', t => {
   const e = Err('Err').sequence(MockCrock.of)
 
   t.ok(isSameType(MockCrock, o), 'Provides an outer type of MockCrock')
-  t.ok(isSameType(Result, o.valueOf()), 'Provides an outer type of MockCrock')
+  t.ok(isSameType(Result, o.valueOf()), 'Provides an inner type of Result')
   t.equal(o.valueOf().either(constant(0), identity), x, 'Result contains original inner value')
 
   t.ok(isSameType(MockCrock, e), 'Provides an outer type of MockCrock')
   t.ok(isSameType(Result, e.valueOf()), 'Provides an inner type of Result')
   t.equal(e.valueOf().either(identity, constant(0)), 'Err', 'Result contains original Err value')
+
+  const ar = x => [ x ]
+  const arO = Ok([ x ]).sequence(ar)
+  const arE = Err('Err').sequence(ar)
+
+  t.ok(isSameType(Array, arO), 'Provides an outer type of Array')
+  t.ok(isSameType(Result, arO[0]), 'Provides an inner type of Result')
+  t.equal(arO[0].either(constant(0), identity), x, 'Result contains original inner value')
+
+  t.ok(isSameType(Array, arE), 'Provides an outer type of Array')
+  t.ok(isSameType(Result, arE[0]), 'Provides an inner type of Result')
+  t.equal(arE[0].either(identity, constant(0)), 'Err', 'Result contains original Err value')
 
   t.end()
 })
@@ -903,6 +915,18 @@ test('Result traverse functionality', t => {
   t.ok(isSameType(MockCrock, l), 'Provides an outer type of MockCrock')
   t.ok(isSameType(Result, l.valueOf()), 'Provides an inner type of Result')
   t.equal(l.valueOf().either(identity, constant(0)), 'Err', 'Result contains original Err value')
+
+  const ar = x => [ x ]
+  const arO = Ok(x).traverse(ar, ar)
+  const arE = Err('Err').traverse(ar, ar)
+
+  t.ok(isSameType(Array, arO), 'Provides an outer type of Array')
+  t.ok(isSameType(Result, arO[0]), 'Provides an inner type of Result')
+  t.equal(arO[0].either(constant(0), identity), x, 'Result contains original inner value')
+
+  t.ok(isSameType(Array, arE), 'Provides an outer type of Array')
+  t.ok(isSameType(Result, arE[0]), 'Provides an inner type of Result')
+  t.equal(arE[0].either(identity, constant(0)), 'Err', 'Result contains original Err value')
 
   t.end()
 })

--- a/src/Result/index.js
+++ b/src/Result/index.js
@@ -9,7 +9,8 @@ const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Result')
 
 const compose = require('../core/compose')
-const isApplicative = require('../core/isApplicative')
+const isApply = require('../core/isApply')
+const isArray = require('../core/isArray')
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
 const isSemigroup = require('../core/isSemigroup')
@@ -38,11 +39,11 @@ const concatAltErr =
   r => l => Result.Err(isSemigroup(r) && isSameType(l, r) ? l.concat(r) : r)
 
 function runSequence(x) {
-  if(!isApplicative(x)) {
+  if(!(isApply(x) || isArray(x))) {
     throw new TypeError('Result.sequence: Must wrap an Applicative')
   }
 
-  return x.map(Result.of)
+  return x.map(v => Result.of(v))
 }
 
 function Result(u) {
@@ -190,13 +191,13 @@ function Result(u) {
 
     const m = either(compose(af, Result.Err), f)
 
-    if(!isApplicative(m)) {
+    if(!(isApply(m) || isArray(m))) {
       throw new TypeError('Result.traverse: Both functions must return an Applicative')
     }
 
     return either(
       constant(m),
-      constant(m.map(Result.Ok))
+      constant(m.map(v => Result.Ok(v)))
     )
   }
 

--- a/src/core/List.spec.js
+++ b/src/core/List.spec.js
@@ -9,6 +9,7 @@ const curry = require('./curry')
 const _compose = curry(require('./compose'))
 const isFunction = require('./isFunction')
 const isObject = require('./isObject')
+const isSameType = require('./isSameType')
 const unit = require('./_unit')
 
 const Maybe = require('./Maybe')
@@ -611,6 +612,14 @@ test('List sequence functionality', t => {
   t.equal(m.type(), 'MockCrock', 'Provides an outer type of MockCrock')
   t.equal(m.valueOf().type(), 'List', 'Provides an inner type of List')
   t.same(m.valueOf().valueOf(), [ x ], 'inner List contains original inner value')
+
+  const ar = x => [ x ]
+  const arM = List.of([ x ]).sequence(ar)
+
+  t.ok(isSameType(Array, arM), 'Provides an outer type of Array')
+  t.ok(isSameType(List, arM[0]), 'Provides an inner type of List')
+  t.same(arM[0].valueOf(), [ x ], 'inner List contains original inner value')
+
   t.end()
 })
 
@@ -657,5 +666,13 @@ test('List traverse functionality', t => {
   t.equal(m.type(), 'MockCrock', 'Provides an outer type of MockCrock')
   t.equal(m.valueOf().type(), 'List', 'Provides an inner type of List')
   t.same(m.valueOf().valueOf(), [ x ], 'inner List contains original inner value')
+
+  const ar = x => [ x ]
+  const arM = List.of(x).traverse(ar, ar)
+
+  t.ok(isSameType(Array, arM), 'Provides an outer type of Array')
+  t.ok(isSameType(List, arM[0]), 'Provides an inner type of List')
+  t.same(arM[0].valueOf(), [ x ], 'inner List contains original inner value')
+
   t.end()
 })

--- a/src/core/Maybe.js
+++ b/src/core/Maybe.js
@@ -9,7 +9,8 @@ const _inspect = require('./inspect')
 const type = require('./types').type('Maybe')
 
 const compose = require('./compose')
-const isApplicative = require('./isApplicative')
+const isApply = require('./isApply')
+const isArray = require('./isArray')
 const isFunction = require('./isFunction')
 const isSameType = require('./isSameType')
 
@@ -38,11 +39,11 @@ const _zero =
   compose(Maybe, Nothing)
 
 function runSequence(x) {
-  if(!isApplicative(x)) {
+  if(!(isApply(x) || isArray(x))) {
     throw new TypeError('Maybe.sequence: Must wrap an Applicative')
   }
 
-  return x.map(Maybe.of)
+  return x.map(v => Maybe.of(v))
 }
 
 function Maybe(u) {
@@ -175,13 +176,13 @@ function Maybe(u) {
 
     const m = either(compose(af, Maybe.Nothing), f)
 
-    if(!isApplicative(m)) {
+    if(!(isApply(m) || isArray(m))) {
       throw new TypeError('Maybe.traverse: Both functions must return an Applicative')
     }
 
     return either(
       constant(m),
-      constant(m.map(Maybe))
+      constant(m.map(v => Maybe(v)))
     )
   }
 

--- a/src/core/Maybe.spec.js
+++ b/src/core/Maybe.spec.js
@@ -599,7 +599,8 @@ test('Maybe sequence errors', t => {
 })
 
 test('Maybe sequence functionality', t => {
-  const x = [ 'a' ]
+  const x = 97
+
   const s = Maybe.Just(MockCrock(x)).sequence(MockCrock.of)
   const n = Maybe.Nothing().sequence(MockCrock.of)
 
@@ -610,6 +611,18 @@ test('Maybe sequence functionality', t => {
   t.equal(n.type(), 'MockCrock', 'Provides an outer type of MockCrock')
   t.equal(n.valueOf().type(), 'Maybe', 'Provides an inner type of Maybe')
   t.equal(n.valueOf().option('Nothing'), 'Nothing', 'Reports as a Nothing')
+
+  const ar = x => [ x ]
+  const arS = Maybe.Just([ x ]).sequence(ar)
+  const arN = Maybe.Nothing().sequence(ar)
+
+  t.ok(isSameType(Array, arS), 'Provides an outer type of Array')
+  t.ok(isSameType(Maybe, arS[0]), 'Provides an inner type of Maybe')
+  t.same(arS[0].option('Nothing'), x, 'Maybe contains original inner value')
+
+  t.ok(isSameType(Array, arN), 'Provides an outer type of MockCrock')
+  t.ok(isSameType(Maybe, arN[0]), 'Provides an inner type of Maybe')
+  t.equal(arN[0].option('Nothing'), 'Nothing', 'Reports as a Nothing')
 
   t.end()
 })
@@ -689,6 +702,18 @@ test('Maybe traverse functionality', t => {
   t.equal(l.type(), 'MockCrock', 'Provides an outer type of MockCrock')
   t.equal(l.valueOf().type(), 'Maybe', 'Provides an inner type of Maybe')
   t.equal(l.valueOf().option('Nothing'), 'Nothing', 'Maybe is a Nothing')
+
+  const ar = x => [ x ]
+  const arS = Maybe.Just(x).traverse(ar, ar)
+  const arN = Maybe.Nothing().traverse(ar, ar)
+
+  t.ok(isSameType(Array, arS), 'Provides an outer type of Array')
+  t.ok(isSameType(Maybe, arS[0]), 'Provides an inner type of Maybe')
+  t.same(arS[0].option('Nothing'), x, 'Maybe contains original inner value')
+
+  t.ok(isSameType(Array, arN), 'Provides an outer type of MockCrock')
+  t.ok(isSameType(Maybe, arN[0]), 'Provides an inner type of Maybe')
+  t.equal(arN[0].option('Nothing'), 'Nothing', 'Reports as a Nothing')
 
   t.end()
 })

--- a/src/core/array.js
+++ b/src/core/array.js
@@ -1,9 +1,10 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const isApplicative = require('./isApplicative')
+const isApply = require('./isApply')
 const isArray = require('./isArray')
 const isFunction = require('./isFunction')
+const isSameType = require('./isSameType')
 
 const identity = x => x
 
@@ -14,8 +15,12 @@ function runTraverse(name, fn) {
   return function(acc, x) {
     const m = fn(x)
 
-    if(!isApplicative(acc) || !isApplicative(m)) {
+    if(!((isApply(acc) || isArray(acc)) && isSameType(acc, m))) {
       throw new TypeError(`Array.${name}: Must wrap Applicatives`)
+    }
+
+    if(isArray(m)) {
+      return ap(acc, map(v => concat([ v ]), m))
     }
 
     return m

--- a/src/core/array.spec.js
+++ b/src/core/array.spec.js
@@ -1,16 +1,20 @@
 const test = require('tape')
 const helpers = require('../test/helpers')
+const MockCrock = require('../test/MockCrock')
 
 const bindFunc = helpers.bindFunc
 
 const curry = require('./curry')
 const compose = curry(require('./compose'))
+const isSameType = require('./isSameType')
 
 const array = require('./array')
 
 const map = array.map
 const ap = array.ap
 const chain = array.chain
+const sequence = array.sequence
+const traverse = array.traverse
 
 const constant = x => () => x
 const identity = x => x
@@ -121,6 +125,74 @@ test('array chain functionality', t => {
 
   t.same(chain(f, [ 1, 2 ]), [ 1, 2, 2, 3 ], 'chains as expected with elements')
   t.same(chain(f, []), [], 'chain on empty array, returns an empty array')
+
+  t.end()
+})
+
+test('array sequence errors', t => {
+  const seq = bindFunc(x => sequence(MockCrock.of, [ x ]))
+
+  const err = /Array.sequence: Must wrap Applicatives/
+  t.throws(seq(undefined), err, 'throws with undefined')
+  t.throws(seq(null), err, 'throws with null')
+  t.throws(seq(0), err, 'throws falsey with number')
+  t.throws(seq(1), err, 'throws truthy with number')
+  t.throws(seq(''), err, 'throws falsey with string')
+  t.throws(seq('string'), err, 'throws with truthy string')
+  t.throws(seq(false), err, 'throws with false')
+  t.throws(seq(true), err, 'throws with true')
+  t.throws(seq([]), err, 'throws with an array')
+  t.throws(seq({}), err, 'throws with an object')
+
+  t.doesNotThrow(seq(MockCrock(2)), 'allows an Applicative returning function')
+
+  t.end()
+})
+
+test('array sequence functionality', t => {
+  const x = 'string'
+  const m = sequence(MockCrock.of, [ MockCrock(x) ])
+
+  t.ok(isSameType(MockCrock, m), 'Provides an outer type of MockCrock')
+  t.ok(isSameType(Array, m.valueOf()), 'Provides an inner type of array')
+  t.same(m.valueOf()[0], x, 'inner List contains original inner value')
+
+  const ar = x => [ x ]
+  const arM = sequence(ar, [ [ x ] ])
+
+  t.ok(isSameType(Array, arM), 'Provides an outer type of Array')
+  t.ok(isSameType(Array, arM[0]), 'Provides an inner type of Array')
+  t.same(arM[0][0], x, 'inner array contains original inner value')
+
+  t.end()
+})
+
+test('array traverse errors', t => {
+  const trav = bindFunc((af, fn, x) => traverse(af, fn, [ x ]))
+
+  const noAppl = /Array.traverse: Must wrap Applicatives/
+  t.throws(trav(constant(undefined), MockCrock, 2), noAppl, 'throws when first function returns non-applicative')
+  t.throws(trav(MockCrock, constant([ 99 ]), 2), noAppl, 'throws when second function returns a different type')
+
+  t.doesNotThrow(trav(MockCrock, MockCrock, 2), 'allows Applicative returning functions')
+
+  t.end()
+})
+
+test('List traverse functionality', t => {
+  const x = 'string'
+  const m = traverse(MockCrock.of, MockCrock, [ x ])
+
+  t.ok(isSameType(MockCrock, m), 'Provides an outer type of MockCrock')
+  t.ok(isSameType(Array, m.valueOf), 'Provides an inner type of Array')
+  t.same(m.valueOf()[0], x, 'inner array contains original inner value')
+
+  const ar = x => [ x ]
+  const arM = traverse(ar, ar, [ x ])
+
+  t.ok(isSameType(Array, arM), 'Provides an outer type of Array')
+  t.ok(isSameType(Array, arM[0]), 'Provides an inner type of Array')
+  t.same(arM[0][0], x, 'inner array contains original inner value')
 
   t.end()
 })


### PR DESCRIPTION
## Traverse the path less traveled
![image](https://user-images.githubusercontent.com/3665793/34902511-aea541e4-f7d1-11e7-8283-90cf8a2574b5.png)

Noticed that we were not accepting `Array` for traversable types while it was a valid Applicative. This PR addresses [this issue](https://github.com/evilsoft/crocks/issues/181) and allows for `Array`s as the Applicative for the following types:
* `Array`
* `Either`
* `Identity`
* `List`
* `Maybe`
* `Result`