### PR TITLE
Add `@@type` to all ADTs

### DIFF
--- a/src/All/All.spec.js
+++ b/src/All/All.spec.js
@@ -21,6 +21,7 @@ test('All', t => {
 
   t.ok(isFunction(All.empty), 'provides an empty function')
   t.ok(isFunction(All.type), 'provides a type function')
+  t.ok(isFunction(All['@@type']), 'provides a @@type function')
 
   const err = /All: Non-function value required/
   t.throws(All, err, 'throws with nothing')
@@ -77,9 +78,21 @@ test('All valueOf', t => {
 })
 
 test('All type', t => {
-  t.ok(isFunction(All(0).type), 'is a function')
-  t.equal(All.type, All(0).type, 'is the same function as the static type')
-  t.equal(All(0).type(), 'All', 'reports All')
+  const m = All(0)
+
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(All.type, m.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'All', 'reports All')
+
+  t.end()
+})
+
+test('All @@type', t => {
+  const m = All(0)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(All['@@type'], m['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/All@1', 'reports crocks/All@1')
 
   t.end()
 })

--- a/src/All/index.js
+++ b/src/All/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('All')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isFunction = require('../core/isFunction')
 const isNil = require('../core/isNil')
@@ -39,6 +42,7 @@ function All(b) {
   return {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
+    '@@type': _type,
     constructor: All
   }
 }
@@ -47,10 +51,8 @@ All['@@implements'] = _implements(
   [ 'concat', 'empty' ]
 )
 
-All.empty =
-  _empty
-
-All.type =
-  type
+All.empty = _empty
+All.type = type
+All['@@type'] = _type
 
 module.exports = All

--- a/src/Any/Any.spec.js
+++ b/src/Any/Any.spec.js
@@ -21,6 +21,7 @@ test('Any', t => {
 
   t.ok(isFunction(Any.empty), 'provides an empty function')
   t.ok(isFunction(Any.type), 'provides a type function')
+  t.ok(isFunction(Any['@@type']), 'provides a @@type function')
 
   const err = /Any: Non-function value required/
   t.throws(Any, err, 'throws with nothing')
@@ -81,6 +82,15 @@ test('Any type', t => {
 
   t.equal(Any(0).type, Any.type, 'static and instance versions are the same')
   t.equal(Any(0).type(), 'Any', 'reports Any')
+
+  t.end()
+})
+
+test('Any @@type', t => {
+  t.ok(isFunction(Any(0)['@@type']), 'is a function')
+
+  t.equal(Any['@@type'], Any(0)['@@type'], 'static and instance versions are the same')
+  t.equal(Any(0)['@@type'](), 'crocks/Any@1', 'reports crocks/Any@1')
 
   t.end()
 })

--- a/src/Any/index.js
+++ b/src/Any/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Any')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isFunction = require('../core/isFunction')
 const isNil = require('../core/isNil')
@@ -39,6 +42,7 @@ function Any(b) {
   return {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
+    '@@type': _type,
     constructor: Any
   }
 }
@@ -49,5 +53,6 @@ Any['@@implements'] = _implements(
 
 Any.empty = _empty
 Any.type  = type
+Any['@@type'] = _type
 
 module.exports = Any

--- a/src/Arrow/Arrow.spec.js
+++ b/src/Arrow/Arrow.spec.js
@@ -23,8 +23,9 @@ test('Arrow', t => {
 
   t.ok(isFunction(Arrow), 'is a function')
 
-  t.ok(isFunction(Arrow.type), 'provides a type function')
   t.ok(isFunction(Arrow.id), 'provides an id function')
+  t.ok(isFunction(Arrow.type), 'provides a type function')
+  t.ok(isFunction(Arrow['@@type']), 'provides a @@type function')
 
   t.ok(isObject(Arrow(unit)), 'returns an object')
 
@@ -76,6 +77,17 @@ test('Arrow type', t => {
 
   t.equal(a.type, Arrow.type, 'static and instance versions are the same')
   t.equal(a.type(), 'Arrow', 'reports Arrow')
+
+  t.end()
+})
+
+test('Arrow @@type', t => {
+  const a = Arrow(unit)
+
+  t.ok(isFunction(a['@@type']), 'is a function')
+
+  t.equal(a['@@type'], Arrow['@@type'], 'static and instance versions are the same')
+  t.equal(a['@@type'](), 'crocks/Arrow@1', 'reports crocks/Arrow@1')
 
   t.end()
 })

--- a/src/Arrow/index.js
+++ b/src/Arrow/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Arrow')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
@@ -88,12 +91,14 @@ function Arrow(runWith) {
     inspect, toString: inspect, type,
     runWith, id, compose, map, contramap,
     promap, first, second, both,
+    '@@type': _type,
     constructor: Arrow
   }
 }
 
 Arrow.id = _id
 Arrow.type = type
+Arrow['@@type'] = _type
 
 Arrow['@@implements'] = _implements(
   [ 'compose', 'contramap', 'id', 'map', 'promap' ]

--- a/src/Assign/Assign.spec.js
+++ b/src/Assign/Assign.spec.js
@@ -21,6 +21,7 @@ test('Assign', t => {
 
   t.ok(isFunction(Assign.empty), 'provides an empty function')
   t.ok(isFunction(Assign.type), 'provides a type function')
+  t.ok(isFunction(Assign['@@type']), 'provides a @@type function')
 
   t.throws(Assign, TypeError, 'throws with nothing')
   t.throws(a(identity), TypeError, 'throws with a function')
@@ -77,6 +78,15 @@ test('Assign type', t => {
 
   t.equal(Assign({}).type, Assign.type, 'static and instance versions are the same')
   t.equal(Assign({}).type(), 'Assign', 'reports Assign')
+
+  t.end()
+})
+
+test('Assign @@type', t => {
+  t.ok(isFunction(Assign({})['@@type']), 'is a function')
+
+  t.equal(Assign({})['@@type'], Assign['@@type'], 'static and instance versions are the same')
+  t.equal(Assign({})['@@type'](), 'crocks/Assign@1', 'reports crocks/Assign@1')
 
   t.end()
 })

--- a/src/Assign/index.js
+++ b/src/Assign/index.js
@@ -1,10 +1,14 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const _object = require('../core/object')
+
 const type = require('../core/types').type('Assign')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isNil = require('../core/isNil')
 const isObject = require('../core/isObject')
@@ -40,6 +44,7 @@ function Assign(o) {
   return {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
+    '@@type': _type,
     constructor: Assign
   }
 }
@@ -48,10 +53,8 @@ Assign['@@implements'] = _implements(
   [ 'concat', 'empty' ]
 )
 
-Assign.empty =
-  _empty
-
-Assign.type =
-  type
+Assign.empty = _empty
+Assign.type = type
+Assign['@@type'] = _type
 
 module.exports = Assign

--- a/src/Async/Async.spec.js
+++ b/src/Async/Async.spec.js
@@ -28,6 +28,7 @@ test('Async', t => {
 
   t.ok(isFunction(Async.of), 'provides an of function')
   t.ok(isFunction(Async.type), 'provides a type function')
+  t.ok(isFunction(Async['@@type']), 'provides a @@type function')
 
   t.equals(Async.Resolved(3).constructor, Async, 'provides TypeRep on constructor on Resolved')
   t.equals(Async.Rejected(3).constructor, Async, 'provides TypeRep on constructor on Rejected')
@@ -255,7 +256,19 @@ test('Async inspect', t => {
 })
 
 test('Async type', t => {
+  t.ok(isFunction(Async(unit).type), 'is a function')
+
+  t.equal(Async(unit).type, Async.type, 'static and instance versions are the same')
   t.equal(Async(unit).type(), 'Async', 'returns Async')
+
+  t.end()
+})
+
+test('Async @@type', t => {
+  t.ok(isFunction(Async(unit)['@@type']), 'is a function')
+
+  t.equal(Async(unit)['@@type'], Async['@@type'], 'static and instance versions are the same')
+  t.equal(Async(unit)['@@type'](), 'crocks/Async@1', 'returns Async')
 
   t.end()
 })

--- a/src/Async/index.js
+++ b/src/Async/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Async')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const array = require('../core/array')
 const compose = require('../core/compose')
@@ -240,12 +243,14 @@ function Async(fn, parentCancel) {
     toString: inspect, type,
     swap, coalesce, map, bimap,
     alt, ap, chain, of,
+    '@@type': _type,
     constructor: Async
   }
 }
 
-Async.type = type
 Async.of = _of
+Async.type = type
+Async['@@type'] = _type
 
 Async.Rejected = Rejected
 Async.Resolved = _of

--- a/src/Const/Const.spec.js
+++ b/src/Const/Const.spec.js
@@ -22,6 +22,7 @@ test('Const', t => {
   t.ok(isObject(m), 'returns an object')
 
   t.ok(isFunction(Const.type), 'provides a type function')
+  t.ok(isFunction(Const['@@type']), 'provides a @@type function')
 
   t.equals(Const(true).constructor, Const, 'provides TypeRep on constructor')
 
@@ -57,6 +58,16 @@ test('Const type', t => {
 
   t.ok(isFunction(m.type), 'provides a type function')
   t.equal(m.type(), 'Const', 'type returns Const')
+
+  t.end()
+})
+
+test('Const @@type', t => {
+  const m = Const(0)
+
+  t.ok(isFunction(m['@@type']), 'provides a @@type function')
+  t.equal(m['@@type'], Const['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Const@1', 'type returns crocks/Const@1')
 
   t.end()
 })

--- a/src/Const/index.js
+++ b/src/Const/index.js
@@ -1,10 +1,13 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _equals = require('../core/equals')
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Const')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
@@ -59,12 +62,13 @@ function Const(x) {
   return {
     inspect, toString: inspect, valueOf,
     type, equals, concat, map, ap, chain,
+    '@@type': _type,
     constructor: Const
   }
 }
 
-Const.type =
-  type
+Const.type = type
+Const['@@type'] = _type
 
 Const['@@implements'] = _implements(
   [ 'ap', 'chain', 'concat', 'equals', 'map' ]

--- a/src/Either/Either.spec.js
+++ b/src/Either/Either.spec.js
@@ -34,9 +34,10 @@ test('Either', t => {
   t.equals(Either.Left(0).constructor, Either, 'provides TypeRep on constructor for Left')
 
   t.ok(isFunction(Either.of), 'provides an of function')
-  t.ok(isFunction(Either.type), 'provides a type function')
   t.ok(isFunction(Either.Left), 'provides a Left function')
   t.ok(isFunction(Either.Right), 'provides a Right function')
+  t.ok(isFunction(Either.type), 'provides a type function')
+  t.ok(isFunction(Either['@@type']), 'provides a @@type function')
 
   const err = /Either: Must wrap something, try using Left or Right constructors/
   t.throws(Either, err, 'throws with no parameters')
@@ -93,7 +94,32 @@ test('Either inspect', t => {
 })
 
 test('Either type', t => {
-  t.equal(Either(0).type(), 'Either', 'type returns Either')
+  const { Left, Right } = Either
+
+  t.ok(isFunction(Right(0).type), 'is a function on Right')
+  t.ok(isFunction(Left(0).type), 'is a function on Left')
+
+  t.equal(Right(0).type, Either.type, 'static and instance versions are the same for Right')
+  t.equal(Left(0).type, Either.type, 'static and instance versions are the same for Left')
+
+  t.equal(Right(0).type(), 'Either', 'type returns Either for Right')
+  t.equal(Left(0).type(), 'Either', 'type returns Either for Left')
+
+  t.end()
+})
+
+test('Either @@type', t => {
+  const { Left, Right } = Either
+
+  t.ok(isFunction(Right(0)['@@type']), 'is a function on Right')
+  t.ok(isFunction(Left(0)['@@type']), 'is a function on Left')
+
+  t.equal(Right(0)['@@type'], Either['@@type'], 'static and instance versions are the same for Right')
+  t.equal(Left(0)['@@type'], Either['@@type'], 'static and instance versions are the same for Left')
+
+  t.equal(Right(0)['@@type'](), 'crocks/Either@1', 'returns crocks/Either@1 for Right')
+  t.equal(Left(0)['@@type'](), 'crocks/Either@1', 'returns crocks/Either@1 for Left')
+
   t.end()
 })
 

--- a/src/Either/index.js
+++ b/src/Either/index.js
@@ -1,12 +1,15 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _defineUnion = require('../core/defineUnion')
 const _equals = require('../core/equals')
 const _implements = require('../core/implements')
 const _innerConcat = require('../core/innerConcat')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Either')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const compose = require('../core/compose')
 const isArray = require('../core/isArray')
@@ -196,12 +199,14 @@ function Either(u) {
     type, concat, swap, coalesce, equals,
     map, bimap, alt, ap, of, chain, sequence,
     traverse,
+    '@@type': _type,
     constructor: Either
   }
 }
 
 Either.of   = _of
 Either.type = type
+Either['@@type'] = _type
 
 Either['@@implements'] = _implements(
   [ 'alt', 'ap', 'bimap', 'chain', 'concat', 'equals', 'map', 'of', 'traverse' ]

--- a/src/Endo/Endo.spec.js
+++ b/src/Endo/Endo.spec.js
@@ -24,6 +24,7 @@ test('Endo', t => {
 
   t.ok(isFunction(Endo.empty), 'provides an empty function')
   t.ok(isFunction(Endo.type), 'provides a type function')
+  t.ok(isFunction(Endo['@@type']), 'provides a @@type function')
 
   const err = /Endo: Function value required/
   t.throws(Endo, err, 'throws with nothing')
@@ -94,6 +95,16 @@ test('Endo type', t => {
 
   t.equal(m.type, Endo.type, 'static and instance versions are the same')
   t.equal(m.type(), 'Endo', 'reports Endo')
+
+  t.end()
+})
+
+test('Endo @@type', t => {
+  const m = Endo(identity)
+  t.ok(isFunction(m['@@type']), 'is a function')
+
+  t.equal(m['@@type'], Endo['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Endo@1', 'reports crocks/Endo@1')
 
   t.end()
 })

--- a/src/Endo/index.js
+++ b/src/Endo/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Endo')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
@@ -38,6 +41,7 @@ function Endo(runWith) {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
     runWith,
+    '@@type': _type,
     constructor: Endo
   }
 }
@@ -48,6 +52,7 @@ Endo['@@implements'] = _implements(
 
 Endo.empty = _empty
 Endo.type = type
+Endo['@@type'] = _type
 
 module.exports = Endo
 

--- a/src/Equiv/Equiv.spec.js
+++ b/src/Equiv/Equiv.spec.js
@@ -22,8 +22,9 @@ test('Equiv', t => {
 
   t.ok(isFunction(Equiv), 'is a function')
 
-  t.ok(isFunction(Equiv.type), 'provides a type function')
   t.ok(isFunction(Equiv.empty), 'provides an empty function')
+  t.ok(isFunction(Equiv.type), 'provides a type function')
+  t.ok(isFunction(Equiv['@@type']), 'provides a @@type function')
 
   t.ok(isObject(Equiv(isSame)), 'returns an object')
 
@@ -68,8 +69,23 @@ test('Equiv inspect', t => {
 })
 
 test('Equiv type', t => {
-  t.equal(Equiv(isSame).type(), 'Equiv', 'type returns Equiv')
-  t.equal(Equiv(isSame).type(), Equiv.type(), 'constructor and instance return same value')
+  const m = Equiv(isSame)
+
+  t.ok(isFunction(m.type), 'is a function')
+
+  t.equal(m.type, Equiv.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'Equiv', 'type returns Equiv')
+
+  t.end()
+})
+
+test('Equiv @@type', t => {
+  const m = Equiv(isSame)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+
+  t.equal(m['@@type'], Equiv['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Equiv@1', 'type returns crocks/Equiv@1')
 
   t.end()
 })

--- a/src/Equiv/index.js
+++ b/src/Equiv/index.js
@@ -1,6 +1,8 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 
@@ -9,6 +11,7 @@ const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
 
 const type = require('../core/types').type('Equiv')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const _empty =
   () => Equiv(() => true)
@@ -55,12 +58,14 @@ function Equiv(compare) {
     inspect, toString: inspect, type,
     compareWith, valueOf, contramap,
     concat, empty,
+    '@@type': _type,
     constructor: Equiv
   }
 }
 
-Equiv.type = type
 Equiv.empty = _empty
+Equiv.type = type
+Equiv['@@type'] = _type
 
 Equiv['@@implements'] = _implements(
   [ 'concat', 'contramap', 'empty' ]

--- a/src/First/First.spec.js
+++ b/src/First/First.spec.js
@@ -23,6 +23,7 @@ test('First', t => {
 
   t.ok(isFunction(First.empty), 'provides an empty function')
   t.ok(isFunction(First.type), 'provides a type function')
+  t.ok(isFunction(First['@@type']), 'provides a @@type function')
 
   const err = /First: Requires one argument/
   t.throws(First, err, 'throws when passed nothing')
@@ -73,9 +74,21 @@ test('First valueOf', t => {
 })
 
 test('First type', t => {
-  t.ok(isFunction(First(0).type), 'is a function')
-  t.equal(First.type, First(0).type, 'is the same function as the static type')
-  t.equal(First(0).type(), 'First', 'reports First')
+  const m = First(0)
+
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(First.type, m.type, 'is the same function as the static type')
+  t.equal(m.type(), 'First', 'reports First')
+
+  t.end()
+})
+
+test('First type', t => {
+  const m = First(0)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(First['@@type'], m['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/First@1', 'reports crocks/First@1')
 
   t.end()
 })

--- a/src/First/index.js
+++ b/src/First/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('First')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isSameType = require('../core/isSameType')
 
@@ -49,6 +52,7 @@ function First(x) {
     inspect, toString: inspect,
     concat, empty, option, type,
     valueOf,
+    '@@type': _type,
     constructor: First
   }
 }
@@ -59,5 +63,6 @@ First['@@implements'] = _implements(
 
 First.empty = _empty
 First.type = type
+First['@@type'] = _type
 
 module.exports = First

--- a/src/IO/IO.spec.js
+++ b/src/IO/IO.spec.js
@@ -29,6 +29,7 @@ test('IO', t => {
 
   t.ok(isFunction(IO.of), 'provides an of function')
   t.ok(isFunction(IO.type), 'provides a type function')
+  t.ok(isFunction(IO['@@type']), 'provides a @@type function')
 
   t.throws(io(), TypeError, 'throws with no parameters')
 
@@ -70,7 +71,22 @@ test('IO inspect', t => {
 })
 
 test('IO type', t => {
-  t.equal(IO(unit).type(), 'IO', 'type returns IO')
+  const m = IO(unit)
+
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(IO.type, m.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'IO', 'reports IO')
+
+  t.end()
+})
+
+test('IO @@type', t => {
+  const m = IO(unit)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(IO['@@type'], m['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/IO@1', 'reports crocks/IO@1')
+
   t.end()
 })
 

--- a/src/IO/index.js
+++ b/src/IO/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('IO')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
@@ -58,12 +61,14 @@ function IO(run) {
   return {
     inspect, toString: inspect, run,
     type, map, ap, of, chain,
+    '@@type': _type,
     constructor: IO
   }
 }
 
 IO.of = _of
 IO.type = type
+IO['@@type'] = _type
 
 IO['@@implements'] = _implements(
   [ 'ap', 'chain', 'map', 'of' ]

--- a/src/Identity/Identity.spec.js
+++ b/src/Identity/Identity.spec.js
@@ -30,6 +30,7 @@ test('Identity', t => {
 
   t.ok(isFunction(Identity.of), 'provides an of function')
   t.ok(isFunction(Identity.type), 'provides a type function')
+  t.ok(isFunction(Identity['@@type']), 'provides a @@type function')
 
   const err = /Identity: Must wrap something/
   t.throws(Identity, err, 'throws with no parameters')
@@ -65,7 +66,19 @@ test('Identity type', t => {
   const m = Identity(0)
 
   t.ok(isFunction(m.type), 'provides a type function')
+  t.equal(Identity.type, m.type, 'is the same function as the static type')
   t.equal(m.type(), 'Identity', 'type returns Identity')
+
+  t.end()
+})
+
+test('Identity @@type', t => {
+  const m = Identity(0)
+
+  t.ok(isFunction(m['@@type']), 'provides a @@type function')
+  t.equal(Identity['@@type'], m['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Identity@1', '@@type returns Identity')
+
   t.end()
 })
 

--- a/src/Identity/index.js
+++ b/src/Identity/index.js
@@ -1,11 +1,14 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _equals = require('../core/equals')
 const _implements = require('../core/implements')
 const _innerConcat = require('../core/innerConcat')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Identity')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isArray = require('../core/isArray')
 const isApply = require('../core/isApply')
@@ -105,12 +108,14 @@ function Identity(x) {
     inspect, toString: inspect, valueOf,
     type, equals, concat, map, ap, of,
     chain, sequence, traverse,
+    '@@type': _type,
     constructor: Identity
   }
 }
 
 Identity.of = _of
 Identity.type = type
+Identity['@@type'] = _type
 
 Identity['@@implements'] = _implements(
   [ 'ap', 'chain', 'concat', 'equals', 'map', 'of', 'traverse' ]

--- a/src/Last/Last.spec.js
+++ b/src/Last/Last.spec.js
@@ -21,6 +21,7 @@ test('Last', t => {
 
   t.ok(isFunction(Last.empty), 'provides an empty function')
   t.ok(isFunction(Last.type), 'provides a type function')
+  t.ok(isFunction(Last['@@type']), 'provides a @@type function')
 
   const err = /Last: Requires one argument/
   t.throws(Last, err, 'throws when passed nothing')
@@ -71,9 +72,21 @@ test('Last valueOf', t => {
 })
 
 test('Last type', t => {
-  t.ok(isFunction(Last(0).type), 'is a function')
-  t.equal(Last.type, Last(0).type, 'is the same function as the static type')
-  t.equal(Last(0).type(), 'Last', 'reports Last')
+  const m = Last(0)
+
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(Last.type, m.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'Last', 'reports Last')
+
+  t.end()
+})
+
+test('Last @@type', t => {
+  const m = Last(0)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(Last['@@type'], m['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Last@1', 'reports crocks/Last@1')
 
   t.end()
 })

--- a/src/Last/index.js
+++ b/src/Last/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Last')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isSameType = require('../core/isSameType')
 
@@ -51,6 +54,7 @@ function Last(x) {
   return {
     inspect, toString: inspect, concat,
     empty, option, type, valueOf,
+    '@@type': _type,
     constructor: Last
   }
 }
@@ -59,10 +63,8 @@ Last['@@implements'] = _implements(
   [ 'concat', 'empty' ]
 )
 
-Last.empty =
-  _empty
-
-Last.type =
-  type
+Last.empty = _empty
+Last.type = type
+Last['@@type'] = _type
 
 module.exports = Last

--- a/src/Max/Max.spec.js
+++ b/src/Max/Max.spec.js
@@ -15,10 +15,11 @@ test('Max', t => {
   const m = bindFunc(Max)
 
   t.ok(isFunction(Max), 'is a function')
+  t.ok(isObject(Max(0)), 'returns an object')
 
   t.ok(isFunction(Max.empty), 'provides an empty function')
   t.ok(isFunction(Max.type), 'provides a type function')
-  t.ok(isObject(Max(0)), 'returns an object')
+  t.ok(isFunction(Max['@@type']), 'provides a @@type function')
 
   t.equals(Max(0).constructor, Max, 'provides TypeRep on constructor')
 
@@ -73,10 +74,21 @@ test('Max valueOf', t => {
 })
 
 test('Max type', t => {
-  t.ok(isFunction(Max(0).type), 'is a function')
+  const m = Max(0)
 
-  t.equal(Max(0).type, Max.type, 'static and instance versions are the same')
-  t.equal(Max(0).type(), 'Max', 'reports Max')
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(m.type, Max.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'Max', 'reports Max')
+
+  t.end()
+})
+
+test('Max @@type', t => {
+  const m = Max(0)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(m['@@type'], Max['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Max@1', 'reports crocks/Max@1')
 
   t.end()
 })

--- a/src/Max/index.js
+++ b/src/Max/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Max')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isNil = require('../core/isNil')
 const isNumber = require('../core/isNumber')
@@ -39,6 +42,7 @@ function Max(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
+    '@@type': _type,
     constructor: Max
   }
 }
@@ -49,5 +53,6 @@ Max['@@implements'] = _implements(
 
 Max.empty = _empty
 Max.type = type
+Max['@@type'] = _type
 
 module.exports = Max

--- a/src/Min/Min.spec.js
+++ b/src/Min/Min.spec.js
@@ -15,10 +15,11 @@ test('Min', t => {
   const m = bindFunc(Min)
 
   t.ok(isFunction(Min), 'is a function')
+  t.ok(isObject(Min(0)), 'returns an object')
 
   t.ok(isFunction(Min.empty), 'provides an empty function')
   t.ok(isFunction(Min.type), 'provides a type function')
-  t.ok(isObject(Min(0)), 'returns an object')
+  t.ok(isFunction(Min['@@type']), 'provides a @@type function')
 
   t.equals(Min(0).constructor, Min, 'provides TypeRep on constructor')
 
@@ -73,10 +74,21 @@ test('Min valueOf', t => {
 })
 
 test('Min type', t => {
-  t.ok(isFunction(Min(0).type), 'is a function')
+  const m = Min(0)
 
-  t.equal(Min(0).type, Min.type, 'static and instance versions are the same')
-  t.equal(Min(0).type(), 'Min', 'reports Min')
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(m.type, Min.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'Min', 'reports Min')
+
+  t.end()
+})
+
+test('Min @@type', t => {
+  const m = Min(0)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(m['@@type'], Min['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Min@1', 'reports crocks/Min@1')
 
   t.end()
 })

--- a/src/Min/index.js
+++ b/src/Min/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Min')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isNil = require('../core/isNil')
 const isNumber = require('../core/isNumber')
@@ -39,6 +42,7 @@ function Min(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
+    '@@type': _type,
     constructor: Min
   }
 }
@@ -49,5 +53,6 @@ Min['@@implements'] = _implements(
 
 Min.empty = _empty
 Min.type = type
+Min['@@type'] = _type
 
 module.exports = Min

--- a/src/Pred/Pred.spec.js
+++ b/src/Pred/Pred.spec.js
@@ -18,11 +18,11 @@ test('Pred', t => {
   const p = bindFunc(Pred)
 
   t.ok(isFunction(Pred), 'is a function')
-
-  t.ok(isFunction(Pred.type), 'provides a type function')
-  t.ok(isFunction(Pred.empty), 'provides an empty function')
-
   t.ok(isObject(Pred(unit)), 'returns an object')
+
+  t.ok(isFunction(Pred.empty), 'provides an empty function')
+  t.ok(isFunction(Pred.type), 'provides a type function')
+  t.ok(isFunction(Pred['@@type']), 'provides a @@type function')
 
   t.equals(Pred(unit).constructor, Pred, 'provides TypeRep on constructor')
 
@@ -65,8 +65,21 @@ test('Pred inspect', t => {
 })
 
 test('Pred type', t => {
-  t.equal(Pred(unit).type(), 'Pred', 'type returns Pred')
-  t.equal(Pred(unit).type(), Pred.type(), 'constructor and instance return same value')
+  const m = Pred(unit)
+
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(m.type, Pred.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'Pred', 'type returns Pred')
+
+  t.end()
+})
+
+test('Pred @@type', t => {
+  const m = Pred(unit)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(m['@@type'], Pred['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Pred@1', 'reports crocks/Pred@1')
 
   t.end()
 })

--- a/src/Pred/index.js
+++ b/src/Pred/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Pred')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
@@ -48,12 +51,14 @@ function Pred(pred) {
   return {
     inspect, toString: inspect, runWith,
     type, valueOf, empty, concat, contramap,
+    '@@type': _type,
     constructor: Pred
   }
 }
 
 Pred.empty = _empty
 Pred.type = type
+Pred['@@type'] = _type
 
 Pred['@@implements'] = _implements(
   [ 'concat', 'contramap', 'empty' ]

--- a/src/Prod/Prod.spec.js
+++ b/src/Prod/Prod.spec.js
@@ -21,6 +21,7 @@ test('Prod', t => {
 
   t.ok(isFunction(Prod.empty), 'provides an empty function')
   t.ok(isFunction(Prod.type), 'provides a type function')
+  t.ok(isFunction(Prod['@@type']), 'provides a @@type function')
 
   t.throws(s(), TypeError, 'throws with nothing')
   t.throws(s(identity), TypeError, 'throws with a function')
@@ -73,10 +74,21 @@ test('Prod valueOf', t => {
 })
 
 test('Prod type', t => {
-  t.ok(isFunction(Prod(0).type), 'is a function')
+  const m = Prod(0)
 
-  t.equal(Prod(0).type, Prod.type, 'static and instance versions are the same')
-  t.equal(Prod(0).type(), 'Prod', 'reports Prod')
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(m.type, Prod.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'Prod', 'reports Prod')
+
+  t.end()
+})
+
+test('Prod @@type', t => {
+  const m = Prod(0)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(m['@@type'], Prod['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Prod@1', 'reports crocks/Prod@1')
 
   t.end()
 })

--- a/src/Prod/index.js
+++ b/src/Prod/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Prod')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isNil = require('../core/isNil')
 const isNumber = require('../core/isNumber')
@@ -39,6 +42,7 @@ function Prod(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
+    '@@type': _type,
     constructor: Prod
   }
 }
@@ -49,5 +53,6 @@ Prod['@@implements'] = _implements(
 
 Prod.empty = _empty
 Prod.type = type
+Prod['@@type'] = _type
 
 module.exports = Prod

--- a/src/Reader/Reader.spec.js
+++ b/src/Reader/Reader.spec.js
@@ -29,9 +29,9 @@ test('Reader', t => {
   t.equals(Reader(unit).constructor, Reader, 'provides TypeRep on constructor')
 
   t.ok(isFunction(Reader.of), 'provides an of function')
-  t.ok(isFunction(Reader.type), 'provides a type function')
   t.ok(isFunction(Reader.ask), 'provides an ask function')
-
+  t.ok(isFunction(Reader.type), 'provides a type function')
+  t.ok(isFunction(Reader['@@type']), 'provides a @@type function')
 
   const err = /Reader: Must wrap a function/
   t.throws(r(), err, 'throws with no parameters')
@@ -73,7 +73,20 @@ test('Reader inspect', t => {
 })
 
 test('Reader type', t => {
-  t.equal(Reader(unit).type(), 'Reader', 'type returns Reader')
+  const m = Reader(unit)
+
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(Reader.type, m.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'Reader', 'type returns Reader')
+  t.end()
+})
+
+test('Reader @@type', t => {
+  const m = Reader(unit)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(Reader['@@type'], m['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Reader@1', 'type returns crocks/Reader@1')
   t.end()
 })
 

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Reader')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
@@ -78,13 +81,15 @@ function Reader(runWith) {
   return {
     inspect, toString: inspect, runWith,
     type, map, ap, chain, of,
+    '@@type': _type,
     constructor: Reader
   }
 }
 
 Reader.of = _of
-Reader.type = type
 Reader.ask = ask
+Reader.type = type
+Reader['@@type'] = _type
 
 Reader['@@implements'] = _implements(
   [ 'ap', 'chain', 'map', 'of' ]

--- a/src/Result/Result.spec.js
+++ b/src/Result/Result.spec.js
@@ -34,9 +34,10 @@ test('Result', t => {
   t.equals(Result.Err(true).constructor, Result, 'provides TypeRep on constructor for Err')
 
   t.ok(isFunction(Result.of), 'provides an of function')
-  t.ok(isFunction(Result.type), 'provides a type function')
   t.ok(isFunction(Result.Err), 'provides an Err function')
   t.ok(isFunction(Result.Ok), 'provides an Ok function')
+  t.ok(isFunction(Result.type), 'provides a type function')
+  t.ok(isFunction(Result['@@type']), 'provides a @@type function')
 
   const err = /Result: Must wrap something, try using Err or Ok constructors/
   t.throws(Result, err, 'throws with no parameters')
@@ -93,7 +94,38 @@ test('Result inspect', t => {
 })
 
 test('Result type', t => {
-  t.equal(Result(0).type(), 'Result', 'type returns Result')
+  const { Err, Ok } = Result
+
+  const m = Ok(0)
+  const e = Err(0)
+
+  t.ok(isFunction(m.type), 'is a function on Ok')
+  t.ok(isFunction(e.type), 'is a function on Err')
+
+  t.equal(Result.type, m.type, 'static and instance versions are the same for Ok')
+  t.equal(Result.type, e.type, 'static and instance versions are the same for Err')
+
+  t.equal(m.type(), 'Result', 'reports Result for Ok')
+  t.equal(e.type(), 'Result', 'reports Result for Err')
+
+  t.end()
+})
+
+test('Result @@type', t => {
+  const { Err, Ok } = Result
+
+  const m = Ok(0)
+  const e = Err(0)
+
+  t.ok(isFunction(m['@@type']), 'is a function on Ok')
+  t.ok(isFunction(e['@@type']), 'is a function on Err')
+
+  t.equal(Result['@@type'], m['@@type'], 'static and instance versions are the same for Ok')
+  t.equal(Result['@@type'], e['@@type'], 'static and instance versions are the same for Err')
+
+  t.equal(m['@@type'](), 'crocks/Result@1', 'reports crocks/Result@1 for Ok')
+  t.equal(e['@@type'](), 'crocks/Result@1', 'reports crocks/Result@1 for Err')
+
   t.end()
 })
 

--- a/src/Result/index.js
+++ b/src/Result/index.js
@@ -1,12 +1,15 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _defineUnion = require('../core/defineUnion')
 const _equals = require('../core/equals')
 const _implements = require('../core/implements')
 const _innerConcat = require('../core/innerConcat')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Result')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const compose = require('../core/compose')
 const isApply = require('../core/isApply')
@@ -206,12 +209,14 @@ function Result(u) {
     type, either, concat, swap, coalesce,
     map, bimap, alt, ap, chain, of, sequence,
     traverse,
+    '@@type': _type,
     constructor: Result
   }
 }
 
 Result.of = _of
 Result.type = type
+Result['@@type'] = _type
 
 Result['@@implements'] = _implements(
   [ 'alt', 'ap', 'bimap', 'chain', 'concat', 'equals', 'map', 'of', 'traverse' ]

--- a/src/Star/Star.spec.js
+++ b/src/Star/Star.spec.js
@@ -24,12 +24,12 @@ test('Star', t => {
   const a = bindFunc(_Star)
 
   t.ok(isFunction(_Star), 'is a function')
+  t.ok(isObject(Star(unit)), 'returns an object')
 
   t.ok(isFunction(Star.type), 'provides a type function')
+  t.ok(isFunction(Star['@@type']), 'provides a @@type function')
 
   t.equals(Star(unit).constructor, Star, 'provides TypeRep on constructor')
-
-  t.ok(isObject(Star(unit)), 'returns an object')
 
   const err = /Star: Monad required for construction/
   t.throws(a(), err, 'throws with nothing')
@@ -55,8 +55,9 @@ test('Star construction', t => {
 
   t.ok(isFunction(Star), 'Constructor returns a function')
 
-  t.ok(isFunction(Star.type), 'provides a type function')
   t.ok(isFunction(Star.id), 'provides an id function')
+  t.ok(isFunction(Star.type), 'provides a type function')
+  t.ok(isFunction(Star['@@type']), 'provides a @@type function')
 
   t.ok(isObject(Star(unit)), 'returns an object')
 
@@ -101,11 +102,21 @@ test('Star inspect', t => {
 })
 
 test('Star type', t => {
-  const a = Star(unit)
-  t.ok(isFunction(a.type), 'is a function')
+  const m = Star(unit)
 
-  t.equal(a.type, Star.type, 'static and instance versions are the same')
-  t.equal(a.type(), 'Star( MockCrock )', 'reports Star with embeded type')
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(m.type, Star.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'Star( MockCrock )', 'reports Star with embeded type')
+
+  t.end()
+})
+
+test('Star @@type', t => {
+  const m = Star(unit)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(m['@@type'], Star['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Star@1( crocks/MockCrock@1 )', 'reports crocks/Star@1 with embeded type')
 
   t.end()
 })

--- a/src/Star/index.js
+++ b/src/Star/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const _type = require('../core/types').type('Star')
+const __type = require('../core/types').typeFn(_type(), VERSION)
 
 const array = require('../core/array')
 const isFunction = require('../core/isFunction')
@@ -29,8 +32,14 @@ function _Star(Monad) {
   const innerType =
     Monad.type()
 
+  const innerFullType =
+    Monad['@@type']()
+
   const outerType =
     `${_type()}( ${innerType} )`
+
+  const typeFn =
+    () => `${__type()}( ${innerFullType} )`
 
   const type =
     () => outerType
@@ -163,12 +172,14 @@ function _Star(Monad) {
       inspect, toString: inspect, type,
       runWith, id, compose, map, contramap,
       promap, first, second, both,
+      '@@type': typeFn,
       constructor: Star
     }
   }
 
   Star.id = _id
   Star.type = type
+  Star['@@type'] = typeFn
 
   Star['@@implements'] = _implements(
     [ 'compose', 'contramap', 'id', 'map', 'promap' ]

--- a/src/State/State.spec.js
+++ b/src/State/State.spec.js
@@ -26,10 +26,11 @@ test('State', t => {
   t.equals(State(unit).constructor, State, 'provides TypeRep on constructor')
 
   t.ok(isFunction(State.of), 'provides an of function')
-  t.ok(isFunction(State.type), 'provides a type function')
   t.ok(isFunction(State.get), 'provides a get function')
   t.ok(isFunction(State.put), 'provides a put function')
   t.ok(isFunction(State.modify), 'provides a modify function')
+  t.ok(isFunction(State.type), 'provides a type function')
+  t.ok(isFunction(State['@@type']), 'provides a @@type function')
 
   const err = /State: Must wrap a function in the form \(s -> Pair a s\)/
   t.throws(s(), err, 'throws with no parameters')
@@ -72,7 +73,22 @@ test('State inspect', t => {
 })
 
 test('State type', t => {
-  t.equal(State(unit).type(), 'State', 'type returns State')
+  const m = State(unit)
+
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(State.type, m.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'State', 'type returns State')
+
+  t.end()
+})
+
+test('State @@type', t => {
+  const m = State(unit)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(State['@@type'], m['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/State@1', 'reports crocks/State@1')
+
   t.end()
 })
 

--- a/src/State/index.js
+++ b/src/State/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('State')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const Pair = require('../core/Pair')
 const Unit = require('../core/Unit')
@@ -115,18 +118,21 @@ function State(fn) {
     inspect, toString: inspect, runWith,
     execWith, evalWith, type, map, ap,
     chain, of,
+    '@@type': _type,
     constructor: State
   }
 }
 
 State.of = _of
-State.type = type
 State.get = get
 
 State.modify = modify
 
 State.put =
   x => modify(() => (x))
+
+State.type = type
+State['@@type'] = _type
 
 State['@@implements'] = _implements(
   [ 'ap', 'chain', 'map', 'of' ]

--- a/src/Sum/Sum.spec.js
+++ b/src/Sum/Sum.spec.js
@@ -21,6 +21,7 @@ test('Sum', t => {
 
   t.ok(isFunction(Sum.empty), 'provides an empty function')
   t.ok(isFunction(Sum.type), 'provides a type function')
+  t.ok(isFunction(Sum['@@type']), 'provides a @@type function')
 
   t.throws(Sum, TypeError, 'throws with nothing')
   t.throws(s(identity), TypeError, 'throws with a function')
@@ -73,10 +74,21 @@ test('Sum valueOf', t => {
 })
 
 test('Sum type', t => {
-  t.ok(isFunction(Sum(0).type), 'is a function')
+  const m = Sum(0)
 
-  t.equal(Sum(0).type, Sum.type, 'static and instance versions are the same')
-  t.equal(Sum(0).type(), 'Sum', 'reports Sum')
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(m.type, Sum.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'Sum', 'reports Sum')
+
+  t.end()
+})
+
+test('Sum @@type', t => {
+  const m = Sum(0)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(m['@@type'], Sum['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Sum@1', 'reports crocks/Sum@1')
 
   t.end()
 })

--- a/src/Sum/index.js
+++ b/src/Sum/index.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Sum')
+const _type = require('../core/types').typeFn(type(), VERSION)
 
 const isNil = require('../core/isNil')
 const isNumber = require('../core/isNumber')
@@ -39,6 +42,7 @@ function Sum(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
+    '@@type': _type,
     constructor: Sum
   }
 }
@@ -49,5 +53,6 @@ Sum['@@implements'] = _implements(
 
 Sum.empty = _empty
 Sum.type = type
+Sum['@@type'] = _type
 
 module.exports = Sum

--- a/src/Writer/Writer.spec.js
+++ b/src/Writer/Writer.spec.js
@@ -51,6 +51,7 @@ test('Writer', t => {
 
   t.ok(isFunction(Writer.of), 'provides an of function')
   t.ok(isFunction(Writer.type), 'provides a type function')
+  t.ok(isFunction(Writer['@@type']), 'provides a @@type function')
 
   t.throws(f(), TypeError, 'throws with no parameters')
   t.throws(f(0), TypeError, 'throws with one parameter')
@@ -84,7 +85,19 @@ test('Writer type', t => {
   const m = Writer(0, 0)
 
   t.ok(isFunction(m.type), 'is a function')
+  t.equal(Writer.type, m.type, 'static and instance versions are the same')
   t.equal(m.type(), 'Writer( Last )', 'returns Writer with Monoid Type')
+
+  t.end()
+})
+
+test('Writer @@type', t => {
+  const m = Writer(0, 0)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(Writer['@@type'], m['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Writer@1( crocks/Last@1 )', 'returns crocks/Writer@1 with Monoid Type')
+
   t.end()
 })
 

--- a/src/Writer/index.js
+++ b/src/Writer/index.js
@@ -1,10 +1,14 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _equals = require('../core/equals')
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const __type = require('../core/types').type('Writer')
+const _typeFn = require('../core/types').typeFn(__type(), VERSION)
+
 const Pair = require('../core/Pair')
 
 const isFunction = require('../core/isFunction')
@@ -22,7 +26,10 @@ function _Writer(Monoid) {
     x => Writer(Monoid.empty().valueOf(), x)
 
   const _type =
-    () => `${__type()}( ${Monoid.type()} )`
+    constant(`${__type()}( ${Monoid.type()} )`)
+
+  const typeFn =
+    constant(`${_typeFn()}( ${Monoid['@@type']()} )`)
 
   function Writer(entry, val) {
     if(arguments.length !== 2) {
@@ -88,15 +95,14 @@ function _Writer(Monoid) {
       inspect, toString: inspect, read,
       valueOf, log, type, equals, map,
       ap, of, chain,
+      '@@type': typeFn,
       constructor: Writer
     }
   }
 
-  Writer.of =
-    _of
-
-  Writer.type =
-    _type
+  Writer.of = _of
+  Writer.type = _type
+  Writer['@@type'] = typeFn
 
   Writer['@@implements'] = _implements(
     [ 'ap', 'chain', 'equals', 'map', 'of' ]

--- a/src/core/List.js
+++ b/src/core/List.js
@@ -1,10 +1,13 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _equals = require('./equals')
 const _implements = require('./implements')
 const _inspect = require('./inspect')
 const type = require('./types').type('List')
+const _type = require('./types').typeFn(type(), VERSION)
 
 const array = require('./array')
 
@@ -235,18 +238,15 @@ function List(x) {
     head, tail, cons, type, equals, concat, empty,
     reduce, fold, filter, reject, map, ap, of, chain,
     sequence, traverse,
+    '@@type': _type,
     constructor: List
   }
 }
 
-List.type =
-  type
-
-List.of =
-  _of
-
-List.empty =
-  _empty
+List.of = _of
+List.empty = _empty
+List.type = type
+List['@@type'] = _type
 
 List.fromArray =
   fromArray

--- a/src/core/List.spec.js
+++ b/src/core/List.spec.js
@@ -34,6 +34,7 @@ test('List', t => {
   t.ok(isFunction(List.of), 'provides an of function')
   t.ok(isFunction(List.fromArray), 'provides a fromArray function')
   t.ok(isFunction(List.type), 'provides a type function')
+  t.ok(isFunction(List['@@type']), 'provides a @@type function')
 
   const err = /List: List must wrap something/
   t.throws(List, err, 'throws with no parameters')
@@ -84,7 +85,7 @@ test('List fromArray', t => {
 
   const data = [ [ 2, 1 ], 'a' ]
 
-  t.equal(List.fromArray([ 0 ]).type(), 'List', 'returns a List')
+  t.ok(isSameType(List, List.fromArray([ 0 ])), 'returns a List')
   t.same(List.fromArray(data).valueOf(), data, 'wraps the value passed into List in an array')
 
   t.end()
@@ -101,7 +102,24 @@ test('List inspect', t => {
 })
 
 test('List type', t => {
-  t.equal(List([]).type(), 'List', 'returns List')
+  const m = List([])
+
+  t.ok(isFunction(m.type), 'is a function')
+
+  t.equal(m.type, List.type, 'static and instance versions are the same')
+  t.equal(m.type(), 'List', 'returns List')
+
+  t.end()
+})
+
+test('List @@type', t => {
+  const m = List([])
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+
+  t.equal(m['@@type'], List['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/List@1', 'returns crocks/List@1')
+
   t.end()
 })
 
@@ -112,9 +130,9 @@ test('List head', t => {
 
   t.ok(isFunction(two.head), 'Provides a head Function')
 
-  t.equal(empty.head().type(), Maybe.type(), 'empty List returns a Maybe')
-  t.equal(one.head().type(), Maybe.type(), 'one element List returns a Maybe')
-  t.equal(two.head().type(), Maybe.type(), 'two element List returns a Maybe')
+  t.ok(isSameType(Maybe, empty.head()), 'empty List returns a Maybe')
+  t.ok(isSameType(Maybe, one.head()), 'one element List returns a Maybe')
+  t.ok(isSameType(Maybe, two.head()), 'two element List returns a Maybe')
 
   t.equal(empty.head().option('Nothing'), 'Nothing', 'empty List returns a Nothing')
   t.equal(one.head().option('Nothing'), 1, 'one element List returns a `Just 1`')

--- a/src/core/Maybe.js
+++ b/src/core/Maybe.js
@@ -1,12 +1,15 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _defineUnion = require('./defineUnion')
 const _equals = require('./equals')
 const _implements = require('./implements')
 const _innerConcat = require('./innerConcat')
 const _inspect = require('./inspect')
 const type = require('./types').type('Maybe')
+const _type = require('./types').typeFn(type(), VERSION)
 
 const compose = require('./compose')
 const isApply = require('./isApply')
@@ -191,18 +194,15 @@ function Maybe(u) {
     option, type, concat, equals, coalesce,
     map, alt, zero, ap, of, chain, sequence,
     traverse,
+    '@@type': _type,
     constructor: Maybe
   }
 }
 
-Maybe.of =
-  _of
-
-Maybe.type =
-  type
-
-Maybe.zero =
-  _zero
+Maybe.of = _of
+Maybe.zero = _zero
+Maybe.type = type
+Maybe['@@type'] = _type
 
 Maybe['@@implements'] = _implements(
   [ 'alt', 'ap', 'chain', 'concat', 'equals', 'map', 'of', 'traverse', 'zero' ]

--- a/src/core/Maybe.spec.js
+++ b/src/core/Maybe.spec.js
@@ -34,10 +34,11 @@ test('Maybe', t => {
   t.equals(Maybe.Nothing().constructor, Maybe, 'provides TypeRep on constructor for Nothing')
 
   t.ok(isFunction(Maybe.of), 'provides an of function')
-  t.ok(isFunction(Maybe.type), 'provides a type function')
   t.ok(isFunction(Maybe.zero), 'provides a zero function')
   t.ok(isFunction(Maybe.Nothing), 'provides a Nothing constructor')
   t.ok(isFunction(Maybe.Just), 'provides a Just constructor')
+  t.ok(isFunction(Maybe.type), 'provides a type function')
+  t.ok(isFunction(Maybe['@@type']), 'provides a @@type function')
 
   const err = /Maybe: Must wrap something, try using Nothing or Just constructors/
   t.throws(Maybe, err, 'throws with no parameters')
@@ -77,8 +78,29 @@ test('Maybe inspect', t => {
 })
 
 test('Maybe type', t => {
-  t.equal(Maybe.Just(0).type(), 'Maybe', 'type returns Maybe for Just')
-  t.equal(Maybe.Nothing().type(), 'Maybe', 'type returns Maybe for Nothing')
+  const { Just, Nothing } = Maybe
+
+  t.ok(isFunction(Maybe(0).type), 'is a function')
+
+  t.equal(Just(0).type, Maybe.type, 'static and instance versions are the same for Just')
+  t.equal(Nothing(0).type, Maybe.type, 'static and instance versions are the same for Nothing')
+
+  t.equal(Just(0).type(), 'Maybe', 'type returns Maybe for Just')
+  t.equal(Nothing().type(), 'Maybe', 'type returns Maybe for Nothing')
+
+  t.end()
+})
+
+test('Maybe @@type', t => {
+  const { Just, Nothing } = Maybe
+
+  t.ok(isFunction(Maybe(0)['@@type']), 'is a function')
+
+  t.equal(Just(0)['@@type'], Maybe['@@type'], 'static and instance versions are the same for Just')
+  t.equal(Nothing(0)['@@type'], Maybe['@@type'], 'static and instance versions are the same for Nothing')
+
+  t.equal(Just(0)['@@type'](), 'crocks/Maybe@1', 'type returns crocks/Maybe@1 for Just')
+  t.equal(Nothing()['@@type'](), 'crocks/Maybe@1', 'type returns crocks/Maybe@1 for Nothing')
 
   t.end()
 })

--- a/src/core/Pair.js
+++ b/src/core/Pair.js
@@ -1,10 +1,13 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _equals = require('./equals')
 const _implements = require('./implements')
 const _inspect = require('./inspect')
 const type = require('./types').type('Pair')
+const _type = require('./types').typeFn(type(), VERSION)
 
 const isFunction = require('./isFunction')
 const isSameType = require('./isSameType')
@@ -152,12 +155,13 @@ function Pair(l, r) {
     snd, toArray, type, merge, equals,
     concat, swap, map, bimap, ap, chain,
     extend,
+    '@@type': _type,
     constructor: Pair
   }
 }
 
-Pair.type =
-  type
+Pair.type = type
+Pair['@@type'] = _type
 
 Pair['@@implements'] = _implements(
   [ 'ap', 'bimap', 'chain', 'concat', 'extend', 'equals', 'map' ]

--- a/src/core/Pair.spec.js
+++ b/src/core/Pair.spec.js
@@ -27,6 +27,7 @@ test('Pair core', t => {
   t.equals(Pair(0, 0).constructor, Pair, 'provides TypeRep on constructor')
 
   t.ok(isFunction(Pair.type), 'provides a type function')
+  t.ok(isFunction(Pair['@@type']), 'provides a @@type function')
 
   const err = /Pair: Must provide a first and second value/
   t.throws(m(), err, 'throws with no parameters')
@@ -62,8 +63,21 @@ test('Pair inspect', t => {
 test('Pair type', t => {
   const p = Pair(0, 0)
 
-  t.ok(isFunction(p.type), 'provides a type function')
+  t.ok(isFunction(p.type), 'is a function')
+
+  t.equal(p.type, Pair.type, 'static and instance versions are the same')
   t.equal(p.type(), 'Pair', 'type returns Pair')
+
+  t.end()
+})
+
+test('Pair @@type', t => {
+  const p = Pair(0, 0)
+
+  t.ok(isFunction(p['@@type']), 'is a function')
+
+  t.equal(p['@@type'], Pair['@@type'], 'static and instance versions are the same')
+  t.equal(p['@@type'](), 'crocks/Pair@1', 'type returns crocks/Pair@1')
 
   t.end()
 })

--- a/src/core/Unit.js
+++ b/src/core/Unit.js
@@ -1,8 +1,11 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('./implements')
 const type = require('./types').type('Unit')
+const _type = require('./types').typeFn(type(), VERSION)
 
 const isFunction = require('./isFunction')
 const isSameType = require('./isSameType')
@@ -65,13 +68,15 @@ function Unit() {
     inspect, toString: inspect, valueOf,
     type, equals, concat, empty, map, ap,
     of, chain,
+    '@@type': _type,
     constructor: Unit
   }
 }
 
-Unit.type = type
 Unit.of = _of
 Unit.empty = _empty
+Unit.type = type
+Unit['@@type'] = _type
 
 Unit['@@implements'] = _implements(
   [ 'ap', 'chain', 'concat', 'empty', 'equals', 'map', 'of' ]

--- a/src/core/Unit.spec.js
+++ b/src/core/Unit.spec.js
@@ -27,8 +27,9 @@ test('Unit', t => {
 
   t.equals(Unit(false).constructor, Unit, 'provides TypeRep on constructor')
 
-  t.ok(isFunction(Unit.type), 'provides a type function')
   t.ok(isFunction(Unit.empty), 'provides an empty function')
+  t.ok(isFunction(Unit.type), 'provides a type function')
+  t.ok(isFunction(Unit['@@type']), 'provides a @@type function')
 
   t.doesNotThrow(Unit, 'allows no parameters')
 
@@ -62,8 +63,19 @@ test('Unit inspect', t => {
 test('Unit type', t => {
   const m = Unit(0)
 
-  t.ok(isFunction(m.type), 'provides a type function')
+  t.ok(isFunction(m.type), 'is a function')
+  t.equal(m.type, Unit.type, 'static and instance versions are the same')
   t.equal(m.type(), 'Unit', 'type returns Unit')
+
+  t.end()
+})
+
+test('Unit @@type', t => {
+  const m = Unit(0)
+
+  t.ok(isFunction(m['@@type']), 'is a function')
+  t.equal(m['@@type'], Unit['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'](), 'crocks/Unit@1', 'type returns crocks/Unit@1')
 
   t.end()
 })

--- a/src/core/types.js
+++ b/src/core/types.js
@@ -38,6 +38,11 @@ const type =
 const proxy =
   t => ({ type: type(t) })
 
+const typeFn = (t, ver) => {
+  const typeStr = type(t)()
+  return () => `crocks/${typeStr}@${ver || 0}`
+}
+
 module.exports = {
-  proxy, type
+  proxy, type, typeFn
 }

--- a/src/core/types.spec.js
+++ b/src/core/types.spec.js
@@ -5,10 +5,11 @@ const isFunction = require('./isFunction')
 const _types = require('./types')
 
 test('types core', t => {
-  const { proxy, type } = _types
+  const { proxy, type, typeFn } = _types
 
   t.ok(isFunction(type), 'provides a `types` function')
   t.ok(isFunction(proxy), 'provides a `proxy` function')
+  t.ok(isFunction(typeFn), 'provides a `typeFn` function')
 
   t.end()
 })
@@ -28,6 +29,7 @@ test('type function ', t => {
   t.equals(fn('Const'), 'Const', 'returns `Const` for key `Const`')
   t.equals(fn('Either'), 'Either', 'returns `Either` for key `Either`')
   t.equals(fn('Endo'), 'Endo', 'returns `Endo` for key `Endo`')
+  t.equals(fn('Equiv'), 'Equiv', 'returns `Equiv` for key `Equiv`')
   t.equals(fn('First'), 'First', 'returns `First` for key `First`')
   t.equals(fn('Identity'), 'Identity', 'returns `Identity` for key `Identity`')
   t.equals(fn('IO'), 'IO', 'returns `IO` for key `IO`')
@@ -65,6 +67,7 @@ test('proxy function ', t => {
   t.equals(fn('Const'), 'Const', 'returns `Const` for key `Const`')
   t.equals(fn('Either'), 'Either', 'returns `Either` for key `Either`')
   t.equals(fn('Endo'), 'Endo', 'returns `Endo` for key `Endo`')
+  t.equals(fn('Equiv'), 'Equiv', 'returns `Equiv` for key `Equiv`')
   t.equals(fn('First'), 'First', 'returns `First` for key `First`')
   t.equals(fn('Identity'), 'Identity', 'returns `Identity` for key `Identity`')
   t.equals(fn('IO'), 'IO', 'returns `IO` for key `IO`')
@@ -83,6 +86,47 @@ test('proxy function ', t => {
   t.equals(fn('Sum'), 'Sum', 'returns `Sum` for key `Sum`')
   t.equals(fn('Unit'), 'Unit', 'returns `Unit` for key `Unit`')
   t.equals(fn('Writer'), 'Writer', 'returns `Writer` for key `Writer`')
+
+  t.end()
+})
+
+test('typeFn function ', t => {
+  const { typeFn } = _types
+
+  const fn =
+    (x, v) => typeFn(x, v)()
+
+  t.equals(fn('All'), 'crocks/All@0', 'returns `crocks/All@0` for key `All` with no version')
+  t.equals(fn('All', 1), 'crocks/All@1', 'returns `crocks/All@1` for key `All` with a version of 1')
+
+  t.equals(fn('silly'), 'crocks/unknown@0', 'returns `crocks/unknown@0` if key is not defined')
+  t.equals(fn('All'), 'crocks/All@0', 'returns `crocks/All@0` for key `All`')
+  t.equals(fn('Any'), 'crocks/Any@0', 'returns `crocks/Any@0` for key `Any`')
+  t.equals(fn('Arrow'), 'crocks/Arrow@0', 'returns `crocks/Arrow@0` for key `Arrow`')
+  t.equals(fn('Assign'), 'crocks/Assign@0', 'returns `crocks/Assign@0` for key `Assign`')
+  t.equals(fn('Async'), 'crocks/Async@0', 'returns `crocks/Async@0` for key `Async`')
+  t.equals(fn('Const'), 'crocks/Const@0', 'returns `crocks/Const@0` for key `Const`')
+  t.equals(fn('Either'), 'crocks/Either@0', 'returns `crocks/Either@0` for key `Either`')
+  t.equals(fn('Endo'), 'crocks/Endo@0', 'returns `crocks/Endo@0` for key `Endo`')
+  t.equals(fn('Equiv'), 'crocks/Equiv@0', 'returns `crocks/Equiv@0` for key `Equiv`')
+  t.equals(fn('First'), 'crocks/First@0', 'returns `crocks/First@0` for key `First`')
+  t.equals(fn('Identity'), 'crocks/Identity@0', 'returns `crocks/Identity@0` for key `Identity`')
+  t.equals(fn('IO'), 'crocks/IO@0', 'returns `crocks/IO@0` for key `IO`')
+  t.equals(fn('Last'), 'crocks/Last@0', 'returns `crocks/Last@0` for key `Last`')
+  t.equals(fn('List'), 'crocks/List@0', 'returns `crocks/List@0` for key `List`')
+  t.equals(fn('Max'), 'crocks/Max@0', 'returns `crocks/Max@0` for key `Max`')
+  t.equals(fn('Maybe'), 'crocks/Maybe@0', 'returns `crocks/Maybe@0` for key `Maybe`')
+  t.equals(fn('Min'), 'crocks/Min@0', 'returns `crocks/Min@0` for key `Min`')
+  t.equals(fn('Pair'), 'crocks/Pair@0', 'returns `crocks/Pair@0` for key `Pair`')
+  t.equals(fn('Pred'), 'crocks/Pred@0', 'returns `crocks/Pred@0` for key `Pred`')
+  t.equals(fn('Prod'), 'crocks/Prod@0', 'returns `crocks/Prod@0` for key `Prod`')
+  t.equals(fn('Reader'), 'crocks/Reader@0', 'returns `crocks/Reader@0` for key `Reader`')
+  t.equals(fn('Result'), 'crocks/Result@0', 'returns `crocks/Result@0` for key `Result`')
+  t.equals(fn('Star'), 'crocks/Star@0', 'returns `crocks/Star@0` for key `Star`')
+  t.equals(fn('State'), 'crocks/State@0', 'returns `crocks/State@0` for key `State`')
+  t.equals(fn('Sum'), 'crocks/Sum@0', 'returns `crocks/Sum@0` for key `Sum`')
+  t.equals(fn('Unit'), 'crocks/Unit@0', 'returns `crocks/Unit@0` for key `Unit`')
+  t.equals(fn('Writer'), 'crocks/Writer@0', 'returns `crocks/Writer@0` for key `Writer`')
 
   t.end()
 })

--- a/src/test/LastMonoid.js
+++ b/src/test/LastMonoid.js
@@ -4,19 +4,22 @@ const _inspect = require('../core/inspect')
 const constant = x => () => x
 const identity = x => x
 
+const typeFn = constant('crocks/Last@1')
 const _type = constant('Last')
 
 function LastMonoid(x) {
   return {
     inspect: constant('Last' + _inspect(x)),
     concat: identity,
-    valueOf:  constant(x),
-    type:   _type
+    valueOf: constant(x),
+    type: _type,
+    '@@type': typeFn
   }
 }
 
 LastMonoid.empty = () => LastMonoid(null)
 LastMonoid.type = _type
+LastMonoid['@@type'] = typeFn
 
 LastMonoid['@@implements'] = _implements(
   [ 'concat', 'empty' ]

--- a/src/test/MockCrock.js
+++ b/src/test/MockCrock.js
@@ -4,6 +4,7 @@ const _equals = require('../core/equals')
 const constant = x => () => x
 
 const _type = constant('MockCrock')
+const typeFn = constant('crocks/MockCrock@1')
 const _of   = x => MockCrock(x)
 
 function MockCrock(x) {
@@ -21,12 +22,14 @@ function MockCrock(x) {
   return {
     valueOf, type, map, ap,
     chain, of, sequence,
+    '@@type': typeFn,
     traverse, equals
   }
 }
 
-MockCrock.type  = _type
-MockCrock.of    = _of
+MockCrock.of = _of
+MockCrock.type = _type
+MockCrock['@@type'] = typeFn
 
 MockCrock['@@implements'] = _implements(
   [ 'ap', 'chain', 'equals', 'map', 'of', 'traverse' ]


### PR DESCRIPTION
## The path to enlightenment
![image](https://user-images.githubusercontent.com/3665793/35485946-9253e440-041b-11e8-80ee-62b5842371c4.png)

This PR is another step in addressing [this issue](https://github.com/evilsoft/crocks/issues/162) to add the `@@type` method/static function to all ADTs. This PR only adds `@@type` and ADT versioning to the ADTs and does not actually utilize it yet.

There will be (2) follow up PRs to this one to complete the actual item on the issue:
1. Switch all type checking to use the core `isSameType` function and have `isSameType` check `@@type`. (non-breaking)
1. Remove `type` from every ADT. (breaking)
