### PR TITLE
Clean up heading on existing READMEs

### DIFF
--- a/docs/src/pages/docs/monoids/All.md
+++ b/docs/src/pages/docs/monoids/All.md
@@ -9,7 +9,7 @@ weight: 10
 All Boolean
 ```
 
-`All` is a `Monoid` that will combine two values of any type using logical
+`All` is a `Monoid` that will combine (2) values of any type using logical
 conjunction (AND) on their coerced `Boolean` values, mapping truth-y values to
 `true` and false-y values to `false`.
 
@@ -109,7 +109,7 @@ All ~> All -> All
 ```
 
 `concat` is used to combine (2) `Semigroup`s of the same type under an operation
-specified by the `Semigroup`. In the case of `All`, it will combine the two
+specified by the `Semigroup`. In the case of `All`, it will combine the (2)
 using logical AND (conjunction).
 
 ```javascript
@@ -136,7 +136,7 @@ will result in the underlying `Boolean` value.
 ```javascript
 const All = require('crocks/All')
 
-All(0).value()          //=> false
+All(0).valueOf()          //=> false
 All('string').valueOf() //=> true
 
 //=> false

--- a/docs/src/pages/docs/monoids/Any.md
+++ b/docs/src/pages/docs/monoids/Any.md
@@ -9,7 +9,7 @@ weight: 20
 Any Boolean
 ```
 
-`Any` is a `Monoid` that will combine two values of any type using logical
+`Any` is a `Monoid` that will combine (2) values of any type using logical
 disjunction (OR) on their coerced `Boolean` values, mapping truth-y values to
 `true` and false-y values to `false`.
 
@@ -114,7 +114,7 @@ Any ~> Any -> Any
 ```
 
 `concat` is used to combine (2) `Semigroup`s of the same type under an operation
-specified by the `Semigroup`. In the case of `Any`, it will combine the two
+specified by the `Semigroup`. In the case of `Any`, it will combine the (2)
 using logical OR (disjunction).
 
 ```javascript
@@ -135,7 +135,7 @@ Any ~> () -> Boolean
 `valueOf` is used on all `crocks` `Monoid`s as a means of extraction. While the
 extraction is available, types that implement `valueOf` are not necessarily a
 `Comonad`. This function is used primarily for convenience for some of the
-helper functions that ship with `crocks`. Calling `value` on an `Any` instance
+helper functions that ship with `crocks`. Calling `valueOf` on an `Any` instance
 will result in the underlying `Boolean` value.
 
 ```javascript

--- a/src/All/README.md
+++ b/src/All/README.md
@@ -4,7 +4,7 @@
 All Boolean
 ```
 
-`All` is a `Monoid` that will combine two values of any type using logical
+`All` is a `Monoid` that will combine (2) values of any type using logical
 conjunction (AND) on their coerced `Boolean` values, mapping truth-y values to
 `true` and false-y values to `false`.
 
@@ -39,7 +39,7 @@ allGood([ 'nice', '00', null ])
 
 ## Constructor Methods
 
-### empty
+#### empty
 
 ```haskell
 All.empty :: () -> All
@@ -59,8 +59,7 @@ All(true).concat(All.empty())   //=> All true
 All(false).concat(All.empty())  //=> All false
 ```
 
-
-### type
+#### type
 
 ```haskell
 All.type :: () -> String
@@ -90,14 +89,14 @@ isSameType(All(false), Maybe)     //=> false
 
 ## Instance Methods
 
-### concat
+#### concat
 
 ```haskell
 All ~> All -> All
 ```
 
 `concat` is used to combine (2) `Semigroup`s of the same type under an operation
-specified by the `Semigroup`. In the case of `All`, it will combine the two
+specified by the `Semigroup`. In the case of `All`, it will combine the (2)
 using logical AND (conjunction).
 
 ```javascript
@@ -109,7 +108,7 @@ All(false).concat(All(true))  //=> All false
 All(false).concat(All(false)) //=> All false
 ```
 
-### valueOf
+#### valueOf
 
 ```haskell
 All ~> () -> Boolean
@@ -124,7 +123,7 @@ will result in the underlying `Boolean` value.
 ```javascript
 const All = require('crocks/All')
 
-All(0).value()          //=> false
+All(0).valueOf()          //=> false
 All('string').valueOf() //=> true
 
 //=> false

--- a/src/Any/README.md
+++ b/src/Any/README.md
@@ -4,7 +4,7 @@
 Any Boolean
 ```
 
-`Any` is a `Monoid` that will combine two values of any type using logical
+`Any` is a `Monoid` that will combine (2) values of any type using logical
 disjunction (OR) on their coerced `Boolean` values, mapping truth-y values to
 `true` and false-y values to `false`.
 
@@ -40,7 +40,7 @@ anyNumber([ true, 'string' ])
 
 ## Constructor Methods
 
-### empty
+#### empty
 
 ```haskell
 Any.empty :: () -> Any
