### PR TITLE
Remove mention of the type method from Documentation

### DIFF
--- a/docs/src/pages/docs/crocks/Arrow.md
+++ b/docs/src/pages/docs/crocks/Arrow.md
@@ -108,36 +108,6 @@ right.runWith(12) //=> '12'
 left.runWith(12)  //=> '12'
 ```
 
-
-#### type
-
-```haskell
-Arrow.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be useful
-to the end user for debugging and building out custom types based on the standard
-`crocks` types. While type comparisons can easily be done manually by calling
-`type` on a given type, using the `isSameType` function hides much of the
-boilerplate. `type` is available on both the Constructor and the Instance for
-convenience.
-
-```javascript
-const Arrow = require('crocks/Arrow')
-const Identity = require('crocks/Identity')
-
-const I = require('crocks/combinators/identity')
-const isSameType = require('crocks/predicates/isSameType')
-
-Arrow.type() //=> "Arrow"
-
-isSameType(Arrow, Arrow(x => x + 3))  //=> true
-isSameType(Arrow, Arrow)              //=> true
-isSameType(Arrow, Identity(0))        //=> false
-isSameType(Arrow(I), Identity)        //=> false
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/crocks/Equiv.md
+++ b/docs/src/pages/docs/crocks/Equiv.md
@@ -101,35 +101,6 @@ empty
 //=> false
 ```
 
-#### type
-
-```haskell
-Equiv.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Equiv = require('crocks/Equiv')
-
-const Endo = require('crocks/Endo')
-const equals = require('crocks/pointfree/equals')
-const isSameType = require('crocks/predicates/isSameType')
-
-Equiv.type() //=>  "Equiv"
-
-isSameType(Equiv, Equiv(equals))    //=> true
-isSameType(Equiv, Equiv)            //=> true
-isSameType(Equiv, Endo(x => x * 2)) //=> false
-isSameType(Equiv(equals), Endo)     //=> false
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/crocks/Maybe.md
+++ b/docs/src/pages/docs/crocks/Maybe.md
@@ -268,36 +268,6 @@ firstValid([ null, undefined, 'wrong' ])
 //=> Nothing
 ```
 
-#### type
-
-```haskell
-Maybe.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Maybe = require('crocks/Maybe')
-const { Just, Nothing } = Maybe
-
-const Any = require('crocks/Any')
-const isSameType = require('crocks/predicates/isSameType')
-
-Maybe.type() //=>  "Maybe"
-
-isSameType(Maybe, Nothing())      //=> true
-isSameType(Maybe, Just(3))        //=> true
-isSameType(Nothing(), Just(23))   //=> true
-isSameType(Maybe, Any(true))      //=> false
-isSameType(Maybe(null), Any)      //=> false
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/crocks/Pred.md
+++ b/docs/src/pages/docs/crocks/Pred.md
@@ -133,35 +133,6 @@ empty
 //=> true
 ```
 
-#### type
-
-```haskell
-Pred.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Pred = require('crocks/Pred')
-
-const Maybe = require('crocks/Maybe')
-const isNil = require('crocks/predicates/isEmpty')
-const isSameType = require('crocks/predicates/isSameType')
-
-Pred.type()   //=>  "Pred"
-
-isSameType(Pred, Pred(isNil))    //=> true
-isSameType(Pred, Pred)           //=> true
-isSameType(Pred, Maybe.Just(4))  //=> false
-isSameType(Pred(isNil), Maybe)   //=> false
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/crocks/Reader.md
+++ b/docs/src/pages/docs/crocks/Reader.md
@@ -137,35 +137,6 @@ Reader.of(57)
 //=> 100
 ```
 
