### PR TITLE
Add First and Last monoids to documentation

### DIFF
--- a/docs/src/pages/docs/functions/pointfree-functions.md
+++ b/docs/src/pages/docs/functions/pointfree-functions.md
@@ -98,11 +98,11 @@ accepted Datatype):
 | `chain` | `Array`, `Async`, `Const`, `Either`, `Identity`, `IO`, `List`, [`Maybe`][maybe-chain], `Pair`, [`Reader`][reader-chain], `Result`, [`State`][state-chain], `Unit`, `Writer` |
 | `coalesce` | `Async`, `Either`, [`Maybe`][maybe-coalesce], `Result` |
 | `compareWith` | [`Equiv`][equiv-compare] |
-| `concat` | [`All`][all-concat], [`Any`][any-concat], `Array`, [`Assign`][assign-concat], `Const`, `Either`, [`Endo`][endo-concat], [`Equiv`][equiv-concat], `First`, `Identity`, `Last`, `List`, `Max`, [`Maybe`][maybe-concat], `Min`, `Pair`, [`Pred`][pred-concat], [`Prod`][prod-concat], `Result`, `String`, [`Sum`][sum-concat], `Unit` |
+| `concat` | [`All`][all-concat], [`Any`][any-concat], `Array`, [`Assign`][assign-concat], `Const`, `Either`, [`Endo`][endo-concat], [`Equiv`][equiv-concat], [`First`][first-concat], `Identity`, [`Last`][last-concat], `List`, `Max`, [`Maybe`][maybe-concat], `Min`, `Pair`, [`Pred`][pred-concat], [`Prod`][prod-concat], `Result`, `String`, [`Sum`][sum-concat], `Unit` |
 | `cons` | `Array`, `List` |
 | `contramap` | [`Arrow`][arrow-contra], [`Equiv`][equiv-contra], [`Pred`][pred-contra], `Star` |
 | `either` | `Either`, [`Maybe`][maybe-either], `Result` |
-| `empty` | [`All`][all-empty], [`Any`][any-empty], `Array`, [`Assign`][assign-empty], [`Endo`][endo-empty], [`Equiv`][equiv-empty], `First`, `Last`, `List`, `Max`, `Min`, `Object`, [`Pred`][pred-empty], [`Prod`][prod-empty], `String`, [`Sum`][sum-empty], `Unit` |
+| `empty` | [`All`][all-empty], [`Any`][any-empty], `Array`, [`Assign`][assign-empty], [`Endo`][endo-empty], [`Equiv`][equiv-empty], [`First`][first-empty], [`Last`][last-empty], `List`, `Max`, `Min`, `Object`, [`Pred`][pred-empty], [`Prod`][prod-empty], `String`, [`Sum`][sum-empty], `Unit` |
 | [`evalWith`][eval] | [`State`][state-eval] |
 | [`execWith`][exec] | [`State`][state-exec] |
 | `extend` | `Pair` |
@@ -114,7 +114,7 @@ accepted Datatype):
 | `log` | `Writer` |
 | `map` | `Async`, `Array`, [`Arrow`][arrow-map], `Const`, `Either`, `Function`, `Identity`, `IO`, `List`, [`Maybe`][maybe-map], `Object`, `Pair`, [`Reader`][reader-map], `Result`, `Star`, [`State`][state-map], `Unit`, `Writer` |
 | `merge` | `Pair` |
-| `option` | `First`, `Last`, [`Maybe`][maybe-option] |
+| `option` | [`First`][first-option], [`Last`][last-option], [`Maybe`][maybe-option] |
 | `promap` | [`Arrow`][arrow-pro], `Star` |
 | `read` | `Writer` |
 | `reduce` | `Array`, `List` |
@@ -128,7 +128,7 @@ accepted Datatype):
 | `swap` | `Async`, `Either`, `Pair`, `Result` |
 | `tail` | `Array`, `List`, `String` |
 | `traverse` | `Array`, `Either`, `Identity`, `List`, [`Maybe`][maybe-traverse], `Result` |
-| `valueOf` | [`All`][all-value], [`Any`][any-value], [`Assign`][assign-value], `Const`, [`Endo`][endo-value], [`Equiv`][equiv-value], `First`, `Identity`, `Last`, `Max`, `Min`, [`Pred`][pred-value], [`Prod`][prod-value], [`Sum`][sum-value], `Unit`, `Writer` |
+| `valueOf` | [`All`][all-value], [`Any`][any-value], [`Assign`][assign-value], `Const`, [`Endo`][endo-value], [`Equiv`][equiv-value], [`First`][first-value], `Identity`, [`Last`][last-value], `Max`, `Min`, [`Pred`][pred-value], [`Prod`][prod-value], [`Sum`][sum-value], `Unit`, `Writer` |
 
 [all-concat]: ../monoids/All.html#concat
 [all-empty]: ../monoids/All.html#empty
@@ -160,6 +160,16 @@ accepted Datatype):
 [equiv-contra]: ../crocks/Equiv.html#contramap
 [equiv-empty]: ../crocks/Equiv.html#empty
 [equiv-value]: ../crocks/Equiv.html#valueof
+
+[first-concat]: ../monoids/First.html#concat
+[first-empty]: ../monoids/First.html#empty
+[first-option]: ../monoids/First.html#option
+[first-value]: ../monoids/First.html#valueof
+
+[last-concat]: ../monoids/Last.html#concat
+[last-empty]: ../monoids/Last.html#empty
+[last-option]: ../monoids/Last.html#option
+[last-value]: ../monoids/Last.html#valueof
 
 [maybe-alt]: ../crocks/Maybe.html#alt
 [maybe-ap]: ../crocks/Maybe.html#ap