@@ -61,7 +61,7 @@ Any(false).concat(Any.empty())  //=> Any false
 ```
 
 
-### type
+#### type
 
 ```haskell
 Any.type :: () -> String
@@ -93,14 +93,14 @@ isSameType(Any, Assign({ food: 'always' }))
 
 ## Instance Methods
 
-### concat
+#### concat
 
 ```haskell
 Any ~> Any -> Any
 ```
 
 `concat` is used to combine (2) `Semigroup`s of the same type under an operation
-specified by the `Semigroup`. In the case of `Any`, it will combine the two
+specified by the `Semigroup`. In the case of `Any`, it will combine the (2)
 using logical OR (disjunction).
 
 ```javascript
@@ -112,7 +112,7 @@ Any(false).concat(Any(true))  //=> Any true
 Any(false).concat(Any(false)) //=> Any false
 ```
 
-### valueOf
+#### valueOf
 
 ```haskell
 Any ~> () -> Boolean
@@ -121,7 +121,7 @@ Any ~> () -> Boolean
 `valueOf` is used on all `crocks` `Monoid`s as a means of extraction. While the
 extraction is available, types that implement `valueOf` are not necessarily a
 `Comonad`. This function is used primarily for convenience for some of the
-helper functions that ship with `crocks`. Calling `value` on an `Any` instance
+helper functions that ship with `crocks`. Calling `valueOf` on an `Any` instance
 will result in the underlying `Boolean` value.
 
 ```javascript

--- a/src/Arrow/README.md
+++ b/src/Arrow/README.md
@@ -62,7 +62,7 @@ arrUpperName
 
 ## Constructor Methods
 
-### id
+#### id
 
 ```haskell
 Arrow.id :: () -> Arrow a
@@ -96,7 +96,7 @@ right.runWith(12) //=> '12'
 left.runWith(12)  //=> '12'
 ```
 
-### type
+#### type
 
 ```haskell
 Arrow.type :: () -> String
@@ -127,7 +127,7 @@ isSameType(Arrow(I), Identity)        //=> false
 
 ## Instance Methods
 
-### both
+#### both
 
 ```haskell
 Pair p => Arrow a b ~> () -> Arrow (p a a) (p b b)
@@ -169,7 +169,7 @@ arrDoubleAndAdd
   .runWith(Pair(200, 10))  //=> 420
 ```
 
-### compose
+#### compose
 
 ```haskell
 Arrow a b ~> Arrow b c -> Arrow a c
@@ -219,7 +219,7 @@ arrEvenCount
 //=> 3
 ```
 
-### contramap
+#### contramap
 
 ```haskell
 Arrow a b ~> (c -> a) -> Arrow c b
@@ -273,7 +273,7 @@ arrAdd10Value
 //=> 10
 ```
 
-### first
+#### first
 
 ```haskell
 Pair p => Arrow a b ~> () -> Arrow (p a c) (p b c)
@@ -313,7 +313,7 @@ flow
 //=> { original: 'taco time', result: 'TACO TIME' }
 ```
 
-### map
+#### map
 
 ```haskell
 Arrow a b ~> (b -> c) -> Arrow a c
@@ -355,7 +355,7 @@ arrStringFS
 //=> '-9.12 dbFS'
 ```
 
-### promap
+#### promap
 
 ```haskell
 Arrow a b ~> ((c -> a), (b -> d)) -> Arrow c d
@@ -412,7 +412,7 @@ arrTitleObject
 // { title: '' }
 ```
 
-### runWith
+#### runWith
 
 ```haskell
 Arrow a b ~> a -> b
@@ -461,7 +461,7 @@ arrAvgList
 //=> 54.25
 ```
 
-### second
+#### second
 
 ```haskell
 Pair p => Arrow a b ~> () -> Arrow (p c a) (p c b)

--- a/src/Assign/README.md
+++ b/src/Assign/README.md
@@ -24,7 +24,7 @@ Assign(first)
 
 ## Constructor Methods
 
-### empty
+#### empty
 
 ```haskell
 Assign.empty :: () -> Assign
@@ -50,7 +50,7 @@ Assign({ a: 1 })
 //=> Assign { a: 1 }
 ```
 
-### type
+#### type
 
 ```haskell
 Assign.type :: () -> String
@@ -88,7 +88,7 @@ isSameType(Assign, myData)
 
 ## Instance Methods
 
-### concat
+#### concat
 
 ```haskell
 Assign ~> Assign -> Assign