-#### type
-
-```haskell
-Reader.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be useful
-to the end user for debugging and building out custom types based on the standard
-`crocks` types. While type comparisons can easily be done manually by calling
-`type` on a given type, using the `isSameType` function hides much of the
-boilerplate. `type` is available on both the Constructor and the Instance for
-convenience.
-
-```javascript
-const Reader = require('crocks/Reader')
-const Identity = require('crocks/Identity')
-
-const I = require('crocks/combinators/identity')
-const isSameType = require('crocks/predicates/isSameType')
-
-Reader.type() //=> 'Reader'
-
-isSameType(Reader, Reader.of(76))   //=> true
-isSameType(Reader, Reader)          //=> true
-isSameType(Reader, Identity(0))     //=> false
-isSameType(Reader(I), Identity)     //=> false
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/crocks/State.md
+++ b/docs/src/pages/docs/crocks/State.md
@@ -266,35 +266,6 @@ State.of('hotness')
 //=> Pair('crusty', 'hotness')
 ```
 
-#### type
-
-```haskell
-State.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const State = require('crocks/State')
-
-const Reader = require('crocks/Reader')
-const identity = require('crocks/combinators/identity')
-const isSameType = require('crocks/predicates/isSameType')
-
-State.type() //=>  "State"
-
-isSameType(State, State.of(3))        //=> true
-isSameType(State, State)              //=> true
-isSameType(State, Reader(identity))   //=> false
-isSameType(State.of(false), Reader)   //=> false
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/crocks/index.md
+++ b/docs/src/pages/docs/crocks/index.md
@@ -13,8 +13,7 @@ constructor that takes either a function or value (depending on the type)
 and will return you a "container" that wraps whatever you passed it. Each
 container provides a variety of functions that act as the operations you can do
 on the contained value. There are many types that share the same function names,
-but what they do from type to type may vary.  Every Crock provides type function
-on the Constructor and both inspect and type functions on their Instances.
+but what they do from type to type may vary.
 
 | Crock | Constructor | Instance |
 |---|:---|:---|

--- a/docs/src/pages/docs/monoids/All.md
+++ b/docs/src/pages/docs/monoids/All.md
@@ -68,34 +68,6 @@ All(true).concat(All.empty())   //=> All true
 All(false).concat(All.empty())  //=> All false
 ```
 
-#### type
-
-```haskell
-All.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const All = require('crocks/All')
-
-const Maybe = require('crocks/Maybe')
-const isSameType = require('crocks/predicates/isSameType')
-
-All.type() //=>  "All"
-
-isSameType(All, All(3))           //=> true
-isSameType(All, All)              //=> true
-isSameType(All, Maybe.Just('3'))  //=> false
-isSameType(All(false), Maybe)     //=> false
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/monoids/Any.md
+++ b/docs/src/pages/docs/monoids/Any.md
@@ -71,36 +71,6 @@ Any(true).concat(Any.empty())   //=> Any true
 Any(false).concat(Any.empty())  //=> Any false
 ```
 
-#### type
-
-```haskell
-Any.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Any = require('crocks/Any')
-
-const Assign = require('crocks/Assign')
-const isSameType = require('crocks/predicates/isSameType')
-
-Any.type() //=>  "Any"
-
-isSameType(Any, Any(3))         //=> true
-isSameType(Any, Any)            //=> true
-isSameType(Any(false), Assign)  //=> false
-
-isSameType(Any, Assign({ food: 'always' }))
-//=> false
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/monoids/Assign.md
+++ b/docs/src/pages/docs/monoids/Assign.md
@@ -61,42 +61,6 @@ Assign({ a: 1 })
 //=> Assign { a: 1 }
 ```
 
-#### type
-
-```haskell
-Assign.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Assign = require('crocks/Assign')
-const Sum = require('crocks/Sum')
-const Maybe = require('crocks/Maybe')
-const isSameType = require('crocks/predicates/isSameType')
-
-const myData =
-  Assign({ name: 'Joe', age: 41 })
-
-myData.type()
-//=> "Assign"
-
-isSameType(Sum, myData)
-//=> false
-
-isSameType(Maybe, myData)
-//=> false
-
-isSameType(Assign, myData)
-//=> true
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/monoids/Endo.md
+++ b/docs/src/pages/docs/monoids/Endo.md
@@ -98,35 +98,6 @@ runNice(toUpper.concat(empty))
 //=> "NICE"
 ```
 
-#### type
-
-```haskell
-Endo.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Endo = require('crocks/Endo')
-const Maybe = require('crocks/Maybe')
-
-const constant = require('crocks/combinators/constant')
-const identity = require('crocks/combinators/identity')
-const isSameType = require('crocks/predicates/isSameType')
-
-Endo.type() //=>  "Endo"
-
-isSameType(Endo, Endo(identity))              //=> true
-isSameType(Endo(identity), Endo(constant(3))) //=> true
-isSameType(Endo(identity), Maybe)             //=> false
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/monoids/Prod.md
+++ b/docs/src/pages/docs/monoids/Prod.md
@@ -81,40 +81,6 @@ Prod.empty()
 //=> Prod 4
 ```
 
-### type
-
-```haskell
-Prod.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on
-the standard `crocks` types. While type comparisons can easily be done manually
-by calling `type` on a given type, using the `isSameType` function hides much
-of the boilerplate. `type` is available on both the Constructor and the
-Instance for convenience.
-
-```javascript
-const Prod = require('crocks/Prod')
-const Sum = require('crocks/Sum')
-const isSameType = require('crocks/predicates/isSameType')
-
-const prod5 = Prod(5)
-
-prod5.type()
-//=> "Prod"
-
-isSameType(Sum, prod5)
-//=> false
-
-isSameType(Prod, prod5)
-//=> true
-
-isSameType(Prod.empty(), prod5)
-//=> true
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/monoids/Sum.md
+++ b/docs/src/pages/docs/monoids/Sum.md
@@ -75,40 +75,6 @@ Sum.empty()
 //=> Sum 4
 ```
 
