### PR TITLE
Add `sequence` and `traverse` to `Pair`

### DIFF
--- a/docs/src/pages/docs/crocks/index.md
+++ b/docs/src/pages/docs/crocks/index.md
@@ -26,7 +26,7 @@ but what they do from type to type may vary.
 | `IO` | `of` | `ap`, `chain`, `map`, `of`, `run` |
 | `List` |  `empty`, `fromArray`, `of` | `ap`, `chain`, `concat`, `cons`, `empty`, `equals`, `filter`, `head`, `map`, `of`, `reduce`, `reduceRight`, `reject`, `sequence`, `tail`, `toArray`, `traverse`, `valueOf` |
 | [`Maybe`][maybe] | [`Nothing`][maybe-nothing], [`Just`][maybe-just], [`of`][maybe-of], [`zero`][maybe-zero] | [`alt`][maybe-alt], [`ap`][maybe-ap], [`chain`][maybe-chain], [`coalesce`][maybe-coalesce], [`concat`][maybe-concat], [`equals`][maybe-equals], [`either`][maybe-either], [`map`][maybe-map], [`of`][maybe-of], [`option`][maybe-option], [`sequence`][maybe-sequence], [`traverse`][maybe-traverse], [`zero`][maybe-zero] |
-| `Pair` | --- | `ap`, `bimap`, `chain`, `concat`, `equals`, `extend`, `fst`, `map`, `merge`, `of`, `snd`, `swap`, `toArray` |
+| `Pair` | --- | `ap`, `bimap`, `chain`, `concat`, `equals`, `extend`, `fst`, `map`, `merge`, `of`, `sequence`, `snd`, `swap`, `traverse`, `toArray` |
 | [`Pred`][pred] * | [`empty`][pred-empty] | [`concat`][pred-concat], [`contramap`][pred-contra], [`runWith`][pred-run], [`valueOf`][pred-value] |
 | [`Reader`][reader] | [`ask`][reader-ask], [`of`][reader-of] | [`ap`][reader-ap], [`chain`][reader-chain], [`map`][reader-map], [`runWith`][reader-run] |
 | [`ReaderT`][readert] | [`ask`][readert-ask], [`lift`][readert-lift], [`liftFn`][readert-liftfn], [`of`][readert-of] | [`ap`][readert-ap], [`chain`][readert-chain], [`map`][readert-map], [`runWith`][readert-run] |

--- a/docs/src/pages/docs/functions/pointfree-functions.md
+++ b/docs/src/pages/docs/functions/pointfree-functions.md
@@ -123,11 +123,11 @@ accepted Datatype):
 | `run` | `IO` |
 | `runWith` | [`Arrow`][arrow-run], [`Endo`][endo-run], [`Pred`][pred-run], [`Reader`][reader-run], `Star`, [`State`][state-run] |
 | `second` | [`Arrow`][arrow-second], `Function`, `Star` |
-| `sequence` | `Array`, `Either`, `Identity`, `List`, [`Maybe`][maybe-sequence], `Result` |
+| `sequence` | `Array`, `Either`, `Identity`, `List`, [`Maybe`][maybe-sequence], `Pair`, `Result` |
 | `snd` | `Pair` |
 | `swap` | [`Async`][async-swap], `Either`, `Pair`, `Result` |
 | `tail` | `Array`, `List`, `String` |
-| `traverse` | `Array`, `Either`, `Identity`, `List`, [`Maybe`][maybe-traverse], `Result` |
+| `traverse` | `Array`, `Either`, `Identity`, `List`, [`Maybe`][maybe-traverse], `Pair`, `Result` |
 | `valueOf` | [`All`][all-value], [`Any`][any-value], [`Assign`][assign-value], `Const`, [`Endo`][endo-value], [`Equiv`][equiv-value], [`First`][first-value], `Identity`, [`Last`][last-value], `Max`, `Min`, [`Pred`][pred-value], [`Prod`][prod-value], [`Sum`][sum-value], `Unit`, `Writer` |
 
 [all-concat]: ../monoids/All.html#concat

--- a/src/core/Pair.js
+++ b/src/core/Pair.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const VERSION = 1
+const VERSION = 2
 
 const _equals = require('./equals')
 const _implements = require('./implements')
@@ -10,6 +10,8 @@ const type = require('./types').type('Pair')
 const _type = require('./types').typeFn(type(), VERSION)
 const fl = require('./flNames')
 
+const isApply = require('./isApply')
+const isArray = require('./isArray')
 const isFunction = require('./isFunction')
 const isSameType = require('./isSameType')
 const isSemigroup = require('./isSemigroup')
@@ -143,6 +145,33 @@ function Pair(l, r) {
     )
   }
 
+  function sequence(af) {
+    if(!isFunction(af)) {
+      throw new TypeError('Pair.sequence: Apply returning function required')
+    }
+
+    if(!(isApply(r) || isArray(r))) {
+      throw new TypeError('Pair.sequence: Must wrap an Apply in the second')
+    }
+
+    return r.map(v => Pair(l, v))
+
+  }
+
+  function traverse(af, f) {
+    if(!isFunction(f) || !isFunction(af)) {
+      throw new TypeError('Pair.traverse: Apply returning functions required for both arguments')
+    }
+
+    const m = f(r)
+
+    if(!(isApply(m) || isArray(m))) {
+      throw new TypeError('Pair.traverse: Both functions must return an Apply of the same type')
+    }
+
+    return m.map(v => Pair(l, v))
+  }
+
   function extend(fn) {
     if(!isFunction(fn)) {
       throw new TypeError('Pair.extend: Function required')
@@ -155,7 +184,7 @@ function Pair(l, r) {
     inspect, toString: inspect, fst,
     snd, toArray, type, merge, equals,
     concat, swap, map, bimap, ap, chain,
-    extend,
+    sequence, traverse, extend,
     [fl.equals]: equals,
     [fl.concat]: concat,
     [fl.map]: map,
@@ -171,7 +200,7 @@ Pair.type = type
 Pair['@@type'] = _type
 
 Pair['@@implements'] = _implements(
-  [ 'ap', 'bimap', 'chain', 'concat', 'extend', 'equals', 'map' ]
+  [ 'ap', 'bimap', 'chain', 'concat', 'extend', 'equals', 'map', 'traverse' ]
 )
 
 module.exports = Pair


### PR DESCRIPTION
## Super Power that Pair
![image](https://user-images.githubusercontent.com/3665793/36238409-437c664a-11b7-11e8-878b-031eeeb59a26.png)

Thought I had already added `traverse` and `sequence` to both the `Pair` and `Writer` types...until I went to write an example for someone. :smh:

This PR adds those methods to `Pair` and each will traverse over the far right (second) parameter. So you can turn your `Pair Array (Maybe a)` into a `Maybe (Pair Array a)`...all the good things.