### PR TITLE
Add Fantasy Land Prefixed Method Names

### DIFF
--- a/src/All/All.spec.js
+++ b/src/All/All.spec.js
@@ -41,6 +41,17 @@ test('All', t => {
   t.end()
 })
 
+test('All fantasy-land api', t => {
+  const m = All(true)
+
+  t.equals(All['fantasy-land/empty'], All.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+
+  t.end()
+})
+
 test('All @@implements', t => {
   const f = All['@@implements']
 

--- a/src/All/index.js
+++ b/src/All/index.js
@@ -43,6 +43,8 @@ function All(b) {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
     '@@type': _type,
+    'fantasy-land/concat': concat,
+    'fantasy-land/empty': empty,
     constructor: All
   }
 }
@@ -53,6 +55,8 @@ All['@@implements'] = _implements(
 
 All.empty = _empty
 All.type = type
+
+All['fantasy-land/empty'] = _empty
 All['@@type'] = _type
 
 module.exports = All

--- a/src/Any/Any.spec.js
+++ b/src/Any/Any.spec.js
@@ -41,6 +41,17 @@ test('Any', t => {
   t.end()
 })
 
+test('Any fantasy-land api', t => {
+  const m = Any(true)
+
+  t.equals(Any['fantasy-land/empty'], Any.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+
+  t.end()
+})
+
 test('Any @@implements', t => {
   const f = Any['@@implements']
 

--- a/src/Any/index.js
+++ b/src/Any/index.js
@@ -43,6 +43,8 @@ function Any(b) {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
     '@@type': _type,
+    'fantasy-land/concat': concat,
+    'fantasy-land/empty': empty,
     constructor: Any
   }
 }
@@ -53,6 +55,8 @@ Any['@@implements'] = _implements(
 
 Any.empty = _empty
 Any.type  = type
+
+Any['fantasy-land/empty'] = _empty
 Any['@@type'] = _type
 
 module.exports = Any

--- a/src/Arrow/Arrow.spec.js
+++ b/src/Arrow/Arrow.spec.js
@@ -49,6 +49,20 @@ test('Arrow', t => {
   t.end()
 })
 
+test('Arrow fantasy-land api', t => {
+  const m = Arrow(identity)
+
+  t.equals(Arrow['fantasy-land/id'], Arrow.id, 'is same function as public constructor id')
+
+  t.equals(m['fantasy-land/id'], m.id, 'is same function as public instance id')
+  t.equals(m['fantasy-land/compose'], m.compose, 'is same function as public instance compose')
+  t.equals(m['fantasy-land/contramap'], m.contramap, 'is same function as public instance contramap')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/promap'], m.promap, 'is same function as public instance promap')
+
+  t.end()
+})
+
 test('Arrow @@implements', t => {
   const f = Arrow['@@implements']
 

--- a/src/Arrow/index.js
+++ b/src/Arrow/index.js
@@ -91,6 +91,11 @@ function Arrow(runWith) {
     inspect, toString: inspect, type,
     runWith, id, compose, map, contramap,
     promap, first, second, both,
+    'fantasy-land/id': id,
+    'fantasy-land/compose': compose,
+    'fantasy-land/contramap': contramap,
+    'fantasy-land/map': map,
+    'fantasy-land/promap': promap,
     '@@type': _type,
     constructor: Arrow
   }
@@ -98,6 +103,8 @@ function Arrow(runWith) {
 
 Arrow.id = _id
 Arrow.type = type
+
+Arrow['fantasy-land/id'] = _id
 Arrow['@@type'] = _type
 
 Arrow['@@implements'] = _implements(

--- a/src/Assign/Assign.spec.js
+++ b/src/Assign/Assign.spec.js
@@ -40,6 +40,17 @@ test('Assign', t => {
   t.end()
 })
 
+test('Assign fantasy-land api', t => {
+  const m = Assign({})
+
+  t.equals(Assign['fantasy-land/empty'], Assign.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+
+  t.end()
+})
+
 test('Assign @@implements', t => {
   const f = Assign['@@implements']
 

--- a/src/Assign/index.js
+++ b/src/Assign/index.js
@@ -44,6 +44,8 @@ function Assign(o) {
   return {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
+    'fantasy-land/empty': empty,
+    'fantasy-land/concat': concat,
     '@@type': _type,
     constructor: Assign
   }
@@ -55,6 +57,8 @@ Assign['@@implements'] = _implements(
 
 Assign.empty = _empty
 Assign.type = type
+
+Assign['fantasy-land/empty'] = _empty
 Assign['@@type'] = _type
 
 module.exports = Assign

--- a/src/Async/Async.spec.js
+++ b/src/Async/Async.spec.js
@@ -53,6 +53,27 @@ test('Async', t => {
   t.end()
 })
 
+test('Arrow fantasy-land api', t => {
+  const rej = Async.Rejected('')
+  const res = Async.Resolved('')
+
+  t.equals(Async['fantasy-land/of'], Async.of, 'is same function as public constructor of')
+
+  t.equals(rej['fantasy-land/of'], rej.of, 'is same function as public rejected instance of')
+  t.equals(rej['fantasy-land/alt'], rej.alt, 'is same function as public rejected instance alt')
+  t.equals(rej['fantasy-land/bimap'], rej.bimap, 'is same function as public rejected instance bimap')
+  t.equals(rej['fantasy-land/map'], rej.map, 'is same function as public rejected instance map')
+  t.equals(rej['fantasy-land/chain'], rej.chain, 'is same function as public rejected instance chain')
+
+  t.equals(res['fantasy-land/of'], res.of, 'is same function as public resolved instance of')
+  t.equals(res['fantasy-land/alt'], res.alt, 'is same function as public resolved instance alt')
+  t.equals(res['fantasy-land/bimap'], res.bimap, 'is same function as public resolved instance bimap')
+  t.equals(res['fantasy-land/map'], res.map, 'is same function as public resolved instance map')
+  t.equals(res['fantasy-land/chain'], res.chain, 'is same function as public resolved instance chain')
+
+  t.end()
+})
+
 test('Async @@implements', t => {
   const f = Async['@@implements']
 

--- a/src/Async/index.js
+++ b/src/Async/index.js
@@ -243,6 +243,11 @@ function Async(fn, parentCancel) {
     toString: inspect, type,
     swap, coalesce, map, bimap,
     alt, ap, chain, of,
+    'fantasy-land/of': of,
+    'fantasy-land/alt': alt,
+    'fantasy-land/bimap': bimap,
+    'fantasy-land/map': map,
+    'fantasy-land/chain': chain,
     '@@type': _type,
     constructor: Async
   }
@@ -250,6 +255,8 @@ function Async(fn, parentCancel) {
 
 Async.of = _of
 Async.type = type
+
+Async['fantasy-land/of'] = _of
 Async['@@type'] = _type
 
 Async.Rejected = Rejected

--- a/src/Const/Const.spec.js
+++ b/src/Const/Const.spec.js
@@ -31,6 +31,17 @@ test('Const', t => {
   t.end()
 })
 
+test('Const fantasy-land api', t => {
+  const m = Const('always')
+
+  t.equals(m['fantasy-land/equals'], m.equals, 'is same function as public instance equals')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/chain'], m.chain, 'is same function as public instance chain')
+
+  t.end()
+})
+
 test('Const @@implements', t => {
   const f = Const['@@implements']
 

--- a/src/Const/index.js
+++ b/src/Const/index.js
@@ -62,6 +62,10 @@ function Const(x) {
   return {
     inspect, toString: inspect, valueOf,
     type, equals, concat, map, ap, chain,
+    'fantasy-land/equals': equals,
+    'fantasy-land/concat': concat,
+    'fantasy-land/map': map,
+    'fantasy-land/chain': chain,
     '@@type': _type,
     constructor: Const
   }

--- a/src/Either/Either.spec.js
+++ b/src/Either/Either.spec.js
@@ -45,6 +45,31 @@ test('Either', t => {
   t.end()
 })
 
+test('Either fantasy-land api', t => {
+  const l = Either.Left('')
+  const r = Either.Right('')
+
+  t.equals(Either['fantasy-land/of'], Either.of, 'is same function as public constructor of')
+
+  t.equals(l['fantasy-land/of'], l.of, 'is same function as public left instance of')
+  t.equals(l['fantasy-land/equals'], l.equals, 'is same function as public left instance equals')
+  t.equals(l['fantasy-land/alt'], l.alt, 'is same function as public left instance alt')
+  t.equals(l['fantasy-land/bimap'], l.bimap, 'is same function as public left instance bimap')
+  t.equals(l['fantasy-land/concat'], l.concat, 'is same function as public left instance concat')
+  t.equals(l['fantasy-land/map'], l.map, 'is same function as public left instance map')
+  t.equals(l['fantasy-land/chain'], l.chain, 'is same function as public left instance chain')
+
+  t.equals(r['fantasy-land/of'], r.of, 'is same function as public right instance of')
+  t.equals(r['fantasy-land/equals'], r.equals, 'is same function as public right instance equals')
+  t.equals(r['fantasy-land/alt'], r.alt, 'is same function as public right instance alt')
+  t.equals(r['fantasy-land/bimap'], r.bimap, 'is same function as public right instance bimap')
+  t.equals(r['fantasy-land/concat'], r.concat, 'is same function as public right instance concat')
+  t.equals(r['fantasy-land/map'], r.map, 'is same function as public right instance map')
+  t.equals(r['fantasy-land/chain'], r.chain, 'is same function as public right instance chain')
+
+  t.end()
+})
+
 test('Either @@implements', t => {
   const f = Either['@@implements']
 

--- a/src/Either/index.js
+++ b/src/Either/index.js
@@ -199,6 +199,13 @@ function Either(u) {
     type, concat, swap, coalesce, equals,
     map, bimap, alt, ap, of, chain, sequence,
     traverse,
+    'fantasy-land/of': of,
+    'fantasy-land/equals': equals,
+    'fantasy-land/alt': alt,
+    'fantasy-land/bimap': bimap,
+    'fantasy-land/concat': concat,
+    'fantasy-land/map': map,
+    'fantasy-land/chain': chain,
     '@@type': _type,
     constructor: Either
   }
@@ -206,6 +213,8 @@ function Either(u) {
 
 Either.of   = _of
 Either.type = type
+
+Either['fantasy-land/of'] = _of
 Either['@@type'] = _type
 
 Either['@@implements'] = _implements(

--- a/src/Endo/Endo.spec.js
+++ b/src/Endo/Endo.spec.js
@@ -42,6 +42,17 @@ test('Endo', t => {
   t.end()
 })
 
+test('Endo fantasy-land api', t => {
+  const m = Endo(identity)
+
+  t.equals(Endo['fantasy-land/empty'], Endo.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+
+  t.end()
+})
+
 test('Endo @@implements', t => {
   const f = Endo['@@implements']
 

--- a/src/Endo/index.js
+++ b/src/Endo/index.js
@@ -41,6 +41,8 @@ function Endo(runWith) {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
     runWith,
+    'fantasy-land/empty': empty,
+    'fantasy-land/concat': concat,
     '@@type': _type,
     constructor: Endo
   }
@@ -52,6 +54,8 @@ Endo['@@implements'] = _implements(
 
 Endo.empty = _empty
 Endo.type = type
+
+Endo['fantasy-land/empty'] = _empty
 Endo['@@type'] = _type
 
 module.exports = Endo

--- a/src/Equiv/Equiv.spec.js
+++ b/src/Equiv/Equiv.spec.js
@@ -48,6 +48,18 @@ test('Equiv', t => {
   t.end()
 })
 
+test('Equiv fantasy-land api', t => {
+  const m = Equiv(identity)
+
+  t.equals(Equiv['fantasy-land/empty'], Equiv.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+  t.equals(m['fantasy-land/contramap'], m.contramap, 'is same function as public instance contramap')
+
+  t.end()
+})
+
 test('Equiv @@implements', t => {
   const f = Equiv['@@implements']
 

--- a/src/Equiv/index.js
+++ b/src/Equiv/index.js
@@ -58,6 +58,9 @@ function Equiv(compare) {
     inspect, toString: inspect, type,
     compareWith, valueOf, contramap,
     concat, empty,
+    'fantasy-land/empty': empty,
+    'fantasy-land/concat': concat,
+    'fantasy-land/contramap': contramap,
     '@@type': _type,
     constructor: Equiv
   }
@@ -65,6 +68,8 @@ function Equiv(compare) {
 
 Equiv.empty = _empty
 Equiv.type = type
+
+Equiv['fantasy-land/empty'] = _empty
 Equiv['@@type'] = _type
 
 Equiv['@@implements'] = _implements(

--- a/src/First/First.spec.js
+++ b/src/First/First.spec.js
@@ -31,6 +31,17 @@ test('First', t => {
   t.end()
 })
 
+test('First fantasy-land api', t => {
+  const m = First(10)
+
+  t.equals(First['fantasy-land/empty'], First.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+
+  t.end()
+})
+
 test('First @@implements', t => {
   const f = First['@@implements']
 

--- a/src/First/index.js
+++ b/src/First/index.js
@@ -52,6 +52,8 @@ function First(x) {
     inspect, toString: inspect,
     concat, empty, option, type,
     valueOf,
+    'fantasy-land/empty': _empty,
+    'fantasy-land/concat': concat,
     '@@type': _type,
     constructor: First
   }
@@ -63,6 +65,8 @@ First['@@implements'] = _implements(
 
 First.empty = _empty
 First.type = type
+
+First['fantasy-land/empty'] = _empty
 First['@@type'] = _type
 
 module.exports = First

--- a/src/IO/IO.spec.js
+++ b/src/IO/IO.spec.js
@@ -49,6 +49,18 @@ test('IO', t => {
   t.end()
 })
 
+test('IO fantasy-land api', t => {
+  const m = IO(identity)
+
+  t.equals(IO['fantasy-land/of'], IO.of, 'is same function as public constructor of')
+
+  t.equals(m['fantasy-land/of'], m.of, 'is same function as public instance of')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/chain'], m.chain, 'is same function as public instance chain')
+
+  t.end()
+})
+
 test('IO @@implements', t => {
   const f = IO['@@implements']
 

--- a/src/IO/index.js
+++ b/src/IO/index.js
@@ -61,6 +61,9 @@ function IO(run) {
   return {
     inspect, toString: inspect, run,
     type, map, ap, of, chain,
+    'fantasy-land/of': of,
+    'fantasy-land/map': map,
+    'fantasy-land/chain': chain,
     '@@type': _type,
     constructor: IO
   }
@@ -68,6 +71,8 @@ function IO(run) {
 
 IO.of = _of
 IO.type = type
+
+IO['fantasy-land/of'] = _of
 IO['@@type'] = _type
 
 IO['@@implements'] = _implements(

--- a/src/Identity/Identity.spec.js
+++ b/src/Identity/Identity.spec.js
@@ -38,6 +38,20 @@ test('Identity', t => {
   t.end()
 })
 
+test('Identity fantasy-land api', t => {
+  const m = Identity(identity)
+
+  t.equals(Identity['fantasy-land/of'], Identity.of, 'is same function as public constructor of')
+
+  t.equals(m['fantasy-land/of'], m.of, 'is same function as public instance of')
+  t.equals(m['fantasy-land/equals'], m.equals, 'is same function as public instance equals')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/chain'], m.chain, 'is same function as public instance chain')
+
+  t.end()
+})
+
 test('Identity @@implements', t => {
   const f = Identity['@@implements']
 

--- a/src/Identity/index.js
+++ b/src/Identity/index.js
@@ -108,6 +108,11 @@ function Identity(x) {
     inspect, toString: inspect, valueOf,
     type, equals, concat, map, ap, of,
     chain, sequence, traverse,
+    'fantasy-land/of': of,
+    'fantasy-land/equals': equals,
+    'fantasy-land/concat': concat,
+    'fantasy-land/map': map,
+    'fantasy-land/chain': chain,
     '@@type': _type,
     constructor: Identity
   }
@@ -115,6 +120,8 @@ function Identity(x) {
 
 Identity.of = _of
 Identity.type = type
+
+Identity['fantasy-land/of'] = _of
 Identity['@@type'] = _type
 
 Identity['@@implements'] = _implements(

--- a/src/Last/Last.spec.js
+++ b/src/Last/Last.spec.js
@@ -29,6 +29,17 @@ test('Last', t => {
   t.end()
 })
 
+test('Last fantasy-land api', t => {
+  const m = Last(false)
+
+  t.equals(Last['fantasy-land/empty'], Last.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+
+  t.end()
+})
+
 test('Last @@implements', t => {
   const f = Last['@@implements']
 

--- a/src/Last/index.js
+++ b/src/Last/index.js
@@ -54,6 +54,8 @@ function Last(x) {
   return {
     inspect, toString: inspect, concat,
     empty, option, type, valueOf,
+    'fantasy-land/empty': empty,
+    'fantasy-land/concat': concat,
     '@@type': _type,
     constructor: Last
   }
@@ -65,6 +67,8 @@ Last['@@implements'] = _implements(
 
 Last.empty = _empty
 Last.type = type
+
+Last['fantasy-land/empty'] = _empty
 Last['@@type'] = _type
 
 module.exports = Last

--- a/src/Max/Max.spec.js
+++ b/src/Max/Max.spec.js
@@ -40,6 +40,17 @@ test('Max', t => {
   t.end()
 })
 
+test('Max fantasy-land api', t => {
+  const m = Max(99)
+
+  t.equals(Max['fantasy-land/empty'], Max.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+
+  t.end()
+})
+
 test('Max @@implements', t => {
   const f = Max['@@implements']
 

--- a/src/Max/index.js
+++ b/src/Max/index.js
@@ -42,6 +42,8 @@ function Max(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
+    'fantasy-land/empty': empty,
+    'fantasy-land/concat': concat,
     '@@type': _type,
     constructor: Max
   }
@@ -53,6 +55,8 @@ Max['@@implements'] = _implements(
 
 Max.empty = _empty
 Max.type = type
+
+Max['fantasy-land/empty'] = _empty
 Max['@@type'] = _type
 
 module.exports = Max

--- a/src/Min/Min.spec.js
+++ b/src/Min/Min.spec.js
@@ -40,6 +40,17 @@ test('Min', t => {
   t.end()
 })
 
+test('Min fantasy-land api', t => {
+  const m = Min(0)
+
+  t.equals(Min['fantasy-land/empty'], Min.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+
+  t.end()
+})
+
 test('Min @@implements', t => {
   const f = Min['@@implements']
 

--- a/src/Min/index.js
+++ b/src/Min/index.js
@@ -42,6 +42,8 @@ function Min(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
+    'fantasy-land/empty': empty,
+    'fantasy-land/concat': concat,
     '@@type': _type,
     constructor: Min
   }
@@ -53,6 +55,8 @@ Min['@@implements'] = _implements(
 
 Min.empty = _empty
 Min.type = type
+
+Min['fantasy-land/empty'] = _empty
 Min['@@type'] = _type
 
 module.exports = Min

--- a/src/Pred/Pred.spec.js
+++ b/src/Pred/Pred.spec.js
@@ -44,6 +44,18 @@ test('Pred', t => {
   t.end()
 })
 
+test('Pred fantasy-land api', t => {
+  const m = Pred(identity)
+
+  t.equals(Pred['fantasy-land/empty'], Pred.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+  t.equals(m['fantasy-land/contramap'], m.contramap, 'is same function as public instance contramap')
+
+  t.end()
+})
+
 test('Pred @@implements', t => {
   const f = Pred['@@implements']
 

--- a/src/Pred/index.js
+++ b/src/Pred/index.js
@@ -51,6 +51,9 @@ function Pred(pred) {
   return {
     inspect, toString: inspect, runWith,
     type, valueOf, empty, concat, contramap,
+    'fantasy-land/empty': empty,
+    'fantasy-land/concat': concat,
+    'fantasy-land/contramap': contramap,
     '@@type': _type,
     constructor: Pred
   }
@@ -58,6 +61,8 @@ function Pred(pred) {
 
 Pred.empty = _empty
 Pred.type = type
+
+Pred['fantasy-land/empty'] = _empty
 Pred['@@type'] = _type
 
 Pred['@@implements'] = _implements(

--- a/src/Prod/Prod.spec.js
+++ b/src/Prod/Prod.spec.js
@@ -40,6 +40,17 @@ test('Prod', t => {
   t.end()
 })
 
+test('Prod fantasy-land api', t => {
+  const m = Prod(99)
+
+  t.equals(Prod['fantasy-land/empty'], Prod.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+
+  t.end()
+})
+
 test('Prod @@implements', t => {
   const f = Prod['@@implements']
 

--- a/src/Prod/index.js
+++ b/src/Prod/index.js
@@ -42,6 +42,8 @@ function Prod(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
+    'fantasy-land/empty': empty,
+    'fantasy-land/concat': concat,
     '@@type': _type,
     constructor: Prod
   }
@@ -53,6 +55,8 @@ Prod['@@implements'] = _implements(
 
 Prod.empty = _empty
 Prod.type = type
+
+Prod['fantasy-land/empty'] = _empty
 Prod['@@type'] = _type
 
 module.exports = Prod

--- a/src/Reader/Reader.spec.js
+++ b/src/Reader/Reader.spec.js
@@ -51,6 +51,18 @@ test('Reader', t => {
   t.end()
 })
 
+test('Reader fantasy-land api', t => {
+  const m = Reader(identity)
+
+  t.equals(Reader['fantasy-land/of'], Reader.of, 'is same function as public constructor of')
+
+  t.equals(m['fantasy-land/of'], m.of, 'is same function as public instance of')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/chain'], m.chain, 'is same function as public instance chain')
+
+  t.end()
+})
+
 test('Reader @@implements', t => {
   const f = Reader['@@implements']
 

--- a/src/Reader/ReaderT.js
+++ b/src/Reader/ReaderT.js
@@ -112,6 +112,9 @@ function _ReaderT(Monad) {
     return {
       inspect, toString: inspect, type,
       runWith, of, map, ap, chain,
+      'fantasy-land/of': of,
+      'fantasy-land/map': map,
+      'fantasy-land/chain': chain,
       constructor: ReaderT
     }
   }
@@ -121,6 +124,8 @@ function _ReaderT(Monad) {
   ReaderT.ask = ask
   ReaderT.lift = lift
   ReaderT.liftFn = curry(liftFn)
+
+  ReaderT['fantasy-land/of'] = of
 
   ReaderT['@@implements'] = _implements(
     [ 'ap', 'chain', 'map', 'of' ]

--- a/src/Reader/ReaderT.spec.js
+++ b/src/Reader/ReaderT.spec.js
@@ -70,6 +70,18 @@ test('ReaderT', t => {
   t.end()
 })
 
+test('ReaderMock fantasy-land api', t => {
+  const m = ReaderMock(identity)
+
+  t.equals(ReaderMock['fantasy-land/of'], ReaderMock.of, 'is same function as public constructor of')
+
+  t.equals(m['fantasy-land/of'], m.of, 'is same function as public instance of')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/chain'], m.chain, 'is same function as public instance chain')
+
+  t.end()
+})
+
 test('ReaderT @@implements', t => {
   const f = ReaderMock['@@implements']
 

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -81,6 +81,9 @@ function Reader(runWith) {
   return {
     inspect, toString: inspect, runWith,
     type, map, ap, chain, of,
+    'fantasy-land/of': of,
+    'fantasy-land/map': map,
+    'fantasy-land/chain': chain,
     '@@type': _type,
     constructor: Reader
   }
@@ -89,6 +92,8 @@ function Reader(runWith) {
 Reader.of = _of
 Reader.ask = ask
 Reader.type = type
+
+Reader['fantasy-land/of'] = _of
 Reader['@@type'] = _type
 
 Reader['@@implements'] = _implements(

--- a/src/Result/Result.spec.js
+++ b/src/Result/Result.spec.js
@@ -45,6 +45,31 @@ test('Result', t => {
   t.end()
 })
 
+test('Result fantasy-land api', t => {
+  const e = Result.Err('')
+  const o = Result.Ok('')
+
+  t.equals(Result['fantasy-land/of'], Result.of, 'is same function as public constructor of')
+
+  t.equals(e['fantasy-land/of'], e.of, 'is same function as public err instance of')
+  t.equals(e['fantasy-land/equals'], e.equals, 'is same function as public err instance equals')
+  t.equals(e['fantasy-land/alt'], e.alt, 'is same function as public err instance alt')
+  t.equals(e['fantasy-land/bimap'], e.bimap, 'is same function as public err instance bimap')
+  t.equals(e['fantasy-land/concat'], e.concat, 'is same function as public err instance concat')
+  t.equals(e['fantasy-land/map'], e.map, 'is same function as public err instance map')
+  t.equals(e['fantasy-land/chain'], e.chain, 'is same function as public err instance chain')
+
+  t.equals(o['fantasy-land/of'], o.of, 'is same function as public ok instance of')
+  t.equals(o['fantasy-land/equals'], o.equals, 'is same function as public ok instance equals')
+  t.equals(o['fantasy-land/alt'], o.alt, 'is same function as public ok instance alt')
+  t.equals(o['fantasy-land/bimap'], o.bimap, 'is same function as public ok instance bimap')
+  t.equals(o['fantasy-land/concat'], o.concat, 'is same function as public ok instance concat')
+  t.equals(o['fantasy-land/map'], o.map, 'is same function as public ok instance map')
+  t.equals(o['fantasy-land/chain'], o.chain, 'is same function as public ok instance chain')
+
+  t.end()
+})
+
 test('Result @@implements', t => {
   const f = Result['@@implements']
 

--- a/src/Result/index.js
+++ b/src/Result/index.js
@@ -209,6 +209,13 @@ function Result(u) {
     type, either, concat, swap, coalesce,
     map, bimap, alt, ap, chain, of, sequence,
     traverse,
+    'fantasy-land/of': of,
+    'fantasy-land/equals': equals,
+    'fantasy-land/alt': alt,
+    'fantasy-land/bimap': bimap,
+    'fantasy-land/concat': concat,
+    'fantasy-land/map': map,
+    'fantasy-land/chain': chain,
     '@@type': _type,
     constructor: Result
   }
@@ -216,6 +223,8 @@ function Result(u) {
 
 Result.of = _of
 Result.type = type
+
+Result['fantasy-land/of'] = _of
 Result['@@type'] = _type
 
 Result['@@implements'] = _implements(

--- a/src/Star/Star.spec.js
+++ b/src/Star/Star.spec.js
@@ -79,6 +79,20 @@ test('Star construction', t => {
   t.end()
 })
 
+test('Star fantasy-land api', t => {
+  const m = Star(identity)
+
+  t.equals(Star['fantasy-land/id'], Star.id, 'is same function as public constructor id')
+
+  t.equals(m['fantasy-land/id'], m.id, 'is same function as public instance id')
+  t.equals(m['fantasy-land/compose'], m.compose, 'is same function as public instance compose')
+  t.equals(m['fantasy-land/contramap'], m.contramap, 'is same function as public instance contramap')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/promap'], m.promap, 'is same function as public instance promap')
+
+  t.end()
+})
+
 test('Star @@implements', t => {
   const f = Star['@@implements']
 

--- a/src/Star/index.js
+++ b/src/Star/index.js
@@ -172,6 +172,11 @@ function _Star(Monad) {
       inspect, toString: inspect, type,
       runWith, id, compose, map, contramap,
       promap, first, second, both,
+      'fantasy-land/id': id,
+      'fantasy-land/compose': compose,
+      'fantasy-land/contramap': contramap,
+      'fantasy-land/map': map,
+      'fantasy-land/promap': promap,
       '@@type': typeFn,
       constructor: Star
     }
@@ -179,6 +184,8 @@ function _Star(Monad) {
 
   Star.id = _id
   Star.type = type
+
+  Star['fantasy-land/id'] = _id
   Star['@@type'] = typeFn
 
   Star['@@implements'] = _implements(

--- a/src/State/State.spec.js
+++ b/src/State/State.spec.js
@@ -51,6 +51,18 @@ test('State', t => {
   t.end()
 })
 
+test('State fantasy-land api', t => {
+  const m = State(identity)
+
+  t.equals(State['fantasy-land/of'], State.of, 'is same function as public constructor of')
+
+  t.equals(m['fantasy-land/of'], m.of, 'is same function as public instance of')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/chain'], m.chain, 'is same function as public instance chain')
+
+  t.end()
+})
+
 test('State @@implements', t => {
   const f = State['@@implements']
 

--- a/src/State/index.js
+++ b/src/State/index.js
@@ -118,6 +118,9 @@ function State(fn) {
     inspect, toString: inspect, runWith,
     execWith, evalWith, type, map, ap,
     chain, of,
+    'fantasy-land/of': of,
+    'fantasy-land/map': map,
+    'fantasy-land/chain': chain,
     '@@type': _type,
     constructor: State
   }
@@ -132,6 +135,8 @@ State.put =
   x => modify(() => (x))
 
 State.type = type
+
+State['fantasy-land/of'] = _of
 State['@@type'] = _type
 
 State['@@implements'] = _implements(

--- a/src/Sum/Sum.spec.js
+++ b/src/Sum/Sum.spec.js
@@ -40,6 +40,17 @@ test('Sum', t => {
   t.end()
 })
 
+test('Sum fantasy-land api', t => {
+  const m = Sum(99)
+
+  t.equals(Sum['fantasy-land/empty'], Sum.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+
+  t.end()
+})
+
 test('Sum @@implements', t => {
   const f = Sum['@@implements']
 

--- a/src/Sum/index.js
+++ b/src/Sum/index.js
@@ -42,6 +42,8 @@ function Sum(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
+    'fantasy-land/empty': empty,
+    'fantasy-land/concat': concat,
     '@@type': _type,
     constructor: Sum
   }
@@ -53,6 +55,8 @@ Sum['@@implements'] = _implements(
 
 Sum.empty = _empty
 Sum.type = type
+
+Sum['fantasy-land/empty'] = _empty
 Sum['@@type'] = _type
 
 module.exports = Sum

--- a/src/Writer/Writer.spec.js
+++ b/src/Writer/Writer.spec.js
@@ -59,6 +59,19 @@ test('Writer', t => {
   t.end()
 })
 
+test('Writer fantasy-land api', t => {
+  const m = Writer(0, 0)
+
+  t.equals(Writer['fantasy-land/of'], Writer.of, 'is same function as public constructor of')
+
+  t.equals(m['fantasy-land/of'], m.of, 'is same function as public instance of')
+  t.equals(m['fantasy-land/equals'], m.equals, 'is same function as public instance equals')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/chain'], m.chain, 'is same function as public instance chain')
+
+  t.end()
+})
+
 test('Writer @@implements', t => {
   const f = Writer['@@implements']
 

--- a/src/Writer/index.js
+++ b/src/Writer/index.js
@@ -95,6 +95,10 @@ function _Writer(Monoid) {
       inspect, toString: inspect, read,
       valueOf, log, type, equals, map,
       ap, of, chain,
+      'fantasy-land/of': of,
+      'fantasy-land/equals': equals,
+      'fantasy-land/map': map,
+      'fantasy-land/chain': chain,
       '@@type': typeFn,
       constructor: Writer
     }
@@ -102,6 +106,8 @@ function _Writer(Monoid) {
 
   Writer.of = _of
   Writer.type = _type
+
+  Writer['fantasy-land/of'] = _of
   Writer['@@type'] = typeFn
 
   Writer['@@implements'] = _implements(

--- a/src/core/List.js
+++ b/src/core/List.js
@@ -246,6 +246,13 @@ function List(x) {
     head, tail, cons, type, equals, concat, empty,
     reduce, reduceRight, fold, filter, reject, map,
     ap, of, chain, sequence, traverse,
+    'fantasy-land/of': of,
+    'fantasy-land/equals': equals,
+    'fantasy-land/concat': concat,
+    'fantasy-land/empty': empty,
+    'fantasy-land/map': map,
+    'fantasy-land/chain': chain,
+    'fantasy-land/reduce': reduce,
     '@@type': _type,
     constructor: List
   }
@@ -254,6 +261,9 @@ function List(x) {
 List.of = _of
 List.empty = _empty
 List.type = type
+
+List['fantasy-land/of'] = _of
+List['fantasy-land/empty'] = _empty
 List['@@type'] = _type
 
 List.fromArray =

--- a/src/core/List.spec.js
+++ b/src/core/List.spec.js
@@ -53,6 +53,23 @@ test('List', t => {
   t.end()
 })
 
+test('List fantasy-land api', t => {
+  const m = List('value')
+
+  t.equals(List['fantasy-land/of'], List.of, 'is same function as public constructor of')
+  t.equals(List['fantasy-land/empty'], List.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/of'], m.of, 'is same function as public instance of')
+  t.equals(m['fantasy-land/equals'], m.equals, 'is same function as public instance equals')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/chain'], m.chain, 'is same function as public instance chain')
+  t.equals(m['fantasy-land/reduce'], m.reduce, 'is same function as public instance reduce')
+
+  t.end()
+})
+
 test('List @@implements', t => {
   const f = List['@@implements']
 

--- a/src/core/Maybe.js
+++ b/src/core/Maybe.js
@@ -194,6 +194,13 @@ function Maybe(u) {
     option, type, concat, equals, coalesce,
     map, alt, zero, ap, of, chain, sequence,
     traverse,
+    'fantasy-land/zero': zero,
+    'fantasy-land/of': of,
+    'fantasy-land/equals': equals,
+    'fantasy-land/alt': alt,
+    'fantasy-land/concat': concat,
+    'fantasy-land/map': map,
+    'fantasy-land/chain': chain,
     '@@type': _type,
     constructor: Maybe
   }
@@ -202,6 +209,9 @@ function Maybe(u) {
 Maybe.of = _of
 Maybe.zero = _zero
 Maybe.type = type
+
+Maybe['fantasy-land/of'] = _of
+Maybe['fantasy-land/zero'] = _zero
 Maybe['@@type'] = _type
 
 Maybe['@@implements'] = _implements(

--- a/src/core/Maybe.spec.js
+++ b/src/core/Maybe.spec.js
@@ -46,6 +46,32 @@ test('Maybe', t => {
   t.end()
 })
 
+test('Maybe fantasy-land api', t => {
+  const n = Maybe.Nothing()
+  const j = Maybe.Just('')
+
+  t.equals(Maybe['fantasy-land/zero'], Maybe.zero, 'is same function as public constructor zero')
+  t.equals(Maybe['fantasy-land/of'], Maybe.of, 'is same function as public constructor of')
+
+  t.equals(n['fantasy-land/zero'], n.zero, 'is same function as public nothing instance zero')
+  t.equals(n['fantasy-land/of'], n.of, 'is same function as public nothing instance of')
+  t.equals(n['fantasy-land/equals'], n.equals, 'is same function as nothing public instance equals')
+  t.equals(n['fantasy-land/alt'], n.alt, 'is same function as public nothing instance alt')
+  t.equals(n['fantasy-land/concat'], n.concat, 'is same function as public nothing instance concat')
+  t.equals(n['fantasy-land/map'], n.map, 'is same function as public nothing instance map')
+  t.equals(n['fantasy-land/chain'], n.chain, 'is same function as public nothing instance chain')
+
+  t.equals(j['fantasy-land/zero'], j.zero, 'is same function as public instance zero')
+  t.equals(j['fantasy-land/of'], j.of, 'is same function as public instance of')
+  t.equals(j['fantasy-land/equals'], j.equals, 'is same function as public just instance equals')
+  t.equals(j['fantasy-land/alt'], j.alt, 'is same function as public just instance alt')
+  t.equals(j['fantasy-land/concat'], j.concat, 'is same function as public just instance concat')
+  t.equals(j['fantasy-land/map'], j.map, 'is same function as public just instance map')
+  t.equals(j['fantasy-land/chain'], j.chain, 'is same function as public just instance chain')
+
+  t.end()
+})
+
 test('Maybe @@implements', t => {
   const f = Maybe['@@implements']
 

--- a/src/core/Pair.js
+++ b/src/core/Pair.js
@@ -155,6 +155,12 @@ function Pair(l, r) {
     snd, toArray, type, merge, equals,
     concat, swap, map, bimap, ap, chain,
     extend,
+    'fantasy-land/equals': equals,
+    'fantasy-land/concat': concat,
+    'fantasy-land/map': map,
+    'fantasy-land/bimap': bimap,
+    'fantasy-land/chain': chain,
+    'fantasy-land/extend': extend,
     '@@type': _type,
     constructor: Pair
   }

--- a/src/core/Pair.spec.js
+++ b/src/core/Pair.spec.js
@@ -36,6 +36,19 @@ test('Pair core', t => {
   t.end()
 })
 
+test('Pair fantasy-land api', t => {
+  const m = Pair(3, 3)
+
+  t.equals(m['fantasy-land/equals'], m.equals, 'is same function as public instance equals')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/bimap'], m.bimap, 'is same function as public instance bimap')
+  t.equals(m['fantasy-land/chain'], m.chain, 'is same function as public instance chain')
+  t.equals(m['fantasy-land/extend'], m.extend, 'is same function as public instance extend')
+
+  t.end()
+})
+
 test('Pair @@implements', t => {
   const f = Pair['@@implements']
 

--- a/src/core/Unit.js
+++ b/src/core/Unit.js
@@ -68,6 +68,12 @@ function Unit() {
     inspect, toString: inspect, valueOf,
     type, equals, concat, empty, map, ap,
     of, chain,
+    'fantasy-land/of': of,
+    'fantasy-land/empty': empty,
+    'fantasy-land/equals': equals,
+    'fantasy-land/concat': concat,
+    'fantasy-land/map': map,
+    'fantasy-land/chain': chain,
     '@@type': _type,
     constructor: Unit
   }
@@ -76,6 +82,9 @@ function Unit() {
 Unit.of = _of
 Unit.empty = _empty
 Unit.type = type
+
+Unit['fantasy-land/of'] = _of
+Unit['fantasy-land/empty'] = _empty
 Unit['@@type'] = _type
 
 Unit['@@implements'] = _implements(

--- a/src/core/Unit.spec.js
+++ b/src/core/Unit.spec.js
@@ -36,6 +36,21 @@ test('Unit', t => {
   t.end()
 })
 
+test('Unit fantasy-land api', t => {
+  const m = Unit()
+
+  t.equals(Unit['fantasy-land/of'], Unit.of, 'is same function as public constructor of')
+  t.equals(Unit['fantasy-land/empty'], Unit.empty, 'is same function as public constructor empty')
+
+  t.equals(m['fantasy-land/equals'], m.equals, 'is same function as public instance equals')
+  t.equals(m['fantasy-land/empty'], m.empty, 'is same function as public instance empty')
+  t.equals(m['fantasy-land/concat'], m.concat, 'is same function as public instance concat')
+  t.equals(m['fantasy-land/map'], m.map, 'is same function as public instance map')
+  t.equals(m['fantasy-land/chain'], m.chain, 'is same function as public instance chain')
+
+  t.end()
+})
+
 test('Unit @@implements', t => {
   const f = Unit['@@implements']
 


### PR DESCRIPTION
## FINALLY (-ish)
![image](https://user-images.githubusercontent.com/3665793/35955437-3bae3ab0-0c44-11e8-934d-adf3a9cbfd3f.png)

This PR addresses the last item on [this issue](https://github.com/evilsoft/crocks/issues/162) and adds the remaining bits for what `crocks` will implement for the [fantasy-land spec](https://github.com/fantasyland/fantasy-land).

This adds the prefixed method names, which is the 🍒 on the 🍰. For usability reasons we will not be implementing `fantasy-land/ap` and `fantasy-land/traverse`, those will stay with the pre-1.x version of the API.