-### type
-
-```haskell
-Sum.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Sum = require('crocks/Sum')
-const Prod = require('crocks/Prod')
-const isSameType = require('crocks/predicates/isSameType')
-
-const sum5 = Sum(5)
-
-sum5.type()
-//=> "Sum"
-
-isSameType(Sum, sum5)
-//=> true
-
-isSameType(Prod, sum5)
-//=> false
-
-isSameType(Sum.empty(), sum5)
-//=> true
-```
-
 </article>
 
 <article id="topic-instance">

--- a/docs/src/pages/docs/monoids/index.md
+++ b/docs/src/pages/docs/monoids/index.md
@@ -16,9 +16,8 @@ as well.
 All `Monoids` work with the following helper functions
 [mconcat][mconcat], [mreduce][mreduce], [mconcatMap][mconcatmap] and [mreduceMap][mreducemap].
 
-All `Monoids` provide `empty` and `type` functions on their Constructors as well
-as the following Instance Functions: `inspect`, `type`, `valueOf`, `empty` and
-`concat`.
+All `Monoids` provide `empty` functions on their Constructors as well
+as the following Instance Functions: `valueOf`, `empty` and `concat`.
 
 | Monoid | Type | Operation | Empty (Identity) |
 |---|---|---|---|

--- a/src/All/README.md
+++ b/src/All/README.md
@@ -59,34 +59,6 @@ All(true).concat(All.empty())   //=> All true
 All(false).concat(All.empty())  //=> All false
 ```
 
-#### type
-
-```haskell
-All.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const All = require('crocks/All')
-
-const Maybe = require('crocks/Maybe')
-const isSameType = require('crocks/predicates/isSameType')
-
-All.type() //=>  "All"
-
-isSameType(All, All(3))           //=> true
-isSameType(All, All)              //=> true
-isSameType(All, Maybe.Just('3'))  //=> false
-isSameType(All(false), Maybe)     //=> false
-```
-
 ## Instance Methods
 
 #### concat

--- a/src/Any/README.md
+++ b/src/Any/README.md
@@ -60,37 +60,6 @@ Any(true).concat(Any.empty())   //=> Any true
 Any(false).concat(Any.empty())  //=> Any false
 ```
 
-
-#### type
-
-```haskell
-Any.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Any = require('crocks/Any')
-
-const Assign = require('crocks/Assign')
-const isSameType = require('crocks/predicates/isSameType')
-
-Any.type() //=>  "Any"
-
-isSameType(Any, Any(3))         //=> true
-isSameType(Any, Any)            //=> true
-isSameType(Any(false), Assign)  //=> false
-
-isSameType(Any, Assign({ food: 'always' }))
-//=> false
-```
-
 ## Instance Methods
 
 #### concat

--- a/src/Arrow/README.md
+++ b/src/Arrow/README.md
@@ -96,35 +96,6 @@ right.runWith(12) //=> '12'
 left.runWith(12)  //=> '12'
 ```
 
-#### type
-
-```haskell
-Arrow.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be useful
-to the end user for debugging and building out custom types based on the standard
-`crocks` types. While type comparisons can easily be done manually by calling
-`type` on a given type, using the `isSameType` function hides much of the
-boilerplate. `type` is available on both the Constructor and the Instance for
-convenience.
-
-```javascript
-const Arrow = require('crocks/Arrow')
-const Identity = require('crocks/Identity')
-
-const I = require('crocks/combinators/identity')
-const isSameType = require('crocks/predicates/isSameType')
-
-Arrow.type() //=> "Arrow"
-
-isSameType(Arrow, Arrow(x => x + 3))  //=> true
-isSameType(Arrow, Arrow)              //=> true
-isSameType(Arrow, Identity(0))        //=> false
-isSameType(Arrow(I), Identity)        //=> false
-```
-
 ## Instance Methods
 
 #### both