--- a/docs/src/pages/docs/functions/transformation-functions.md
+++ b/docs/src/pages/docs/functions/transformation-functions.md
@@ -137,30 +137,30 @@ bad
 |---|:---|:---|:---|
 | `arrayToList` | `[ a ] -> List a` | `(a -> [ b ]) -> a -> List b` | `crocks/List` |
 | `eitherToAsync` | `Either e a -> Async e a` | `(a -> Either e b) -> a -> Async e b` | `crocks/Async` |
-| `eitherToFirst` | `Either b a -> First a` | `(a -> Either c b) -> a -> First b` | `crocks/First` |
-| `eitherToLast` | `Either b a -> Last a` | `(a -> Either c b) -> a -> Last b` | `crocks/Last` |
+| [`eitherToFirst`][either-first] | `Either b a -> First a` | `(a -> Either c b) -> a -> First b` | `crocks/First` |
+| [`eitherToLast`][either-last] | `Either b a -> Last a` | `(a -> Either c b) -> a -> Last b` | `crocks/Last` |
 | [`eitherToMaybe`][either-maybe] | `Either b a -> Maybe a` | `(a -> Either c b) -> a -> Maybe b` | `crocks/Maybe` |
 | `eitherToResult` | `Either e a -> Result e a` | `(a -> Either e b) -> a -> Result e b` | `crocks/Result` |
 | `firstToAsync` | `e -> First a -> Async e a` | `e -> (a -> First b) -> a -> Async e b` | `crocks/Async` |
 | `firstToEither` | `c -> First a -> Either c a` | `c -> (a -> First b) -> a -> Either c b` | `crocks/Either` |
-| `firstToLast` | `First a -> Last a` | `(a -> First b) -> a -> Last b` | `crocks/Last` |
+| [`firstToLast`][first-last] | `First a -> Last a` | `(a -> First b) -> a -> Last b` | `crocks/Last` |
 | [`firstToMaybe`][first-maybe] | `First a -> Maybe a` | `(a -> First b) -> a -> Maybe b` | `crocks/Maybe` |
 | `firstToResult` | `c -> First a -> Result c a` | `c -> (a -> First b) -> a -> Result c b` | `crocks/Result` |
 | `lastToAsync` | `e -> Last a -> Async e a` | `e -> (a -> Last b) -> a -> Async e b` | `crocks/Async` |
 | `lastToEither` | `c -> Last a -> Either c a` | `c -> (a -> Last b) -> a -> Either c b` | `crocks/Either` |
-| `lastToFirst` | `Last a -> First a` | `(a -> Last b) -> a -> First b` | `crocks/First` |
+| [`lastToFirst`][last-first] | `Last a -> First a` | `(a -> Last b) -> a -> First b` | `crocks/First` |
 | [`lastToMaybe`][last-maybe] | `Last a -> Maybe a` | `(a -> Last b) -> a -> Maybe b` | `crocks/Maybe` |
 | `lastToResult` | `c -> Last a -> Result c a` | `c -> (a -> Last b) -> a -> Result c b` | `crocks/Result` |
 | `listToArray` | `List a -> [ a ]` | `(a -> List b) -> a -> [ b ]` | `crocks/List` |
 | `maybeToAsync` | `e -> Maybe a -> Async e a` | `e -> (a -> Maybe b) -> a -> Async e b` | `crocks/Async` |
 | `maybeToEither` | `c -> Maybe a -> Either c a` | `c -> (a -> Maybe b) -> a -> Either c b` | `crocks/Either` |
-| `maybeToFirst` | `Maybe a -> First a` | `(a -> Maybe b) -> a -> First b` | `crocks/First` |
-| `maybeToLast` | `Maybe a -> Last a` | `(a -> Maybe b) -> a -> Last b` | `crocks/Last` |
+| [`maybeToFirst`][maybe-first] | `Maybe a -> First a` | `(a -> Maybe b) -> a -> First b` | `crocks/First` |
+| [`maybeToLast`][maybe-last] | `Maybe a -> Last a` | `(a -> Maybe b) -> a -> Last b` | `crocks/Last` |
 | `maybeToResult` | `c -> Maybe a -> Result c a` | `c -> (a -> Maybe b) -> a -> Result c b` | `crocks/Result` |
 | `resultToAsync` | `Result e a -> Async e a` | `(a -> Result e b) -> a -> Async e b` | `crocks/Async` |
 | `resultToEither` | `Result e a -> Either e a` | `(a -> Result e b) -> a -> Either e b` | `crocks/Either` |
-| `resultToFirst` | `Result e a -> First a` | `(a -> Result e b) -> a -> First b` | `crocks/First` |
-| `resultToLast` | `Result e a -> Last a` | `(a -> Result e b) -> a -> Last b` | `crocks/Last` |
+| [`resultToFirst`][result-first] | `Result e a -> First a` | `(a -> Result e b) -> a -> First b` | `crocks/First` |
+| [`resultToLast`][result-last] | `Result e a -> Last a` | `(a -> Result e b) -> a -> Last b` | `crocks/Last` |
 | [`resultToMaybe`][result-maybe] | `Result e a -> Maybe a` | `(a -> Result e b) -> a -> Maybe b` | `crocks/Maybe` |
 | `writerToPair` | `Writer m a -> Pair m a` | `(a -> Writer m b) -> a -> Pair m b` | `crocks/Pair` |
 
@@ -168,3 +168,14 @@ bad
 [first-maybe]: ../crocks/Maybe.html#firsttomaybe
 [last-maybe]: ../crocks/Maybe.html#lasttomaybe
 [result-maybe]: ../crocks/Maybe.html#resulttomaybe
