### PR TITLE
Add `toString` to all ADTs for those without `inspect`

### DIFF
--- a/src/All/All.spec.js
+++ b/src/All/All.spec.js
@@ -53,6 +53,7 @@ test('All inspect', t => {
   const m = All(0)
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'All false', 'returns inspect string')
 
   t.end()

--- a/src/All/index.js
+++ b/src/All/index.js
@@ -37,8 +37,8 @@ function All(b) {
   }
 
   return {
-    inspect, valueOf,
-    type, concat, empty,
+    inspect, toString: inspect,
+    valueOf, type, concat, empty,
     constructor: All
   }
 }

--- a/src/Any/Any.spec.js
+++ b/src/Any/Any.spec.js
@@ -53,6 +53,7 @@ test('Any inspect', t => {
   const m = Any(1)
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Any true', 'returns inspect string')
 
   t.end()

--- a/src/Any/index.js
+++ b/src/Any/index.js
@@ -37,8 +37,8 @@ function Any(b) {
   }
 
   return {
-    inspect, valueOf, type,
-    concat, empty,
+    inspect, toString: inspect,
+    valueOf, type, concat, empty,
     constructor: Any
   }
 }

--- a/src/Arrow/Arrow.spec.js
+++ b/src/Arrow/Arrow.spec.js
@@ -64,6 +64,7 @@ test('Arrow inspect', t => {
   const a = Arrow(unit)
 
   t.ok(isFunction(a.inspect), 'provides an inspect function')
+  t.equal(a.inspect, a.toString, 'toString is the same function as inspect')
   t.equal(a.inspect(), 'Arrow Function', 'returns inspect string')
 
   t.end()

--- a/src/Arrow/index.js
+++ b/src/Arrow/index.js
@@ -85,8 +85,8 @@ function Arrow(runWith) {
   }
 
   return {
-    inspect, type, runWith,
-    id, compose, map, contramap,
+    inspect, toString: inspect, type,
+    runWith, id, compose, map, contramap,
     promap, first, second, both,
     constructor: Arrow
   }

--- a/src/Assign/Assign.spec.js
+++ b/src/Assign/Assign.spec.js
@@ -52,6 +52,7 @@ test('Assign inspect', t => {
   const m = Assign({ great: true })
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Assign {}', 'returns inspect string')
 
   t.end()

--- a/src/Assign/index.js
+++ b/src/Assign/index.js
@@ -38,8 +38,8 @@ function Assign(o) {
   }
 
   return {
-    inspect, valueOf,
-    type, concat, empty,
+    inspect, toString: inspect,
+    valueOf, type, concat, empty,
     constructor: Assign
   }
 }

--- a/src/Async/Async.spec.js
+++ b/src/Async/Async.spec.js
@@ -248,6 +248,7 @@ test('Async inspect', t => {
   const a = Async(unit)
 
   t.ok(isFunction(a.inspect), 'provides an inspect function')
+  t.equal(a.inspect, a.toString, 'toString is the same function as inspect')
   t.equals(a.inspect(), 'Async Function', 'returns the expected result')
 
   t.end()

--- a/src/Async/index.js
+++ b/src/Async/index.js
@@ -236,9 +236,10 @@ function Async(fn, parentCancel) {
   }
 
   return {
-    fork, toPromise, inspect, type,
-    swap, coalesce, map, bimap, alt,
-    ap, chain, of,
+    fork, toPromise, inspect,
+    toString: inspect, type,
+    swap, coalesce, map, bimap,
+    alt, ap, chain, of,
     constructor: Async
   }
 }

--- a/src/Const/Const.spec.js
+++ b/src/Const/Const.spec.js
@@ -46,6 +46,7 @@ test('Const inspect', t => {
   const m = Const(0)
 
   t.ok(isFunction(m.inspect), 'provides an inpsect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Const 0', 'returns inspect string')
 
   t.end()

--- a/src/Const/index.js
+++ b/src/Const/index.js
@@ -57,8 +57,8 @@ function Const(x) {
   }
 
   return {
-    inspect, valueOf, type, equals,
-    concat, map, ap, chain,
+    inspect, toString: inspect, valueOf,
+    type, equals, concat, map, ap, chain,
     constructor: Const
   }
 }

--- a/src/Either/Either.spec.js
+++ b/src/Either/Either.spec.js
@@ -81,7 +81,10 @@ test('Either inspect', t => {
   const r = Either.Right(1)
 
   t.ok(isFunction(l.inspect), 'Left provides an inspect function')
+  t.equal(l.inspect, l.toString, 'Left toString is the same function as inspect')
+
   t.ok(isFunction(r.inspect), 'Right provides an inpsect function')
+  t.equal(r.inspect, r.toString, 'Right toString is the same function as inspect')
 
   t.equal(l.inspect(), 'Left 0', 'Left returns inspect string')
   t.equal(r.inspect(), 'Right 1', 'Right returns inspect string')

--- a/src/Either/index.js
+++ b/src/Either/index.js
@@ -192,9 +192,10 @@ function Either(u) {
   }
 
   return {
-    inspect, either, type, concat,
-    swap, coalesce, equals, map, bimap,
-    alt, ap, of, chain, sequence, traverse,
+    inspect, toString: inspect, either,
+    type, concat, swap, coalesce, equals,
+    map, bimap, alt, ap, of, chain, sequence,
+    traverse,
     constructor: Either
   }
 }

--- a/src/Endo/Endo.spec.js
+++ b/src/Endo/Endo.spec.js
@@ -54,6 +54,7 @@ test('Endo inspect', t => {
   const m = Endo(identity)
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Endo Function', 'returns inspect string')
 
   t.end()

--- a/src/Endo/index.js
+++ b/src/Endo/index.js
@@ -35,8 +35,9 @@ function Endo(runWith) {
   }
 
   return {
-    inspect, valueOf, type,
-    concat, empty, runWith,
+    inspect, toString: inspect,
+    valueOf, type, concat, empty,
+    runWith,
     constructor: Endo
   }
 }

--- a/src/Equiv/Equiv.spec.js
+++ b/src/Equiv/Equiv.spec.js
@@ -61,6 +61,7 @@ test('Equiv inspect', t => {
   const m = Equiv(isSame)
 
   t.ok(isFunction(m.inspect), 'provides an inpsect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Equiv Function', 'returns inspect string')
 
   t.end()

--- a/src/Equiv/index.js
+++ b/src/Equiv/index.js
@@ -52,8 +52,9 @@ function Equiv(compare) {
   }
 
   return {
-    inspect, type, compareWith, valueOf,
-    contramap, concat, empty,
+    inspect, toString: inspect, type,
+    compareWith, valueOf, contramap,
+    concat, empty,
     constructor: Equiv
   }
 }

--- a/src/First/First.spec.js
+++ b/src/First/First.spec.js
@@ -45,6 +45,8 @@ test('First inspect', t => {
   const nothing = First(Maybe.Nothing())
 
   t.ok(isFunction(val.inspect), 'provides an inspect function')
+  t.equal(val.inspect, val.toString, 'toString is the same function as inspect')
+
   t.equal(val.inspect(), 'First( Just 0 )', 'returns inspect string for value construction')
   t.equal(just.inspect(), 'First( Just 1 )', 'returns inspect string for value construction')
   t.equal(nothing.inspect(), 'First( Nothing )', 'returns inspect string for value construction')

--- a/src/First/index.js
+++ b/src/First/index.js
@@ -46,8 +46,9 @@ function First(x) {
   }
 
   return {
-    concat, empty, inspect,
-    option, type, valueOf,
+    inspect, toString: inspect,
+    concat, empty, option, type,
+    valueOf,
     constructor: First
   }
 }

--- a/src/IO/IO.spec.js
+++ b/src/IO/IO.spec.js
@@ -63,6 +63,7 @@ test('IO inspect', t => {
   const m = IO(unit)
 
   t.ok(isFunction(m.inspect), 'provides an inpsect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'IO Function', 'returns inspect string')
 
   t.end()

--- a/src/IO/index.js
+++ b/src/IO/index.js
@@ -56,8 +56,8 @@ function IO(run) {
   }
 
   return {
-    inspect, run, type,
-    map, ap, of, chain,
+    inspect, toString: inspect, run,
+    type, map, ap, of, chain,
     constructor: IO
   }
 }

--- a/src/Identity/Identity.spec.js
+++ b/src/Identity/Identity.spec.js
@@ -55,6 +55,7 @@ test('Identity inspect', t => {
   const m = Identity(0)
 
   t.ok(isFunction(m.inspect), 'provides an inpsect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Identity 0', 'returns inspect string')
 
   t.end()

--- a/src/Identity/index.js
+++ b/src/Identity/index.js
@@ -102,9 +102,9 @@ function Identity(x) {
   }
 
   return {
-    inspect, valueOf, type, equals,
-    concat, map, ap, of, chain,
-    sequence, traverse,
+    inspect, toString: inspect, valueOf,
+    type, equals, concat, map, ap, of,
+    chain, sequence, traverse,
     constructor: Identity
   }
 }

--- a/src/Last/Last.spec.js
+++ b/src/Last/Last.spec.js
@@ -43,6 +43,8 @@ test('Last inspect', t => {
   const nothing = Last(Maybe.Nothing())
 
   t.ok(isFunction(val.inspect), 'provides an inspect function')
+  t.equal(val.inspect, val.toString, 'toString is the same function as inspect')
+
   t.equal(val.inspect(), 'Last( Just 0 )', 'returns inspect string for value construction')
   t.equal(just.inspect(), 'Last( Just 1 )', 'returns inspect string for value construction')
   t.equal(nothing.inspect(), 'Last( Nothing )', 'returns inspect string for value construction')

--- a/src/Last/index.js
+++ b/src/Last/index.js
@@ -49,8 +49,8 @@ function Last(x) {
   }
 
   return {
-    concat, empty, inspect,
-    option, type, valueOf,
+    inspect, toString: inspect, concat,
+    empty, option, type, valueOf,
     constructor: Last
   }
 }

--- a/src/Max/Max.spec.js
+++ b/src/Max/Max.spec.js
@@ -52,6 +52,7 @@ test('Max inspect', t => {
   const m = Max(124)
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Max 124', 'returns inspect string')
 
   t.end()

--- a/src/Max/index.js
+++ b/src/Max/index.js
@@ -37,8 +37,8 @@ function Max(n) {
   }
 
   return {
-    inspect, valueOf, type,
-    concat, empty,
+    inspect, toString: inspect, valueOf,
+    type, concat, empty,
     constructor: Max
   }
 }

--- a/src/Min/Min.spec.js
+++ b/src/Min/Min.spec.js
@@ -52,6 +52,7 @@ test('Min inspect', t => {
   const m = Min(0)
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Min 0', 'returns inspect string')
 
   t.end()

--- a/src/Min/index.js
+++ b/src/Min/index.js
@@ -37,8 +37,8 @@ function Min(n) {
   }
 
   return {
-    inspect, valueOf, type,
-    concat, empty,
+    inspect, toString: inspect, valueOf,
+    type, concat, empty,
     constructor: Min
   }
 }

--- a/src/Pred/Pred.spec.js
+++ b/src/Pred/Pred.spec.js
@@ -58,6 +58,7 @@ test('Pred inspect', t => {
   const m = Pred(unit)
 
   t.ok(isFunction(m.inspect), 'provides an inpsect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Pred Function', 'returns inspect string')
 
   t.end()

--- a/src/Pred/index.js
+++ b/src/Pred/index.js
@@ -46,8 +46,8 @@ function Pred(pred) {
   }
 
   return {
-    runWith, inspect, type, valueOf,
-    empty, concat, contramap,
+    inspect, toString: inspect, runWith,
+    type, valueOf, empty, concat, contramap,
     constructor: Pred
   }
 }

--- a/src/Prod/Prod.spec.js
+++ b/src/Prod/Prod.spec.js
@@ -52,6 +52,7 @@ test('Prod inspect', t => {
   const m = Prod(1)
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Prod 1', 'returns inspect string')
 
   t.end()

--- a/src/Prod/index.js
+++ b/src/Prod/index.js
@@ -37,8 +37,8 @@ function Prod(n) {
   }
 
   return {
-    inspect, valueOf, type,
-    concat, empty,
+    inspect, toString: inspect, valueOf,
+    type, concat, empty,
     constructor: Prod
   }
 }

--- a/src/Reader/Reader.spec.js
+++ b/src/Reader/Reader.spec.js
@@ -66,6 +66,7 @@ test('Reader inspect', t => {
   const m = Reader(unit)
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Reader Function', 'returns inspect string')
 
   t.end()

--- a/src/Reader/ReaderT.js
+++ b/src/Reader/ReaderT.js
@@ -110,8 +110,9 @@ function _ReaderT(Monad) {
     }
 
     return {
-      type, inspect, runWith,
-      of, map, ap, chain
+      inspect, toString: inspect, type,
+      runWith, of, map, ap, chain,
+      constructor: ReaderT
     }
   }
 

--- a/src/Reader/ReaderT.spec.js
+++ b/src/Reader/ReaderT.spec.js
@@ -46,6 +46,7 @@ test('ReaderT', t => {
 
   t.ok(isFunction(ReaderMock), 'is a function')
   t.ok(isObject(r), 'returns an object')
+  t.equals(r.constructor, ReaderMock, 'provides TypeRep on constructor')
 
   t.ok(isFunction(ReaderMock.of), 'provides an of function')
   t.ok(isFunction(ReaderMock.type), 'provides a type function')
@@ -84,6 +85,7 @@ test('ReaderT inspect', t => {
   const m = ReaderMock(unit)
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Reader( MockCrock ) Function', 'returns inspect string')
 
   t.end()

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -76,8 +76,8 @@ function Reader(runWith) {
   }
 
   return {
-    inspect, runWith, type, map,
-    ap, chain, of,
+    inspect, toString: inspect, runWith,
+    type, map, ap, chain, of,
     constructor: Reader
   }
 }

--- a/src/Result/Result.spec.js
+++ b/src/Result/Result.spec.js
@@ -81,7 +81,10 @@ test('Result inspect', t => {
   const r = Result.Ok(1)
 
   t.ok(isFunction(l.inspect), 'Err provides an inspect function')
+  t.equal(l.inspect, l.toString, 'toString is the same function as inspect')
+
   t.ok(isFunction(r.inspect), 'Ok provides an inspect function')
+  t.equal(r.inspect, r.toString, 'toString is the same function as inspect')
 
   t.equal(l.inspect(), 'Err 0', 'Err returns inspect string')
   t.equal(r.inspect(), 'Ok 1', 'Ok returns inspect string')

--- a/src/Result/index.js
+++ b/src/Result/index.js
@@ -202,9 +202,10 @@ function Result(u) {
   }
 
   return {
-    inspect, equals, type, either, concat,
-    swap, coalesce, map, bimap, alt, ap,
-    chain, of, sequence, traverse,
+    inspect, toString: inspect, equals,
+    type, either, concat, swap, coalesce,
+    map, bimap, alt, ap, chain, of, sequence,
+    traverse,
     constructor: Result
   }
 }

--- a/src/Star/Star.spec.js
+++ b/src/Star/Star.spec.js
@@ -94,6 +94,7 @@ test('Star inspect', t => {
   const a = Star(unit)
 
   t.ok(isFunction(a.inspect), 'provides an inspect function')
+  t.equal(a.inspect, a.toString, 'toString is the same function as inspect')
   t.equal(a.inspect(), 'Star( MockCrock ) Function', 'returns inspect string')
 
   t.end()

--- a/src/Star/index.js
+++ b/src/Star/index.js
@@ -160,8 +160,8 @@ function _Star(Monad) {
     }
 
     return {
-      inspect, type, runWith,
-      id, compose, map, contramap,
+      inspect, toString: inspect, type,
+      runWith, id, compose, map, contramap,
       promap, first, second, both,
       constructor: Star
     }

--- a/src/State/State.spec.js
+++ b/src/State/State.spec.js
@@ -65,6 +65,7 @@ test('State inspect', t => {
   const m = State(unit)
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'State Function', 'returns inspect string')
 
   t.end()

--- a/src/State/index.js
+++ b/src/State/index.js
@@ -112,8 +112,9 @@ function State(fn) {
   }
 
   return {
-    runWith, execWith, evalWith, inspect,
-    type, map, ap, chain, of,
+    inspect, toString: inspect, runWith,
+    execWith, evalWith, type, map, ap,
+    chain, of,
     constructor: State
   }
 }

--- a/src/Sum/Sum.spec.js
+++ b/src/Sum/Sum.spec.js
@@ -52,6 +52,7 @@ test('Sum inspect', t => {
   const m = Sum(90)
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Sum 90', 'returns inspect string')
 
   t.end()

--- a/src/Sum/index.js
+++ b/src/Sum/index.js
@@ -37,8 +37,8 @@ function Sum(n) {
   }
 
   return {
-    inspect, valueOf, type,
-    concat, empty,
+    inspect, toString: inspect, valueOf,
+    type, concat, empty,
     constructor: Sum
   }
 }

--- a/src/Writer/Writer.spec.js
+++ b/src/Writer/Writer.spec.js
@@ -73,8 +73,8 @@ test('Writer @@implements', t => {
 test('Writer inspect', t => {
   const m = Writer(0, 0)
 
-
   t.ok(isFunction(m.inspect), 'provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Writer( Last 0 0 )', 'returns inspect string')
 
   t.end()

--- a/src/Writer/index.js
+++ b/src/Writer/index.js
@@ -85,8 +85,8 @@ function _Writer(Monoid) {
     }
 
     return {
-      inspect, read, valueOf,
-      log, type, equals, map,
+      inspect, toString: inspect, read,
+      valueOf, log, type, equals, map,
       ap, of, chain,
       constructor: Writer
     }

--- a/src/core/List.js
+++ b/src/core/List.js
@@ -231,9 +231,9 @@ function List(x) {
   }
 
   return {
-    inspect, valueOf, toArray, head, tail, cons,
-    type, equals, concat, empty, reduce, fold,
-    filter, reject, map, ap, of, chain,
+    inspect, toString: inspect, valueOf, toArray,
+    head, tail, cons, type, equals, concat, empty,
+    reduce, fold, filter, reject, map, ap, of, chain,
     sequence, traverse,
     constructor: List
   }

--- a/src/core/List.spec.js
+++ b/src/core/List.spec.js
@@ -94,6 +94,7 @@ test('List inspect', t => {
   const m = List([ 1, true, 'string' ])
 
   t.ok(isFunction(m.inspect), 'provides an inpsect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'List [ 1, true, "string" ]', 'returns inspect string')
 
   t.end()

--- a/src/core/Maybe.js
+++ b/src/core/Maybe.js
@@ -187,9 +187,10 @@ function Maybe(u) {
   }
 
   return {
-    inspect, either, option, type,
-    concat, equals, coalesce, map, alt,
-    zero, ap, of, chain, sequence, traverse,
+    inspect, toString: inspect, either,
+    option, type, concat, equals, coalesce,
+    map, alt, zero, ap, of, chain, sequence,
+    traverse,
     constructor: Maybe
   }
 }

--- a/src/core/Maybe.spec.js
+++ b/src/core/Maybe.spec.js
@@ -66,7 +66,10 @@ test('Maybe inspect', t => {
   const n = Maybe.Nothing()
 
   t.ok(isFunction(m.inspect), 'Just provides an inspect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.ok(isFunction(n.inspect), 'Nothing provides an inspect function')
+  t.equal(n.inspect, n.toString, 'toString is the same function as inspect')
+
   t.equal(m.inspect(), 'Just "great"', 'returns inspect string')
   t.equal(n.inspect(), 'Nothing', 'Nothing returns inspect string')
 

--- a/src/core/Pair.js
+++ b/src/core/Pair.js
@@ -148,9 +148,10 @@ function Pair(l, r) {
   }
 
   return {
-    inspect, fst, snd, toArray, type,
-    merge, equals, concat, swap, map,
-    bimap, ap, chain, extend,
+    inspect, toString: inspect, fst,
+    snd, toArray, type, merge, equals,
+    concat, swap, map, bimap, ap, chain,
+    extend,
     constructor: Pair
   }
 }

--- a/src/core/Pair.spec.js
+++ b/src/core/Pair.spec.js
@@ -53,6 +53,7 @@ test('Pair inspect', t => {
   const m = Pair(0, 'nice')
 
   t.ok(isFunction(m.inspect), 'provides an inpsect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), 'Pair( 0, "nice" )', 'returns inspect string')
 
   t.end()

--- a/src/core/Unit.js
+++ b/src/core/Unit.js
@@ -62,8 +62,9 @@ function Unit() {
   }
 
   return {
-    inspect, valueOf, type, equals,
-    concat, empty, map, ap, of, chain,
+    inspect, toString: inspect, valueOf,
+    type, equals, concat, empty, map, ap,
+    of, chain,
     constructor: Unit
   }
 }

--- a/src/core/Unit.spec.js
+++ b/src/core/Unit.spec.js
@@ -53,6 +53,7 @@ test('Unit inspect', t => {
   const m = Unit(0)
 
   t.ok(isFunction(m.inspect), 'provides an inpsect function')
+  t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
   t.equal(m.inspect(), '()', 'returns inspect string')
 
   t.end()

--- a/src/core/isObject.js
+++ b/src/core/isObject.js
@@ -1,11 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const toString = Object.prototype.toString
+
 // isObject : a -> Boolean
 function isObject(x) {
   return !!x
-    && x.toString
-    && x.toString() === '[object Object]'
+    && toString.call(x) === '[object Object]'
 }
 
 module.exports = isObject


### PR DESCRIPTION
## Better than Cheese
![image](https://user-images.githubusercontent.com/3665793/35367412-0767d2fa-0133-11e8-8a77-461a7fb5cbf3.png)

Added a `toString` method each of the ADTs and had to 🔧 up how we deal with `isObject` as that would have created many problems if this PR never became a thing.