--- a/src/Assign/README.md
+++ b/src/Assign/README.md
@@ -50,42 +50,6 @@ Assign({ a: 1 })
 //=> Assign { a: 1 }
 ```
 
-#### type
-
-```haskell
-Assign.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Assign = require('crocks/Assign')
-const Sum = require('crocks/Sum')
-const Maybe = require('crocks/Maybe')
-const isSameType = require('crocks/predicates/isSameType')
-
-const myData =
-  Assign({ name: 'Joe', age: 41 })
-
-myData.type()
-//=> "Assign"
-
-isSameType(Sum, myData)
-//=> false
-
-isSameType(Maybe, myData)
-//=> false
-
-isSameType(Assign, myData)
-//=> true
-```
-
 ## Instance Methods
 
 #### concat

--- a/src/Endo/README.md
+++ b/src/Endo/README.md
@@ -87,35 +87,6 @@ runNice(toUpper.concat(empty))
 //=> "NICE"
 ```
 
-#### type
-
-```haskell
-Endo.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Endo = require('crocks/Endo')
-const Maybe = require('crocks/Maybe')
-
-const constant = require('crocks/combinators/constant')
-const identity = require('crocks/combinators/identity')
-const isSameType = require('crocks/predicates/isSameType')
-
-Endo.type() //=>  "Endo"
-
-isSameType(Endo, Endo(identity))              //=> true
-isSameType(Endo(identity), Endo(constant(3))) //=> true
-isSameType(Endo(identity), Maybe)             //=> false
-```
-
 ## Instance Methods
 
 #### concat

--- a/src/Equiv/README.md
+++ b/src/Equiv/README.md
@@ -91,35 +91,6 @@ empty
 //=> false
 ```
 
-#### type
-
-```haskell
-Equiv.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Equiv = require('crocks/Equiv')
-
-const Endo = require('crocks/Endo')
-const equals = require('crocks/pointfree/equals')
-const isSameType = require('crocks/predicates/isSameType')
-
-Equiv.type() //=>  "Equiv"
-
-isSameType(Equiv, Equiv(equals))    //=> true
-isSameType(Equiv, Equiv)            //=> true
-isSameType(Equiv, Endo(x => x * 2)) //=> false
-isSameType(Equiv(equals), Endo)     //=> false
-```
-
 ## Instance Methods
 
 #### concat

--- a/src/Maybe/README.md
+++ b/src/Maybe/README.md
@@ -257,36 +257,6 @@ firstValid([ null, undefined, 'wrong' ])
 //=> Nothing
 ```
 
-#### type
-
-```haskell
-Maybe.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Maybe = require('crocks/Maybe')
-const { Just, Nothing } = Maybe
-
-const Any = require('crocks/Any')
-const isSameType = require('crocks/predicates/isSameType')
-
-Maybe.type() //=>  "Maybe"
-
-isSameType(Maybe, Nothing())      //=> true
-isSameType(Maybe, Just(3))        //=> true
-isSameType(Nothing(), Just(23))   //=> true
-isSameType(Maybe, Any(true))      //=> false
-isSameType(Maybe(null), Any)      //=> false
-```
-
 ## Instance Methods
 
 #### equals

--- a/src/Pred/README.md
+++ b/src/Pred/README.md
@@ -123,35 +123,6 @@ empty
 //=> true
 ```
 
-#### type
-
-```haskell
-Pred.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Pred = require('crocks/Pred')
-
-const Maybe = require('crocks/Maybe')
-const isNil = require('crocks/predicates/isEmpty')
-const isSameType = require('crocks/predicates/isSameType')
-
-Pred.type()   //=>  "Pred"
-
-isSameType(Pred, Pred(isNil))    //=> true
-isSameType(Pred, Pred)           //=> true
-isSameType(Pred, Maybe.Just(4))  //=> false
-isSameType(Pred(isNil), Maybe)   //=> false
-```
-
 ## Instance Methods
 
 #### concat

--- a/src/Prod/README.md
+++ b/src/Prod/README.md
@@ -70,40 +70,6 @@ Prod.empty()
 //=> Prod 4
 ```
 