+
+[either-first]: ../monoids/First.html#eithertofirst
+[last-first]: ../monoids/First.html#lasttofirst
+[maybe-first]: ../monoids/First.html#maybetofirst
+[result-first]: ../monoids/First.html#resulttofirst
+
+[either-last]: ../monoids/Last.html#eithertolast
+[first-last]: ../monoids/Last.html#firsttolast
+[maybe-last]: ../monoids/Last.html#maybetolast
+[result-last]: ../monoids/Last.html#resulttolast
+

--- a/docs/src/pages/docs/monoids/First.md
+++ b/docs/src/pages/docs/monoids/First.md
@@ -1,0 +1,484 @@
+---
+title: "First"
+description: "First Monoid"
+layout: "guide"
+weight: 50
+---
+
+```haskell
+First a = First (Maybe a)
+```
+
+`First` is a `Monoid` that will always return the first, non-empty value when
+(2) `First` instances are combined. `First` is able to be a `Monoid` because
+it implements a [`Maybe`][maybe] under the hood. The use of
+the [`Maybe`][maybe] allows for an [`empty`](#empty) `First` to be represented
+with a [`Nothing`][nothing].
+
+`First` can be constructed with either a value or a [`Maybe`][maybe] instance.
+Any value passed to the constructor will be wrapped in a [`Just`][just] to
+represent a non-empty instance of `First`. Any [`Maybe`][maybe] passed to the
+constructor will be lifted as is, allowing the ability to "choose" a value based
+on some disjunction.
+
+While most `Monoid`s only provide a [`valueOf`](#valueof) function used for
+extraction, `First` takes advantage of its underlying [`Maybe`][maybe] to provide an
+additional [`option`](#option) method. Using [`valueOf`](#valueof) will extract
+the underlying [`Maybe`][maybe], while [`option`](#option) will extract the underlying
+value in the[`Maybe`][maybe], using the provided default value when the underlying
+[`Maybe`][maybe] is a [`Nothing`][nothing] instance.
+
+```javascript
+const First = require('crocks/First')
+
+const and = require('crocks/logic/and')
+const isNumber = require('crocks/predicates/isNumber')
+const mconcatMap = require('crocks/helpers/mconcatMap')
+const safe = require('crocks/Maybe/safe')
+
+// isEven :: Number -> Boolean
+const isEven =
+  x => !(x % 2)
+
+// isValid :: a -> Boolean
+const isValid =
+  and(isNumber, isEven)
+
+// chooseFirst :: [ * ] -> First Number
+const chooseFirst =
+  mconcatMap(First, safe(isValid))
+
+chooseFirst([ 21, 45, 2, 22, 19 ])
+  .valueOf()
+//=> Just 2
+
+chooseFirst([ 'a', 'b', 'c' ])
+  .option('')
+//=> ""
+```
+
+<article id="topic-implements">
+
+## Implements
+
+`Semigroup`, `Monoid`
+
+</article>
+
+<article id="topic-constructor">
+
+## Constructor Methods
+
+#### empty
+
+```haskell
+First.empty :: () -> First a
+```
+
+`empty` provides the identity for the `Monoid` in that when the value it
+provides is `concat`ed to any other value, it will return the other value. In
+the case of `First` the result of `empty` is [`Nothing`][nothing]. `empty` is
+available on both the Constructor and the Instance for convenience.
+
+```javascript
+const First = require('crocks/First')
+const { empty } = First
+
+First.empty()
+//=> First( Nothing )
+
+First(3)
+  .concat(empty())
+//=> First( Just 3 )
+
+empty()
+  .concat(First(3))
+//=> First( Just 3 )
+```
+
+</article>
+
+<article id="topic-instance">
+
+## Instance Methods
+
+#### concat
+
+```haskell
+First a ~> First a -> First a
+```
+
+`concat` is used to combine (2) `Semigroup`s of the same type under an operation
+specified by the `Semigroup`. In the case of `First`, it will always provide the
+first non-empty value. Any subsequent non-empty values will be thrown away and
+will always result in the first non-empty value.
+
+```javascript
+const First = require('crocks/First')
+const concat = require('crocks/pointfree/concat')
+
+const a = First('a')
+const b = First('b')
+const c = First('c')
+
+a.concat(b)
+//=> First( Just "a" )
+
+b.concat(a)
+//=> First( Just "b" )
+
+concat(c, concat(b, a))
+//=> First( Just "a" )
+
+concat(concat(c, b), a)
+//=> First( Just "a" )
+
+concat(concat(a, b), c)
+//=> First( Just "c" )
+```
+
+#### option
+
+```haskell
+First a ~> a -> a
+```
+
+`First` wraps an underlying [`Maybe`][maybe] which provides the ability to
+option out a value in the case of an [`empty`](#empty) instance. Just like
+[`option`][option] on a [`Maybe`][maybe] instance, it takes a value as its
+argument. When run on an [`empty`](#empty) instance, the provided default
+will be returned. If `option` is run on a non-empty instance however, the
+wrapped value will be extracted not only from the `First` but also from
+the underlying [`Just`][just].
+
+If the underlying [`Maybe`][maybe] is desired, the [`valueOf`](#valueof)
+method can be used and will return the [`Maybe`][maybe] instead.
+
+```javascript
+const First = require('crocks/First')
+
+const compose = require('crocks/helpers/compose')
+const chain = require('crocks/pointfree/chain')
+const isString = require('crocks/predicates/isString')
+const mconcatMap = require('crocks/helpers/mconcatMap')
+const prop = require('crocks/Maybe/prop')
+const safe = require('crocks/Maybe/safe')
+
+// stringVal :: a -> Maybe String
+const stringVal = compose(
+  chain(safe(isString)),
+  prop('val')
+)
+
+// firstValid :: [ a ] -> First String
+const firstValid =
+  mconcatMap(First, stringVal)
+
+// good :: [ Object ]
+const good =
+  [ { val: 23 }, { val: 'string' }, { val: '23' } ]
+
+// bad :: [ Object ]
+const bad =
+  [ { val: 23 }, { val: null }, {} ]
+
+firstValid(good)
+  .option('')
+//=> "string"
+
+firstValid(bad)
+  .option('')
+//=> ""
+```
+
+#### valueOf
+
+```haskell
+First a ~> () -> Maybe a
+```
+
+`valueOf` is used on all `crocks` `Monoid`s as a means of extraction. While the
+extraction is available, types that implement `valueOf` are not necessarily a
+`Comonad`. This function is used primarily for convenience for some of the
+helper functions that ship with `crocks`. Calling `valueOf` on
+a `First` instance will result in the underlying [`Maybe`][maybe].
+
+```javascript
+const First = require('crocks/First')
+
+const { Nothing } = require('crocks/Maybe')
+const valueOf = require('crocks/pointfree/valueOf')
+
+valueOf(First(56))
+//=> Just 56
+
+valueOf(First.empty())
+//=> Nothing
+
+First(37)
+  .concat(First(99))
+  .valueOf()
+//=> Just 37
+
+First(Nothing())
+  .concat(First.empty())
+  .valueOf()
+//=> Nothing
+```
+
+</article>
+
+<article id="topic-transformation">
+
+## Transformation Functions
+
+#### eitherToFirst
+
+`crocks/First/eitherToFirst`
+
+```haskell
+eitherToFirst :: Either b a -> First a
+eitherToFirst :: (a -> Either c b) -> a -> First b
+```
+
+Used to transform a given `Either` instance to a `First`
+instance, `eitherToFirst` will turn a `Right` instance into a non-empty `First`,
+wrapping the original value contained in the `Right`. All `Left` instances will
+map to an [`empty`](#empty) `First`, mapping the originally contained value to a `Unit`.
+Values on the `Left` will be lost and as such this transformation is considered
+lossy in that regard.
+
+Like all `crocks` transformation functions, `eitherToFirst` has (2) possible
+signatures and will behave differently when passed either an `Either` instance
+or a function that returns an instance of `Either`. When passed the instance,
+a transformed `First` is returned. When passed an `Either` returning function,
+a function will be returned that takes a given value and returns a `First`.
+
+```javascript
+const First = require('crocks/First')
+const { Left, Right } = require('crocks/Either')
+const eitherToFirst = require('crocks/First/eitherToFirst')
+
+const concat = require('crocks/pointfree/concat')
+const constant = require('crocks/combinators/constant')
+const flip = require('crocks/combinators/flip')
+const ifElse = require('crocks/logic/ifElse')
+const isNumber = require('crocks/predicates/isNumber')
+const mapReduce = require('crocks/helpers/mapReduce')
+
+// someNumber :: a -> Either String Number
+const someNumber = ifElse(
+  isNumber,
+  Right,
+  constant(Left('Nope'))
+)
+
+// firstNumber :: [ a ] -> First Number
+const firstNumber = mapReduce(
+  eitherToFirst(someNumber),
+  flip(concat),
+  First.empty()
+)
+
+// "Bad Times" is lost, mapped to Nothing
+eitherToFirst(Left('Bad Times'))
+//=> First( Nothing )
+
+eitherToFirst(Right('correct'))
+//=> First( Just "correct" )
+
+firstNumber([ 'string', null, 34, 76 ])
+//=> First( Just 34 )
+
+firstNumber([ 'string', null, true ])
+//=> First( Nothing )
+```
+
+#### lastToFirst
+
+`crocks/First/lastToFirst`
+
+```haskell
+lastToFirst :: Last a -> First a
+lastToFirst :: (a -> Last b) -> a -> First b
+```
+
+Used to transform a given `Last` instance to a `First` instance, `lastToFirst`
+will turn a non-empty instance into a non-empty `First` wrapping the original
+value contained within the `Last`. All [`empty`](#empty) instances will map
+to an [`empty`](#empty) `First`.
+
+Like all `crocks` transformation functions, `lastToFirst` has (2) possible
+signatures and will behave differently when passed either a `Last` instance
+or a function that returns an instance of `Last`. When passed the instance,
+a transformed `First` is returned. When passed a `Last` returning function,
+a function will be returned that takes a given value and returns a `First`.
+
+```javascript
+const First = require('crocks/First')
+const Last  = require('crocks/Last')
+const lastToFirst = require('crocks/First/lastToFirst')
+
+const isString = require('crocks/predicates/isString')
+const mconcatMap = require('crocks/helpers/mconcatMap')
+const safe = require('crocks/Maybe/safe')
+
+// lastString :: [ a ] -> Last String
+const lastString =
+  mconcatMap(Last, safe(isString))
+
+// fixLastString :: [ a ] -> First String
+const fixLastString =
+  lastToFirst(lastString)
+
+lastToFirst(Last.empty())
+//=> First( Nothing )
+
+lastToFirst(Last(false))
+//=> First( Just false )
+
+fixLastString([ 'one', 2, 'Three', 4 ])
+  .concat(First('another string'))
+//=> First( Just "Three" )
+
+fixLastString([ 1, 2, 3, 4 ])
+  .concat(First('First String'))
+//=> First( Just "First String" )
+```
+
+#### maybeToFirst
+
+`crocks/First/maybeToFirst`
+
+```haskell
+maybeToFirst :: Maybe a -> First a
+maybeToFirst :: (a -> Maybe b) -> a -> First b
+```
+
+Used to transform a given [`Maybe`][maybe] instance to a `First`
+instance, `maybeToFirst` will turn a [`Just`][just] into a non-empty
+`First` instance, wrapping the original value contained within the `First`.
+All [`Nothing`][nothing] instances will map to an [`empty`](#empty) `First`
+instance.
+
+This function is available mostly for completion sake, as `First` can always
+take a `Maybe` as its argument during construction. So while there is not a
+real need for this to be used for transforming instances, it can come in
+handy for lifting [`Maybe`][maybe] returning functions.
+
+Like all `crocks` transformation functions, `maybeToFirst` has (2) possible
+signatures and will behave differently when passed either a [`Maybe`][maybe]
+instance or a function that returns an instance of [`Maybe`][maybe]. When
+passed the instance, a transformed `First` is returned. When passed
+a [`Maybe`][maybe] returning function, a function will be returned that
+takes a given value and returns a `First`.
+
+```javascript
+const First = require('crocks/First')
+const { Nothing, Just } = require('crocks/Maybe')
+const maybeToFirst = require('crocks/First/maybeToFirst')
+
+const chain = require('crocks/pointfree/chain')
+const compose = require('crocks/helpers/compose')
+const isNumber = require('crocks/predicates/isNumber')
+const prop = require('crocks/Maybe/prop')
+const safe = require('crocks/Maybe/safe')
+
+// numVal :: a -> Maybe Number
+const numVal = compose(
+  chain(safe(isNumber)),
+  prop('val')
+)
+
+// firstNumVal :: a -> First Number
+const firstNumVal =
+  maybeToFirst(numVal)
+
+maybeToFirst(Just(99))
+//=> First( Just 99 )
+
+maybeToFirst(Nothing())
+//=> First( Nothing )
+
+First(Just(99))
+//=> First( Just 99 )
+
+First(Nothing())
+//=> First( Nothing )
+
+firstNumVal({ val: 97 })
+  .concat(First(80))
+//=> First( Just 97 )
+
+firstNumVal({ val: '97' })
+  .concat(First(80))
+//=> First( Just 80 )
+
+firstNumVal(null)
+  .concat(First(80))
+//=> First( Just 80 )
+```
+
+#### resultToFirst
+
+`crocks/First/resultToFirst`
+
+```haskell
+resultToFirst :: Result e a -> First a
+resultToFirst :: (a -> Result e b) -> a -> First b
+```
+
+Used to transform a given `Result` instance to a `First` instance,
+`resultToFirst` will turn an `Ok` instance into a non-empty `First`,
+wrapping the original value contained in the `Ok`. All `Err` instances will map
+to an [`empty`](#empty) `First`, mapping the originally contained value to
+a `Unit`. Values on the `Err` will be lost and as such this transformation is
+considered lossy in that regard.
+
+Like all `crocks` transformation functions, `resultToFirst` has (2) possible
+signatures and will behave differently when passed either an `Result` instance
+or a function that returns an instance of `Result`. When passed the instance,
+a transformed `First` is returned. When passed a `Result` returning function,
+a function will be returned that takes a given value and returns a `First`.
+
+```javascript
+const First = require('crocks/First')
+const { Err, Ok } = require('crocks/Result')
+const resultToFirst = require('crocks/First/resultToFirst')
+
+const isNumber = require('crocks/predicates/isNumber')
+const tryCatch = require('crocks/Result/tryCatch')
+
+function onlyNums(x) {
+  if(!isNumber(x)) {
+    throw new Error('something amiss')
+  }
+  return x
+}
+
+// firstNum :: a -> First Number
+const firstNum =
+  resultToFirst(tryCatch(onlyNums))
+
+// "this is bad" is lost, mapped to Nothing
+resultToFirst(Err('this is bad'))
+//=> First( Nothing )
+
+resultToFirst(Ok('this is great'))
+//=> First( Just "this is great" )
+
+firstNum(90)
+  .concat(First(0))
+//=> First( Just 90 )
+
+firstNum(null)
+  .concat(First(0))
+//=> First( Just 0 )
+```
+
+</article>
+
+[just]: ../crocks/Maybe.html#just
+[maybe]: ../crocks/Maybe.html
+[nothing]: ../crocks/Maybe.html#nothing
+[option]: ../crocks/Maybe.html#option

--- a/docs/src/pages/docs/monoids/Last.md
+++ b/docs/src/pages/docs/monoids/Last.md
@@ -1,0 +1,482 @@
+---
+title: "Last"
+description: "Last Monoid"
+layout: "guide"
+weight: 60
+---
+
+```haskell
+Last a = Last (Maybe a)
+```
+
+`Last` is a `Monoid` that will always return the last, non-empty value when
+(2) `Last` instances are combined. `Last` is able to be a `Monoid` because
+it implements a [`Maybe`][maybe] under the hood. The use of the [`Maybe`][maybe] allows for an
+[`empty`](#empty) `Last` to be represented with a `Nothing`.
+
+`Last` can be constructed with either a value or a [`Maybe`][maybe] instance. Any value
+passed to the constructor will be wrapped in a [`Just`][just] to represent a non-empty
+instance of `Last`. Any [`Maybe`][maybe] passed to the constructor will be lifted as
+is, allowing the ability to "choose" a value based on some disjunction.
+
+While most `Monoid`s only provide a [`valueOf`](#valueof) function used for
+extraction, `Last` takes advantage of its underlying [`Maybe`][maybe] to provide an
+additional [`option`](#option) method. Using [`valueOf`](#valueof) will extract
+the underlying [`Maybe`][maybe], while [`option`](#option) will extract the underlying
+value in the [`Maybe`][maybe], using the provided default value when the underlying
+[`Maybe`][maybe] is a [`Nothing`][nothing] instance.
+
+```javascript
+const Last = require('crocks/Last')
+
+const and = require('crocks/logic/and')
+const isNumber = require('crocks/predicates/isNumber')
+const mconcatMap = require('crocks/helpers/mconcatMap')
+const safe = require('crocks/Maybe/safe')
+
+// isEven :: Number -> Boolean
+const isEven =
+  x => x % 2 === 0
+
+// isValid :: a -> Boolean
+const isValid =
+  and(isNumber, isEven)
+
+// chooseLast :: [ * ] -> Last Number
+const chooseLast =
+  mconcatMap(Last, safe(isValid))
+
+chooseLast([ 21, 45, 2, 22, 19 ])
+  .valueOf()
+//=> Just 22
+
+chooseLast([ 'a', 'b', 'c' ])
+  .option('')
+//=> ""
+```
+
+<article id="topic-implements">
+
+## Implements
+
+`Semigroup`, `Monoid`
+
+</article>
+
+<article id="topic-constructor">
+
+## Constructor Methods
+
+#### empty
+
+```haskell
+Last.empty :: () -> Last a
+```
+
+`empty` provides the identity for the `Monoid` in that when the value it
+provides is `concat`ed to any other value, it will return the other value. In
+the case of `Last` the result of `empty` is [`Nothing`][nothing]. `empty` is available
+on both the Constructor and the Instance for convenience.
+
+```javascript
+const Last = require('crocks/Last')
+const { empty } = Last
+
+empty()
+//=> Last( Nothing )
+
+Last(3)
+  .concat(empty())
+//=> Last( Just 3 )
+
+empty()
+  .concat(Last(3))
+//=> Last( Just 3 )
+```
+
+</article>
+
+<article id="topic-instance">
+
+## Instance Methods
+
+#### concat
+
+```haskell
+Last a ~> Last a -> Last a
+```
+
+`concat` is used to combine (2) `Semigroup`s of the same type under an operation
+specified by the `Semigroup`. In the case of `Last`, it will always provide the
+last non-empty value. All previous non-empty values will be thrown away and
+will always result in the last non-empty value.
+
+```javascript
+const Last = require('crocks/Last')
+const concat = require('crocks/pointfree/concat')
+
+const a = Last('a')
+const b = Last('b')
+const c = Last('c')
+
+a.concat(b)
+//=> Last( Just "b" )
+
+b.concat(a)
+//=> Last( Just "a" )
+
+concat(c, concat(b, a))
+//=> Last( Just "c" )
+
+concat(concat(c, b), a)
+//=> Last( Just "c" )
+
+concat(concat(a, b), c)
+//=> Last( Just "a" )
+```
+
+#### option
+
+```haskell
+Last a ~> a -> a
+```
+
+`Last` wraps an underlying [`Maybe`][maybe] which provides the ability to option out
+a value in the case of an [`empty`](#empty) instance. Just like [`option`][option] on
+a [`Maybe`][maybe] instance, it takes a value as its argument. When run on
+an [`empty`](#empty) instance, the provided default will be returned.
+If `option` is run on a non-empty instance however, the wrapped value will be
+extracted not only from the `Last` but also from the underlying [`Just`][just].
+
+If the underlying [`Maybe`][maybe] is desired, the [`valueOf`](#valueof) method can be
+used and will return the [`Maybe`][maybe] instead.
+
+```javascript
+const Last = require('crocks/Last')
+
+const compose = require('crocks/helpers/compose')
+const chain = require('crocks/pointfree/chain')
+const isString = require('crocks/predicates/isString')
+const mconcatMap = require('crocks/helpers/mconcatMap')
+const prop = require('crocks/Maybe/prop')
+const safe = require('crocks/Maybe/safe')
+
+// stringVal :: a -> Maybe String
+const stringVal = compose(
+  chain(safe(isString)),
+  prop('val')
+)
+
+// lastValid :: [ a ] -> Last String
+const lastValid =
+  mconcatMap(Last, stringVal)
+
+// good :: [ Object ]
+const good =
+  [ { val: 23 }, { val: 'string' }, { val: '23' } ]
+
+// bad :: [ Object ]
+const bad =
+  [ { val: 23 }, { val: null }, {} ]
+
+lastValid(good)
+  .option('')
+//=> "23"
+
+lastValid(bad)
+  .option('')
+//=> ""
+```
+
+#### valueOf
+
+```haskell
+Last a ~> () -> Maybe a
+```
+
+`valueOf` is used on all `crocks` `Monoid`s as a means of extraction. While the
+extraction is available, types that implement `valueOf` are not necessarily a
+`Comonad`. This function is used primarily for convenience for some of the
+helper functions that ship with `crocks`. Calling `valueOf` on a `Last` instance
+will result in the underlying [`Maybe`][maybe].
+
+```javascript
+const Last = require('crocks/Last')
+
+const { Nothing } = require('crocks/Maybe')
+const valueOf = require('crocks/pointfree/valueOf')
+
+valueOf(Last(56))
+//=> Just 56
+
+valueOf(Last.empty())
+//=> Nothing
+
+Last(37)
+  .concat(Last(99))
+  .valueOf()
+//=> Just 99
+
+Last(Nothing())
+  .concat(Last.empty())
+  .valueOf()
+//=> Nothing
+```
+
+</article>
+
+<article id="topic-transformation">
+
+## Transformation Functions
+
+#### eitherToLast
+
+`crocks/Last/eitherToLast`
+
+```haskell
+eitherToLast :: Either b a -> Last a
+eitherToLast :: (a -> Either c b) -> a -> Last b
+```
+
+Used to transform a given `Either` instance to a `Last`
+instance, `eitherToLast` will turn a `Right` instance into a non-empty `Last`,
+wrapping the original value contained in the `Right`. All `Left` instances will
+map to an [`empty`](#empty) `Last`, mapping the originally contained value to
+a `Unit`. Values on the `Left` will be lost and as such this transformation is
+considered lossy in that regard.
+
+Like all `crocks` transformation functions, `eitherToLast` has (2) possible
+signatures and will behave differently when passed either an `Either` instance
+or a function that returns an instance of `Either`. When passed the instance,
+a transformed `Last` is returned. When passed an `Either` returning function,
+a function will be returned that takes a given value and returns a `Last`.
+
+```javascript
+const Last = require('crocks/Last')
+const { Left, Right } = require('crocks/Either')
+const eitherToLast = require('crocks/Last/eitherToLast')
+
+const concat = require('crocks/pointfree/concat')
+const constant = require('crocks/combinators/constant')
+const flip = require('crocks/combinators/flip')
+const ifElse = require('crocks/logic/ifElse')
+const isNumber = require('crocks/predicates/isNumber')
+const mapReduce = require('crocks/helpers/mapReduce')
+
+// someNumber :: a -> Either String Number
+const someNumber = ifElse(
+  isNumber,
+  Right,
+  constant(Left('Nope'))
+)
+
+// lastNumber :: [ a ] -> Last Number
+const lastNumber = mapReduce(
+  eitherToLast(someNumber),
+  flip(concat),
+  Last.empty()
+)
+
+// "Bad Times" is lost, mapped to Nothing
+eitherToLast(Left('Bad Times'))
+//=> Last( Nothing )
+
+eitherToLast(Right('correct'))
+//=> Last( Just "correct" )
+
+lastNumber([ 'string', null, 34, 76 ])
+//=> Last( Just 76 )
+
+lastNumber([ 'string', null, true ])
+//=> Last( Nothing )
+```
+
+#### firstToLast
+
+`crocks/Last/firstToLast`
+
+```haskell
+firstToLast :: First a -> Last a
+firstToLast :: (a -> First b) -> a -> Last b
+```
+
+Used to transform a given `First` instance to a `Last` instance, `firstToLast`
+will turn a non-empty instance into a non-empty `Last` wrapping the original
+value contained within the `First`. All [`empty`](#empty) instances will map
+to an [`empty`](#empty) `Last`.
+
+Like all `crocks` transformation functions, `firstToLast` has (2) possible
+signatures and will behave differently when passed either a `First` instance
+or a function that returns an instance of `First`. When passed the instance,
+a transformed `Last` is returned. When passed a `First` returning function,
+a function will be returned that takes a given value and returns a `Last`.
+
+```javascript
+const Last  = require('crocks/Last')
+const First = require('crocks/First')
+const firstToLast = require('crocks/Last/firstToLast')
+
+const isString = require('crocks/predicates/isString')
+const mconcatMap = require('crocks/helpers/mconcatMap')
+const safe = require('crocks/Maybe/safe')
+
+// firstString :: [ a ] -> First String
+const firstString =
+  mconcatMap(First, safe(isString))
+
+// unfixFirstString :: [ a ] -> Last String
+const unfixFirstString =
+  firstToLast(firstString)
+
+firstToLast(First.empty())
+//=> Last( Nothing )
+
+firstToLast(First(false))
+//=> Last( Just false )
+
+unfixFirstString([ 'one', 2, 'Three', 4 ])
+//=> Last( Just "one" )
+
+unfixFirstString([ 'one', 2, 'Three', 4 ])
+  .concat(Last('another string'))
+//=> Last( Just "another string" )
+
+unfixFirstString([ 1, 2, 3, 4 ])
+  .concat(Last('Last String'))
+//=> Last( Just "Last String" )
+```
+
+#### maybeToLast
+
+`crocks/Last/maybeToLast`
+
+```haskell
+maybeToLast :: Maybe a -> Last a
+maybeToLast :: (a -> Maybe b) -> a -> Last b
+```
+
+Used to transform a given [`Maybe`][maybe] instance to a `Last` instance, `maybeToLast`
+will turn a [`Just`][just] into a non-empty `Last` instance, wrapping the original value
+contained within the `Last`. All [`Nothing`][nothing] instances will map to
+an [`empty`](#empty) `Last` instance.
+
+This function is available mostly for completion sake, as `Last` can always
+take a [`Maybe`][maybe] as its argument during construction. So while there is not a
+real need for this to be used for transforming instances, it can come in
+handy for lifting [`Maybe`][maybe] returning functions.
+
+Like all `crocks` transformation functions, `maybeToLast` has (2) possible
+signatures and will behave differently when passed either a [`Maybe`][maybe] instance
+or a function that returns an instance of [`Maybe`][maybe]. When passed the instance,
+a transformed `Last` is returned. When passed a [`Maybe`][maybe] returning function,
+a function will be returned that takes a given value and returns a `Last`.
+
+```javascript
+const Last = require('crocks/Last')
+const { Nothing, Just } = require('crocks/Maybe')
+const maybeToLast = require('crocks/Last/maybeToLast')
+
+const chain = require('crocks/pointfree/chain')
+const compose = require('crocks/helpers/compose')
+const isNumber = require('crocks/predicates/isNumber')
+const prop = require('crocks/Maybe/prop')
+const safe = require('crocks/Maybe/safe')
+
+// numVal :: a -> Maybe Number
+const numVal = compose(
+  chain(safe(isNumber)),
+  prop('val')
+)
+
+// lastNumVal :: a -> Last Number
+const lastNumVal =
+  maybeToLast(numVal)
+
+maybeToLast(Just(99))
+//=> Last( Just 99 )
+
+maybeToLast(Nothing())
+//=> Last( Nothing )
+
+Last(Just(99))
+//=> Last( Just 99 )
+
+Last(Nothing())
+//=> Last( Nothing )
+
+Last(Just(80))
+  .concat(lastNumVal({ val: 97 }))
+//=> Last( Just 97 )
+
+lastNumVal({ val: 97 })
+  .concat(Last(80))
+//=> Last( Just 80 )
+
+lastNumVal(null)
+  .concat(Last(80))
+//=> Last( Just 80 )
+```
+
+#### resultToLast
+
+`crocks/Last/resultToLast`
+
+```haskell
+resultToLast :: Result e a -> Last a
+resultToLast :: (a -> Result e b) -> a -> Last b
+```
+
+Used to transform a given `Result` instance to a `Last` instance,
+`resultToLast` will turn an `Ok` instance into a non-empty `Last`,
+wrapping the original value contained in the `Ok`. All `Err` instances will map
+to an [`empty`](#empty) `Last`, mapping the originally contained value to
+a `Unit`. Values on the `Err` will be lost and as such this transformation is
+considered lossy in that regard.
+
+Like all `crocks` transformation functions, `resultToLast` has (2) possible
+signatures and will behave differently when passed either an `Result` instance
+or a function that returns an instance of `Result`. When passed the instance,
+a transformed `Last` is returned. When passed a `Result` returning function,
+a function will be returned that takes a given value and returns a `Last`.
+
+```javascript
+const Last = require('crocks/Last')
+const { Err, Ok } = require('crocks/Result')
+const resultToLast = require('crocks/Last/resultToLast')
+
+const isNumber = require('crocks/predicates/isNumber')
+const tryCatch = require('crocks/Result/tryCatch')
+
+function onlyNums(x) {
+  if(!isNumber(x)) {
+    throw new Error('something amiss')
+  }
+  return x
+}
+
+// lastNum :: a -> Last Number
+const lastNum =
+  resultToLast(tryCatch(onlyNums))
+
+// "this is bad" is lost, mapped to Nothing
+resultToLast(Err('this is bad'))
+//=> Last( Nothing )
+
+resultToLast(Ok('this is great'))
+//=> Last( Just "this is great" )
+
+lastNum(90)
+  .concat(Last(0))
+//=> Last( Just 0 )
+
+lastNum(null)
+  .concat(Last(0))
+//=> Last( Just 0 )
+```
+
+</article>
+
+[just]: ../crocks/Maybe.html#just
+[maybe]: ../crocks/Maybe.html
+[nothing]: ../crocks/Maybe.html#nothing
+[option]: ../crocks/Maybe.html#option

--- a/docs/src/pages/docs/monoids/index.md
+++ b/docs/src/pages/docs/monoids/index.md
@@ -25,8 +25,8 @@ as the following Instance Functions: `valueOf`, `empty` and `concat`.
 | [`Any`][Any] | Boolean | Logical OR | `false` |
 | [`Assign`][Assign] | Object | `Object.assign` | `{lb}{rb}` |
 | [`Endo`][Endo] | Function | `compose` | `identity` |
-| `First` | Maybe | First `Just` | `Nothing` |
-| `Last` | Maybe | Last `Just` | `Nothing` |
+| [`First`][First] | [`Maybe`][Maybe] | `First` [`Just`][just] | [`Nothing`][nothing] |
+| [`Last`][Last] | [`Maybe`][Maybe] | `Last` [`Just`][just] | [`Nothing`][nothing] |
 | `Max` | Number | `Math.max` | `-Infinity` |
 | `Min` | Number | `Math.min` | `Infinity` |
 | [`Prod`][Prod] | Number | Multiplication | `1` |
@@ -38,9 +38,15 @@ as the following Instance Functions: `valueOf`, `empty` and `concat`.
 [mconcatMap]: ../functions/helpers.html#mconcatmap
 [mreduceMap]: ../functions/helpers.html#mreducemap
 
+[Maybe]: ../crocks/Maybe.html
+[just]: ../crocks/Maybe.html#just
+[nothing]: ../crocks/Maybe.html#nothing
+
 [All]: All.html
 [Any]: Any.html
 [Assign]: Assign.html
 [Endo]: Endo.html
+[First]: First.html
+[Last]: Last.html
 [Prod]: Prod.html
 [Sum]: Sum.html

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "bugs": {
     "url": "https://github.com/evilsoft/crocks/issues"
   },
-  "homepage": "https://github.com/evilsoft/crocks#readme",
+  "homepage": "https://evilsoft.github.io/crocks",
   "nyc": {
     "check-coverage": true,
     "lines": 100,


### PR DESCRIPTION
## Keep em coming!
![image](https://user-images.githubusercontent.com/3665793/35842945-3e8d94be-0aba-11e8-96ba-bf8f219cea59.png)

This PR add both the `Last` and `First` monoids to the main documentation and takes care of all the links to other portions of the docs. Also as a side note, adds the documentation url for the homepage in the `package.json`