### PR TITLE
Move Fantasy-Land method name into one place

### DIFF
--- a/src/All/index.js
+++ b/src/All/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('All')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isFunction = require('../core/isFunction')
 const isNil = require('../core/isNil')
@@ -42,9 +43,9 @@ function All(b) {
   return {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
-    '@@type': _type,
-    'fantasy-land/concat': concat,
-    'fantasy-land/empty': empty,
+    ['@@type']: _type,
+    [fl.concat]: concat,
+    [fl.empty]: empty,
     constructor: All
   }
 }
@@ -56,7 +57,7 @@ All['@@implements'] = _implements(
 All.empty = _empty
 All.type = type
 
-All['fantasy-land/empty'] = _empty
+All[fl.empty] = _empty
 All['@@type'] = _type
 
 module.exports = All

--- a/src/Any/index.js
+++ b/src/Any/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Any')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isFunction = require('../core/isFunction')
 const isNil = require('../core/isNil')
@@ -42,9 +43,9 @@ function Any(b) {
   return {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
-    '@@type': _type,
-    'fantasy-land/concat': concat,
-    'fantasy-land/empty': empty,
+    ['@@type']: _type,
+    [fl.concat]: concat,
+    [fl.empty]: empty,
     constructor: Any
   }
 }
@@ -56,7 +57,7 @@ Any['@@implements'] = _implements(
 Any.empty = _empty
 Any.type  = type
 
-Any['fantasy-land/empty'] = _empty
+Any[fl.empty] = _empty
 Any['@@type'] = _type
 
 module.exports = Any

--- a/src/Arrow/index.js
+++ b/src/Arrow/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Arrow')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
@@ -91,12 +92,12 @@ function Arrow(runWith) {
     inspect, toString: inspect, type,
     runWith, id, compose, map, contramap,
     promap, first, second, both,
-    'fantasy-land/id': id,
-    'fantasy-land/compose': compose,
-    'fantasy-land/contramap': contramap,
-    'fantasy-land/map': map,
-    'fantasy-land/promap': promap,
-    '@@type': _type,
+    [fl.id]: id,
+    [fl.compose]: compose,
+    [fl.contramap]: contramap,
+    [fl.map]: map,
+    [fl.promap]: promap,
+    ['@@type']: _type,
     constructor: Arrow
   }
 }
@@ -104,7 +105,7 @@ function Arrow(runWith) {
 Arrow.id = _id
 Arrow.type = type
 
-Arrow['fantasy-land/id'] = _id
+Arrow[fl.id] = _id
 Arrow['@@type'] = _type
 
 Arrow['@@implements'] = _implements(

--- a/src/Assign/index.js
+++ b/src/Assign/index.js
@@ -9,6 +9,7 @@ const _object = require('../core/object')
 
 const type = require('../core/types').type('Assign')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isNil = require('../core/isNil')
 const isObject = require('../core/isObject')
@@ -44,9 +45,9 @@ function Assign(o) {
   return {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
-    'fantasy-land/empty': empty,
-    'fantasy-land/concat': concat,
-    '@@type': _type,
+    [fl.empty]: empty,
+    [fl.concat]: concat,
+    ['@@type']: _type,
     constructor: Assign
   }
 }
@@ -58,7 +59,7 @@ Assign['@@implements'] = _implements(
 Assign.empty = _empty
 Assign.type = type
 
-Assign['fantasy-land/empty'] = _empty
+Assign[fl.empty] = _empty
 Assign['@@type'] = _type
 
 module.exports = Assign

--- a/src/Async/index.js
+++ b/src/Async/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Async')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const array = require('../core/array')
 const compose = require('../core/compose')
@@ -243,12 +244,12 @@ function Async(fn, parentCancel) {
     toString: inspect, type,
     swap, coalesce, map, bimap,
     alt, ap, chain, of,
-    'fantasy-land/of': of,
-    'fantasy-land/alt': alt,
-    'fantasy-land/bimap': bimap,
-    'fantasy-land/map': map,
-    'fantasy-land/chain': chain,
-    '@@type': _type,
+    [fl.of]: of,
+    [fl.alt]: alt,
+    [fl.bimap]: bimap,
+    [fl.map]: map,
+    [fl.chain]: chain,
+    ['@@type']: _type,
     constructor: Async
   }
 }
@@ -256,7 +257,7 @@ function Async(fn, parentCancel) {
 Async.of = _of
 Async.type = type
 
-Async['fantasy-land/of'] = _of
+Async[fl.of] = _of
 Async['@@type'] = _type
 
 Async.Rejected = Rejected

--- a/src/Const/index.js
+++ b/src/Const/index.js
@@ -8,6 +8,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Const')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
@@ -62,11 +63,11 @@ function Const(x) {
   return {
     inspect, toString: inspect, valueOf,
     type, equals, concat, map, ap, chain,
-    'fantasy-land/equals': equals,
-    'fantasy-land/concat': concat,
-    'fantasy-land/map': map,
-    'fantasy-land/chain': chain,
-    '@@type': _type,
+    [fl.equals]: equals,
+    [fl.concat]: concat,
+    [fl.map]: map,
+    [fl.chain]: chain,
+    ['@@type']: _type,
     constructor: Const
   }
 }

--- a/src/Either/index.js
+++ b/src/Either/index.js
@@ -10,6 +10,7 @@ const _innerConcat = require('../core/innerConcat')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Either')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const compose = require('../core/compose')
 const isArray = require('../core/isArray')
@@ -199,14 +200,14 @@ function Either(u) {
     type, concat, swap, coalesce, equals,
     map, bimap, alt, ap, of, chain, sequence,
     traverse,
-    'fantasy-land/of': of,
-    'fantasy-land/equals': equals,
-    'fantasy-land/alt': alt,
-    'fantasy-land/bimap': bimap,
-    'fantasy-land/concat': concat,
-    'fantasy-land/map': map,
-    'fantasy-land/chain': chain,
-    '@@type': _type,
+    [fl.of]: of,
+    [fl.equals]: equals,
+    [fl.alt]: alt,
+    [fl.bimap]: bimap,
+    [fl.concat]: concat,
+    [fl.map]: map,
+    [fl.chain]: chain,
+    ['@@type']: _type,
     constructor: Either
   }
 }
@@ -214,7 +215,7 @@ function Either(u) {
 Either.of   = _of
 Either.type = type
 
-Either['fantasy-land/of'] = _of
+Either[fl.of] = _of
 Either['@@type'] = _type
 
 Either['@@implements'] = _implements(

--- a/src/Endo/index.js
+++ b/src/Endo/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Endo')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
@@ -41,9 +42,9 @@ function Endo(runWith) {
     inspect, toString: inspect,
     valueOf, type, concat, empty,
     runWith,
-    'fantasy-land/empty': empty,
-    'fantasy-land/concat': concat,
-    '@@type': _type,
+    [fl.empty]: empty,
+    [fl.concat]: concat,
+    ['@@type']: _type,
     constructor: Endo
   }
 }
@@ -55,7 +56,7 @@ Endo['@@implements'] = _implements(
 Endo.empty = _empty
 Endo.type = type
 
-Endo['fantasy-land/empty'] = _empty
+Endo[fl.empty] = _empty
 Endo['@@type'] = _type
 
 module.exports = Endo

--- a/src/Equiv/index.js
+++ b/src/Equiv/index.js
@@ -12,6 +12,7 @@ const isSameType = require('../core/isSameType')
 
 const type = require('../core/types').type('Equiv')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const _empty =
   () => Equiv(() => true)
@@ -58,10 +59,10 @@ function Equiv(compare) {
     inspect, toString: inspect, type,
     compareWith, valueOf, contramap,
     concat, empty,
-    'fantasy-land/empty': empty,
-    'fantasy-land/concat': concat,
-    'fantasy-land/contramap': contramap,
-    '@@type': _type,
+    [fl.empty]: empty,
+    [fl.concat]: concat,
+    [fl.contramap]: contramap,
+    ['@@type']: _type,
     constructor: Equiv
   }
 }
@@ -69,7 +70,7 @@ function Equiv(compare) {
 Equiv.empty = _empty
 Equiv.type = type
 
-Equiv['fantasy-land/empty'] = _empty
+Equiv[fl.empty] = _empty
 Equiv['@@type'] = _type
 
 Equiv['@@implements'] = _implements(

--- a/src/First/index.js
+++ b/src/First/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('First')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isSameType = require('../core/isSameType')
 
@@ -52,9 +53,9 @@ function First(x) {
     inspect, toString: inspect,
     concat, empty, option, type,
     valueOf,
-    'fantasy-land/empty': _empty,
-    'fantasy-land/concat': concat,
-    '@@type': _type,
+    [fl.empty]: _empty,
+    [fl.concat]: concat,
+    ['@@type']: _type,
     constructor: First
   }
 }
@@ -66,7 +67,7 @@ First['@@implements'] = _implements(
 First.empty = _empty
 First.type = type
 
-First['fantasy-land/empty'] = _empty
+First[fl.empty] = _empty
 First['@@type'] = _type
 
 module.exports = First

--- a/src/IO/index.js
+++ b/src/IO/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('IO')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
@@ -61,10 +62,10 @@ function IO(run) {
   return {
     inspect, toString: inspect, run,
     type, map, ap, of, chain,
-    'fantasy-land/of': of,
-    'fantasy-land/map': map,
-    'fantasy-land/chain': chain,
-    '@@type': _type,
+    [fl.of]: of,
+    [fl.map]: map,
+    [fl.chain]: chain,
+    ['@@type']: _type,
     constructor: IO
   }
 }
@@ -72,7 +73,7 @@ function IO(run) {
 IO.of = _of
 IO.type = type
 
-IO['fantasy-land/of'] = _of
+IO[fl.of] = _of
 IO['@@type'] = _type
 
 IO['@@implements'] = _implements(

--- a/src/Identity/index.js
+++ b/src/Identity/index.js
@@ -9,6 +9,7 @@ const _innerConcat = require('../core/innerConcat')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Identity')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isArray = require('../core/isArray')
 const isApply = require('../core/isApply')
@@ -108,12 +109,12 @@ function Identity(x) {
     inspect, toString: inspect, valueOf,
     type, equals, concat, map, ap, of,
     chain, sequence, traverse,
-    'fantasy-land/of': of,
-    'fantasy-land/equals': equals,
-    'fantasy-land/concat': concat,
-    'fantasy-land/map': map,
-    'fantasy-land/chain': chain,
-    '@@type': _type,
+    [fl.of]: of,
+    [fl.equals]: equals,
+    [fl.concat]: concat,
+    [fl.map]: map,
+    [fl.chain]: chain,
+    ['@@type']: _type,
     constructor: Identity
   }
 }
@@ -121,7 +122,7 @@ function Identity(x) {
 Identity.of = _of
 Identity.type = type
 
-Identity['fantasy-land/of'] = _of
+Identity[fl.of] = _of
 Identity['@@type'] = _type
 
 Identity['@@implements'] = _implements(

--- a/src/Last/index.js
+++ b/src/Last/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Last')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isSameType = require('../core/isSameType')
 
@@ -54,9 +55,9 @@ function Last(x) {
   return {
     inspect, toString: inspect, concat,
     empty, option, type, valueOf,
-    'fantasy-land/empty': empty,
-    'fantasy-land/concat': concat,
-    '@@type': _type,
+    [fl.empty]: empty,
+    [fl.concat]: concat,
+    ['@@type']: _type,
     constructor: Last
   }
 }
@@ -68,7 +69,7 @@ Last['@@implements'] = _implements(
 Last.empty = _empty
 Last.type = type
 
-Last['fantasy-land/empty'] = _empty
+Last[fl.empty] = _empty
 Last['@@type'] = _type
 
 module.exports = Last

--- a/src/Max/index.js
+++ b/src/Max/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Max')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isNil = require('../core/isNil')
 const isNumber = require('../core/isNumber')
@@ -42,9 +43,9 @@ function Max(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
-    'fantasy-land/empty': empty,
-    'fantasy-land/concat': concat,
-    '@@type': _type,
+    [fl.empty]: empty,
+    [fl.concat]: concat,
+    ['@@type']: _type,
     constructor: Max
   }
 }
@@ -56,7 +57,7 @@ Max['@@implements'] = _implements(
 Max.empty = _empty
 Max.type = type
 
-Max['fantasy-land/empty'] = _empty
+Max[fl.empty] = _empty
 Max['@@type'] = _type
 
 module.exports = Max

--- a/src/Min/index.js
+++ b/src/Min/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Min')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isNil = require('../core/isNil')
 const isNumber = require('../core/isNumber')
@@ -42,9 +43,9 @@ function Min(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
-    'fantasy-land/empty': empty,
-    'fantasy-land/concat': concat,
-    '@@type': _type,
+    [fl.empty]: empty,
+    [fl.concat]: concat,
+    ['@@type']: _type,
     constructor: Min
   }
 }
@@ -56,7 +57,7 @@ Min['@@implements'] = _implements(
 Min.empty = _empty
 Min.type = type
 
-Min['fantasy-land/empty'] = _empty
+Min[fl.empty] = _empty
 Min['@@type'] = _type
 
 module.exports = Min

--- a/src/Pred/index.js
+++ b/src/Pred/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Pred')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
@@ -51,10 +52,10 @@ function Pred(pred) {
   return {
     inspect, toString: inspect, runWith,
     type, valueOf, empty, concat, contramap,
-    'fantasy-land/empty': empty,
-    'fantasy-land/concat': concat,
-    'fantasy-land/contramap': contramap,
-    '@@type': _type,
+    [fl.empty]: empty,
+    [fl.concat]: concat,
+    [fl.contramap]: contramap,
+    ['@@type']: _type,
     constructor: Pred
   }
 }
@@ -62,7 +63,7 @@ function Pred(pred) {
 Pred.empty = _empty
 Pred.type = type
 
-Pred['fantasy-land/empty'] = _empty
+Pred[fl.empty] = _empty
 Pred['@@type'] = _type
 
 Pred['@@implements'] = _implements(

--- a/src/Prod/index.js
+++ b/src/Prod/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Prod')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isNil = require('../core/isNil')
 const isNumber = require('../core/isNumber')
@@ -42,9 +43,9 @@ function Prod(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
-    'fantasy-land/empty': empty,
-    'fantasy-land/concat': concat,
-    '@@type': _type,
+    [fl.empty]: empty,
+    [fl.concat]: concat,
+    ['@@type']: _type,
     constructor: Prod
   }
 }
@@ -56,7 +57,7 @@ Prod['@@implements'] = _implements(
 Prod.empty = _empty
 Prod.type = type
 
-Prod['fantasy-land/empty'] = _empty
+Prod[fl.empty] = _empty
 Prod['@@type'] = _type
 
 module.exports = Prod

--- a/src/Reader/ReaderT.js
+++ b/src/Reader/ReaderT.js
@@ -2,8 +2,9 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const _implements = require('../core/implements')
-const _type = require('../core/types').type('Reader')()
 const _inspect = require('../core/inspect')
+const _type = require('../core/types').type('Reader')()
+const fl = require('../core/flNames')
 
 const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
@@ -112,9 +113,9 @@ function _ReaderT(Monad) {
     return {
       inspect, toString: inspect, type,
       runWith, of, map, ap, chain,
-      'fantasy-land/of': of,
-      'fantasy-land/map': map,
-      'fantasy-land/chain': chain,
+      [fl.of]: of,
+      [fl.map]: map,
+      [fl.chain]: chain,
       constructor: ReaderT
     }
   }
@@ -125,7 +126,7 @@ function _ReaderT(Monad) {
   ReaderT.lift = lift
   ReaderT.liftFn = curry(liftFn)
 
-  ReaderT['fantasy-land/of'] = of
+  ReaderT[fl.of] = of
 
   ReaderT['@@implements'] = _implements(
     [ 'ap', 'chain', 'map', 'of' ]

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Reader')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
@@ -81,10 +82,10 @@ function Reader(runWith) {
   return {
     inspect, toString: inspect, runWith,
     type, map, ap, chain, of,
-    'fantasy-land/of': of,
-    'fantasy-land/map': map,
-    'fantasy-land/chain': chain,
-    '@@type': _type,
+    [fl.of]: of,
+    [fl.map]: map,
+    [fl.chain]: chain,
+    ['@@type']: _type,
     constructor: Reader
   }
 }
@@ -93,7 +94,7 @@ Reader.of = _of
 Reader.ask = ask
 Reader.type = type
 
-Reader['fantasy-land/of'] = _of
+Reader[fl.of] = _of
 Reader['@@type'] = _type
 
 Reader['@@implements'] = _implements(

--- a/src/Result/index.js
+++ b/src/Result/index.js
@@ -10,6 +10,7 @@ const _innerConcat = require('../core/innerConcat')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Result')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const compose = require('../core/compose')
 const isApply = require('../core/isApply')
@@ -209,14 +210,14 @@ function Result(u) {
     type, either, concat, swap, coalesce,
     map, bimap, alt, ap, chain, of, sequence,
     traverse,
-    'fantasy-land/of': of,
-    'fantasy-land/equals': equals,
-    'fantasy-land/alt': alt,
-    'fantasy-land/bimap': bimap,
-    'fantasy-land/concat': concat,
-    'fantasy-land/map': map,
-    'fantasy-land/chain': chain,
-    '@@type': _type,
+    [fl.of]: of,
+    [fl.equals]: equals,
+    [fl.alt]: alt,
+    [fl.bimap]: bimap,
+    [fl.concat]: concat,
+    [fl.map]: map,
+    [fl.chain]: chain,
+    ['@@type']: _type,
     constructor: Result
   }
 }
@@ -224,7 +225,7 @@ function Result(u) {
 Result.of = _of
 Result.type = type
 
-Result['fantasy-land/of'] = _of
+Result[fl.of] = _of
 Result['@@type'] = _type
 
 Result['@@implements'] = _implements(

--- a/src/Star/index.js
+++ b/src/Star/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const _type = require('../core/types').type('Star')
 const __type = require('../core/types').typeFn(_type(), VERSION)
+const fl = require('../core/flNames')
 
 const array = require('../core/array')
 const isFunction = require('../core/isFunction')
@@ -172,12 +173,12 @@ function _Star(Monad) {
       inspect, toString: inspect, type,
       runWith, id, compose, map, contramap,
       promap, first, second, both,
-      'fantasy-land/id': id,
-      'fantasy-land/compose': compose,
-      'fantasy-land/contramap': contramap,
-      'fantasy-land/map': map,
-      'fantasy-land/promap': promap,
-      '@@type': typeFn,
+      [fl.id]: id,
+      [fl.compose]: compose,
+      [fl.contramap]: contramap,
+      [fl.map]: map,
+      [fl.promap]: promap,
+      ['@@type']: typeFn,
       constructor: Star
     }
   }
@@ -185,7 +186,7 @@ function _Star(Monad) {
   Star.id = _id
   Star.type = type
 
-  Star['fantasy-land/id'] = _id
+  Star[fl.id] = _id
   Star['@@type'] = typeFn
 
   Star['@@implements'] = _implements(

--- a/src/State/index.js
+++ b/src/State/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('State')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const Pair = require('../core/Pair')
 const Unit = require('../core/Unit')
@@ -118,10 +119,10 @@ function State(fn) {
     inspect, toString: inspect, runWith,
     execWith, evalWith, type, map, ap,
     chain, of,
-    'fantasy-land/of': of,
-    'fantasy-land/map': map,
-    'fantasy-land/chain': chain,
-    '@@type': _type,
+    [fl.of]: of,
+    [fl.map]: map,
+    [fl.chain]: chain,
+    ['@@type']: _type,
     constructor: State
   }
 }
@@ -136,7 +137,7 @@ State.put =
 
 State.type = type
 
-State['fantasy-land/of'] = _of
+State[fl.of] = _of
 State['@@type'] = _type
 
 State['@@implements'] = _implements(

--- a/src/Sum/index.js
+++ b/src/Sum/index.js
@@ -7,6 +7,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const type = require('../core/types').type('Sum')
 const _type = require('../core/types').typeFn(type(), VERSION)
+const fl = require('../core/flNames')
 
 const isNil = require('../core/isNil')
 const isNumber = require('../core/isNumber')
@@ -42,9 +43,9 @@ function Sum(n) {
   return {
     inspect, toString: inspect, valueOf,
     type, concat, empty,
-    'fantasy-land/empty': empty,
-    'fantasy-land/concat': concat,
-    '@@type': _type,
+    [fl.empty]: empty,
+    [fl.concat]: concat,
+    ['@@type']: _type,
     constructor: Sum
   }
 }
@@ -56,7 +57,7 @@ Sum['@@implements'] = _implements(
 Sum.empty = _empty
 Sum.type = type
 
-Sum['fantasy-land/empty'] = _empty
+Sum[fl.empty] = _empty
 Sum['@@type'] = _type
 
 module.exports = Sum

--- a/src/Writer/index.js
+++ b/src/Writer/index.js
@@ -8,6 +8,7 @@ const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const __type = require('../core/types').type('Writer')
 const _typeFn = require('../core/types').typeFn(__type(), VERSION)
+const fl = require('../core/flNames')
 
 const Pair = require('../core/Pair')
 
@@ -95,11 +96,11 @@ function _Writer(Monoid) {
       inspect, toString: inspect, read,
       valueOf, log, type, equals, map,
       ap, of, chain,
-      'fantasy-land/of': of,
-      'fantasy-land/equals': equals,
-      'fantasy-land/map': map,
-      'fantasy-land/chain': chain,
-      '@@type': typeFn,
+      [fl.of]: of,
+      [fl.equals]: equals,
+      [fl.map]: map,
+      [fl.chain]: chain,
+      ['@@type']: typeFn,
       constructor: Writer
     }
   }
@@ -107,7 +108,7 @@ function _Writer(Monoid) {
   Writer.of = _of
   Writer.type = _type
 
-  Writer['fantasy-land/of'] = _of
+  Writer[fl.of] = _of
   Writer['@@type'] = typeFn
 
   Writer['@@implements'] = _implements(

--- a/src/core/List.js
+++ b/src/core/List.js
@@ -8,6 +8,7 @@ const _implements = require('./implements')
 const _inspect = require('./inspect')
 const type = require('./types').type('List')
 const _type = require('./types').typeFn(type(), VERSION)
+const fl = require('./flNames')
 
 const array = require('./array')
 
@@ -246,14 +247,14 @@ function List(x) {
     head, tail, cons, type, equals, concat, empty,
     reduce, reduceRight, fold, filter, reject, map,
     ap, of, chain, sequence, traverse,
-    'fantasy-land/of': of,
-    'fantasy-land/equals': equals,
-    'fantasy-land/concat': concat,
-    'fantasy-land/empty': empty,
-    'fantasy-land/map': map,
-    'fantasy-land/chain': chain,
-    'fantasy-land/reduce': reduce,
-    '@@type': _type,
+    [fl.of]: of,
+    [fl.equals]: equals,
+    [fl.concat]: concat,
+    [fl.empty]: empty,
+    [fl.map]: map,
+    [fl.chain]: chain,
+    [fl.reduce]: reduce,
+    ['@@type']: _type,
     constructor: List
   }
 }
@@ -262,8 +263,8 @@ List.of = _of
 List.empty = _empty
 List.type = type
 
-List['fantasy-land/of'] = _of
-List['fantasy-land/empty'] = _empty
+List[fl.of] = _of
+List[fl.empty] = _empty
 List['@@type'] = _type
 
 List.fromArray =

--- a/src/core/Maybe.js
+++ b/src/core/Maybe.js
@@ -10,6 +10,7 @@ const _innerConcat = require('./innerConcat')
 const _inspect = require('./inspect')
 const type = require('./types').type('Maybe')
 const _type = require('./types').typeFn(type(), VERSION)
+const fl = require('./flNames')
 
 const compose = require('./compose')
 const isApply = require('./isApply')
@@ -194,14 +195,14 @@ function Maybe(u) {
     option, type, concat, equals, coalesce,
     map, alt, zero, ap, of, chain, sequence,
     traverse,
-    'fantasy-land/zero': zero,
-    'fantasy-land/of': of,
-    'fantasy-land/equals': equals,
-    'fantasy-land/alt': alt,
-    'fantasy-land/concat': concat,
-    'fantasy-land/map': map,
-    'fantasy-land/chain': chain,
-    '@@type': _type,
+    [fl.zero]: zero,
+    [fl.of]: of,
+    [fl.equals]: equals,
+    [fl.alt]: alt,
+    [fl.concat]: concat,
+    [fl.map]: map,
+    [fl.chain]: chain,
+    ['@@type']: _type,
     constructor: Maybe
   }
 }
@@ -210,8 +211,8 @@ Maybe.of = _of
 Maybe.zero = _zero
 Maybe.type = type
 
-Maybe['fantasy-land/of'] = _of
-Maybe['fantasy-land/zero'] = _zero
+Maybe[fl.of] = _of
+Maybe[fl.zero] = _zero
 Maybe['@@type'] = _type
 
 Maybe['@@implements'] = _implements(

--- a/src/core/Pair.js
+++ b/src/core/Pair.js
@@ -8,6 +8,7 @@ const _implements = require('./implements')
 const _inspect = require('./inspect')
 const type = require('./types').type('Pair')
 const _type = require('./types').typeFn(type(), VERSION)
+const fl = require('./flNames')
 
 const isFunction = require('./isFunction')
 const isSameType = require('./isSameType')
@@ -155,13 +156,13 @@ function Pair(l, r) {
     snd, toArray, type, merge, equals,
     concat, swap, map, bimap, ap, chain,
     extend,
-    'fantasy-land/equals': equals,
-    'fantasy-land/concat': concat,
-    'fantasy-land/map': map,
-    'fantasy-land/bimap': bimap,
-    'fantasy-land/chain': chain,
-    'fantasy-land/extend': extend,
-    '@@type': _type,
+    [fl.equals]: equals,
+    [fl.concat]: concat,
+    [fl.map]: map,
+    [fl.bimap]: bimap,
+    [fl.chain]: chain,
+    [fl.extend]: extend,
+    ['@@type']: _type,
     constructor: Pair
   }
 }

--- a/src/core/Unit.js
+++ b/src/core/Unit.js
@@ -6,6 +6,7 @@ const VERSION = 1
 const _implements = require('./implements')
 const type = require('./types').type('Unit')
 const _type = require('./types').typeFn(type(), VERSION)
+const fl = require('./flNames')
 
 const isFunction = require('./isFunction')
 const isSameType = require('./isSameType')
@@ -68,13 +69,13 @@ function Unit() {
     inspect, toString: inspect, valueOf,
     type, equals, concat, empty, map, ap,
     of, chain,
-    'fantasy-land/of': of,
-    'fantasy-land/empty': empty,
-    'fantasy-land/equals': equals,
-    'fantasy-land/concat': concat,
-    'fantasy-land/map': map,
-    'fantasy-land/chain': chain,
-    '@@type': _type,
+    [fl.of]: of,
+    [fl.empty]: empty,
+    [fl.equals]: equals,
+    [fl.concat]: concat,
+    [fl.map]: map,
+    [fl.chain]: chain,
+    ['@@type']: _type,
     constructor: Unit
   }
 }
@@ -83,8 +84,8 @@ Unit.of = _of
 Unit.empty = _empty
 Unit.type = type
 
-Unit['fantasy-land/of'] = _of
-Unit['fantasy-land/empty'] = _empty
+Unit[fl.of] = _of
+Unit[fl.empty] = _empty
 Unit['@@type'] = _type
 
 Unit['@@implements'] = _implements(

--- a/src/core/flNames.js
+++ b/src/core/flNames.js
@@ -1,0 +1,20 @@
+/** @license ISC License (c) copyright 2018 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+module.exports = {
+  alt: 'fantasy-land/alt',
+  bimap: 'fantasy-land/bimap',
+  chain: 'fantasy-land/chain',
+  compose: 'fantasy-land/compose',
+  concat: 'fantasy-land/concat',
+  contramap: 'fantasy-land/contramap',
+  empty: 'fantasy-land/empty',
+  equals: 'fantasy-land/equals',
+  extend: 'fantasy-land/extend',
+  id: 'fantasy-land/id',
+  map: 'fantasy-land/map',
+  of: 'fantasy-land/of',
+  promap: 'fantasy-land/promap',
+  reduce: 'fantasy-land/reduce',
+  zero: 'fantasy-land/zero',
+}

--- a/src/core/flNames.spec.js
+++ b/src/core/flNames.spec.js
@@ -1,0 +1,24 @@
+const test = require('tape')
+
+const methods = require('./flNames')
+
+
+test('flMethods', t => {
+  t.equals(methods.alt, 'fantasy-land/alt', 'provides alt')
+  t.equals(methods.bimap, 'fantasy-land/bimap', 'provides bimap')
+  t.equals(methods.chain, 'fantasy-land/chain', 'provides chain')
+  t.equals(methods.compose, 'fantasy-land/compose', 'provides compose')
+  t.equals(methods.concat, 'fantasy-land/concat', 'provides concat')
+  t.equals(methods.contramap, 'fantasy-land/contramap', 'provides contramap')
+  t.equals(methods.empty, 'fantasy-land/empty', 'provides empty')
+  t.equals(methods.equals, 'fantasy-land/equals', 'provides equals')
+  t.equals(methods.extend, 'fantasy-land/extend', 'provides extend')
+  t.equals(methods.id, 'fantasy-land/id', 'provides id')
+  t.equals(methods.map, 'fantasy-land/map', 'provides map')
+  t.equals(methods.of, 'fantasy-land/of', 'provides of')
+  t.equals(methods.promap, 'fantasy-land/promap', 'provides promap')
+  t.equals(methods.reduce, 'fantasy-land/reduce', 'provides reduce')
+  t.equals(methods.zero, 'fantasy-land/zero', 'provides zero')
+
+  t.end()
+})


### PR DESCRIPTION
## The Start of Something Abstract
![image](https://user-images.githubusercontent.com/3665793/36243268-8ef38a40-11d5-11e8-969a-aa455fc4088e.png)

In response to [this issue](https://github.com/evilsoft/crocks/issues/202) we will need to have these names peppered in even more places. Makes sense to start abstracting this sooner rather than later. Eventually it will be used to invoke the function and also will be needed for comparison.

Also should clear up some of the errors when Travis runs node 6 due to the way buble was handling `@@type` before running the spec suite.