-#### type
-
-```haskell
-Prod.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on
-the standard `crocks` types. While type comparisons can easily be done manually
-by calling `type` on a given type, using the `isSameType` function hides much
-of the boilerplate. `type` is available on both the Constructor and the
-Instance for convenience.
-
-```javascript
-const Prod = require('crocks/Prod')
-const Sum = require('crocks/Sum')
-const isSameType = require('crocks/predicates/isSameType')
-
-const prod5 = Prod(5)
-
-prod5.type()
-//=> "Prod"
-
-isSameType(Sum, prod5)
-//=> false
-
-isSameType(Prod, prod5)
-//=> true
-
-isSameType(Prod.empty(), prod5)
-//=> true
-```
-
 ## Instance Methods
 
 #### concat

--- a/src/Reader/README.md
+++ b/src/Reader/README.md
@@ -128,35 +128,6 @@ Reader.of(57)
 //=> 100
 ```
 
-#### type
-
-```haskell
-Reader.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be useful
-to the end user for debugging and building out custom types based on the standard
-`crocks` types. While type comparisons can easily be done manually by calling
-`type` on a given type, using the `isSameType` function hides much of the
-boilerplate. `type` is available on both the Constructor and the Instance for
-convenience.
-
-```javascript
-const Reader = require('crocks/Reader')
-const Identity = require('crocks/Identity')
-
-const I = require('crocks/combinators/identity')
-const isSameType = require('crocks/predicates/isSameType')
-
-Reader.type() //=> 'Reader'
-
-isSameType(Reader, Reader.of(76))   //=> true
-isSameType(Reader, Reader)          //=> true
-isSameType(Reader, Identity(0))     //=> false
-isSameType(Reader(I), Identity)     //=> false
-```
-
 ## Instance Methods
 
 #### map

--- a/src/State/README.md
+++ b/src/State/README.md
@@ -256,35 +256,6 @@ State.of('hotness')
 //=> Pair('crusty', 'hotness')
 ```
 
-#### type
-
-```haskell
-State.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const State = require('crocks/State')
-
-const Reader = require('crocks/Reader')
-const identity = require('crocks/combinators/identity')
-const isSameType = require('crocks/predicates/isSameType')
-
-State.type() //=>  "State"
-
-isSameType(State, State.of(3))        //=> true
-isSameType(State, State)              //=> true
-isSameType(State, Reader(identity))   //=> false
-isSameType(State.of(false), Reader)   //=> false
-```
-
 ## Instance Methods
 
 #### map

--- a/src/Sum/README.md
+++ b/src/Sum/README.md
@@ -64,40 +64,6 @@ Sum.empty()
 //=> Sum 4
 ```
 
-#### type
-
-```haskell
-Sum.type :: () -> String
-```
-
-`type` provides a string representation of the type name for a given type in
-`crocks`. While it is used mostly internally for law validation, it can be
-useful to the end user for debugging and building out custom types based on the
-standard `crocks` types. While type comparisons can easily be done manually by
-calling `type` on a given type, using the `isSameType` function hides much of
-the boilerplate. `type` is available on both the Constructor and the Instance
-for convenience.
-
-```javascript
-const Sum = require('crocks/Sum')
-const Prod = require('crocks/Prod')
-const isSameType = require('crocks/predicates/isSameType')
-
-const sum5 = Sum(5)
-
-sum5.type()
-//=> "Sum"
-
-isSameType(Sum, sum5)
-//=> true
-
-isSameType(Prod, sum5)
-//=> false
-
-isSameType(Sum.empty(), sum5)
-//=> true
-```
-
 ## Instance Methods
 
 #### concat


### PR DESCRIPTION
## Transitions are hard
![image](https://user-images.githubusercontent.com/3665793/35423285-e38df20e-0201-11e8-8dd7-aa6788748629.png)

With the `isSameType` function being added a while ago, there is not much use for `type` to really be used. So there is going to be the first in a three step transition to move to the more well know `@@type` method and format (lib/type/version).

To keep newcomers from even know about this, the first step to not talk about. Followed by the implementation and hooks for `@@type`. Then the completle and breaking removal of `type` from the ADTs.