@@ -119,7 +119,7 @@ Assign({ b: 4 })
 //=> Assign { b: 4, a: 1 }
 ```
 
-### valueOf
+#### valueOf
 
 ```haskell
 Assign ~> () -> Object

--- a/src/Equiv/README.md
+++ b/src/Equiv/README.md
@@ -52,7 +52,7 @@ eq.contramap(length)
 
 ## Constructor Methods
 
-### empty
+#### empty
 
 ```haskell
 Equiv.empty :: () -> Equiv a a
@@ -91,7 +91,7 @@ empty
 //=> false
 ```
 
-### type
+#### type
 
 ```haskell
 Equiv.type :: () -> String
@@ -122,7 +122,7 @@ isSameType(Equiv(equals), Endo)     //=> false
 
 ## Instance Methods
 
-### concat
+#### concat
 
 ```haskell
 Equiv a a ~> Equiv a a -> Equiv a a
@@ -188,7 +188,7 @@ run(
 // false
 ```
 
-### contramap
+#### contramap
 
 ```haskell
 Equiv a a ~> (b -> a) -> Equiv b b
@@ -242,7 +242,7 @@ sameLength
 //=> false
 ```
 
-### valueOf
+#### valueOf
 
 ```haskell
 Equiv a a ~> () -> a -> a -> Boolean
@@ -302,7 +302,7 @@ test(
 //=> true
 ```
 
-### compareWith
+#### compareWith
 
 ```haskell
 Equiv a a ~> a -> a -> Boolean

--- a/src/Pred/README.md
+++ b/src/Pred/README.md
@@ -72,7 +72,7 @@ filter(largeNumber, [ 200, 375, 15 ])
 
 ## Constructor Methods
 
-### empty
+#### empty
 
 ```haskell
 Pred.empty :: () -> Pred a
@@ -123,7 +123,7 @@ empty
 //=> true
 ```
 
-### type
+#### type
 
 ```haskell
 Pred.type :: () -> String
@@ -154,7 +154,7 @@ isSameType(Pred(isNil), Maybe)   //=> false
 
 ## Instance Methods
 
-### concat
+#### concat
 
 ```haskell
 Pred a ~> Pred a -> Pred a
@@ -232,7 +232,7 @@ filter(isValid, data)
 //=> [ 4, 12, 19, 32, 76, 7 ]
 ```
 
-### contramap
+#### contramap
 
 ```haskell
 Pred a ~> (b -> a) -> Pred b
@@ -290,7 +290,7 @@ validItemLength
 //=> true
 ```
 
-### valueOf
+#### valueOf
 
 ```haskell
 Pred a ~> () -> a -> Boolean
@@ -347,7 +347,7 @@ fn([])            // false
 fn('')            // false
 ```
 
-### runWith
+#### runWith
 
 ```haskell
 Pred a ~> a -> Boolean

--- a/src/Prod/README.md
+++ b/src/Prod/README.md
@@ -40,7 +40,7 @@ double(11)
 
 ## Constructor Methods
 
-### empty
+#### empty
 
 ```haskell
 Prod.empty :: () -> Prod
@@ -70,7 +70,7 @@ Prod.empty()
 //=> Prod 4
 ```
 
-### type
+#### type
 
 ```haskell
 Prod.type :: () -> String
@@ -106,7 +106,7 @@ isSameType(Prod.empty(), prod5)
 
 ## Instance Methods
 
-### concat
+#### concat
 
 ```haskell
 Prod ~> Prod -> Prod
@@ -136,7 +136,7 @@ Prod.empty()
 //=> Prod 3
 ```
 
-### valueOf
+#### valueOf
 
 ```haskell
 Prod ~> () -> Number

--- a/src/Reader/README.md
+++ b/src/Reader/README.md
@@ -53,7 +53,7 @@ flow
 
 ## Constructor Methods
 
-### ask
+#### ask
 
 ```haskell
 Reader.ask :: () -> Reader e e
@@ -90,7 +90,7 @@ ask(add(10))
 //=> 66
 ```
 
-### of
+#### of
 
 ```haskell
 Reader.of :: a -> Reader e a
@@ -128,7 +128,7 @@ Reader.of(57)
 //=> 100
 ```
 
-### type
+#### type
 
 ```haskell
 Reader.type :: () -> String
@@ -159,7 +159,7 @@ isSameType(Reader(I), Identity)     //=> false
 
 ## Instance Methods
 
-### map
+#### map
 
 ```haskell
 Reader e a ~> (a -> b) -> Reader e b
@@ -208,7 +208,7 @@ Reader.of({ num: 27 })
 //=> { length: 3, num: 27 }
 ```
 
-### ap
+#### ap
 
 ```haskell
 Reader e (a -> b) ~> Reader e a -> Reader e b
@@ -271,7 +271,7 @@ liftAssign(first, last)
 //=> { full: 'Tom Jennings', first: 'Tom', last: 'Jennings' }
 ```
 
-### chain
+#### chain
 
 ```haskell
 Reader e a ~> (a -> Reader e b) -> Reader e b
@@ -335,7 +335,7 @@ applyTransform(45)
 //=> 130
 ```
 
-### runWith
+#### runWith
 
 ```haskell
 Reader e a ~> e -> a
@@ -783,7 +783,7 @@ getLastName
 //=> Nothing
 ```
 
-### runWith
+#### runWith
 
 ```haskell
 Monad m => ReaderT e (m a) ~> e -> m a

--- a/src/State/README.md
+++ b/src/State/README.md
@@ -77,7 +77,7 @@ get(toUpper)
 
 ## Constructor Methods
 
-### get
+#### get
 
 ```haskell
 State.get :: () -> State s s
@@ -130,7 +130,7 @@ get()
 //=> Pair(0, { string: '47'})
 ```
 
-### modify
+#### modify
 
 ```haskell
 State.modify :: (s -> s) -> State s ()
@@ -173,7 +173,7 @@ addValue(5)
 //=> {}
 ```
 
-### put
+#### put
 
 ```haskell
 State.put :: s -> State s ()
@@ -224,7 +224,7 @@ heckYeah
 // Pair((), '')
 ```
 
-### of
+#### of
 
 ```haskell
 State.of :: a -> State s a
@@ -256,7 +256,7 @@ State.of('hotness')
 //=> Pair('crusty', 'hotness')
 ```
 
-### type
+#### type
 
 ```haskell
 State.type :: () -> String
@@ -287,7 +287,7 @@ isSameType(State.of(false), Reader)   //=> false
 
 ## Instance Methods
 
-### map
+#### map
 
 ```haskell
 State s a ~> (a -> b) -> State s b
@@ -346,7 +346,7 @@ getNum
 //=> { result: 42 }
 ```
 
-### ap
+#### ap
 
 ```haskell
 State s (a -> b) ~> State s a -> State s b
@@ -415,7 +415,7 @@ applyTax
 //=> { tax: 0.084, sub: 34.07, total: 37.91 }
 ```
 
-### chain
+#### chain
 
 ```haskell
 State s a ~> (a -> State s b) -> State s b
@@ -468,7 +468,7 @@ add(10)
 //=> 1600
 ```
 
-### runWith
+#### runWith
 
 ```haskell
 State s a ~> s -> Pair a s
@@ -505,7 +505,7 @@ update(45)
 //=> Pair(100, 45)
 ```
 
-### evalWith
+#### evalWith
 
 ```haskell
 State s a ~> s -> a
@@ -559,7 +559,7 @@ combineNames
 //=> [ 'Franklin', 'Jennings' ]
 ```
 
-### execWith
+#### execWith
 
 ```haskell
 State s a ~> s -> s
@@ -601,7 +601,7 @@ yell
 Pointfree Functions
 ---
 
-### evalWith *(pointfree)*
+#### evalWith *(pointfree)*
 
 ```haskell
 evalWith :: s -> State s a -> a
@@ -646,7 +646,7 @@ add(1295, 42)
 // 1337
 ```
 
-### execWith *(pointfree)*
+#### execWith *(pointfree)*
 
 ```haskell
 execWith :: s -> State s a -> s

--- a/src/Sum/README.md
+++ b/src/Sum/README.md
@@ -35,7 +35,7 @@ sumByTen([ 2, 2 ])
 
 ## Constructor Methods
 
-### empty
+#### empty
 
 ```haskell
 Sum.empty :: () -> Sum
@@ -64,7 +64,7 @@ Sum.empty()
 //=> Sum 4
 ```
 
-### type
+#### type
 
 ```haskell
 Sum.type :: () -> String
@@ -100,7 +100,7 @@ isSameType(Sum.empty(), sum5)
 
 ## Instance Methods
 
-### concat
+#### concat
 
 ```haskell
 Sum ~> Sum -> Sum
@@ -130,7 +130,7 @@ Sum(1)
 //=> Sum 4
 ```
 
-### valueOf
+#### valueOf
 
 ```haskell
 Sum ~> () -> Number


### PR DESCRIPTION
## A Janitors Job is never done
![image](https://user-images.githubusercontent.com/3665793/34961020-3428ceea-f9f2-11e7-9f1c-6485bb2ec6f1.png)

This PR cleans up the section headings to make it easier to keep the READMEs in sync with the documentation on dem git pages. Need to get :corn:sistant with how these docs should be styled as more people want to contribute time on the docs.