### PR TITLE
Fix issue in propPathOr if default value is an object

### DIFF
--- a/src/helpers/propPathOr.js
+++ b/src/helpers/propPathOr.js
@@ -1,13 +1,11 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Henrique Limas */
 
-const constant = require('../combinators/constant')
 const curry = require('../core/curry')
-const either = require('../pointfree/either')
-const identity = require('../combinators/identity')
-const isArray = require('../predicates/isArray')
-const isNil = require('../predicates/isNil')
-const propPath = require('../Maybe/propPath')
+const isArray = require('../core/isArray')
+const isInteger = require('../core/isInteger')
+const isNil= require('../core/isNil')
+const isString = require('../core/isString')
 
 // propPathOr : a -> [ String | Integer ] -> b -> c
 function propPathOr(def, keys, target) {
@@ -19,8 +17,17 @@ function propPathOr(def, keys, target) {
     return def
   }
 
-  return either(constant(def), identity, propPath(keys, target))
+  return keys.reduce((target, key) => {
+    if (isNil(target)) {
+      return target
+    }
+
+    if(!(isString(key) || isInteger(key))) {
+      throw new TypeError('propPathOr: Array of strings or integers required for second argument')
+    }
+
+    return target[key]
+  }, target) || def
 }
 
 module.exports = curry(propPathOr)
-

--- a/src/helpers/propPathOr.js
+++ b/src/helpers/propPathOr.js
@@ -13,10 +13,6 @@ function propPathOr(def, keys, target) {
     throw new TypeError('propPathOr: Array of strings or integers required for second argument')
   }
 
-  if(isNil(target)) {
-    return def
-  }
-
   const value = keys.reduce((target, key) => {
     if (isNil(target)) {
       return target

--- a/src/helpers/propPathOr.js
+++ b/src/helpers/propPathOr.js
@@ -1,14 +1,13 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Henrique Limas */
 
+const constant = require('../combinators/constant')
 const curry = require('../core/curry')
-const isArray = require('../core/isArray')
-const isInteger = require('../core/isInteger')
-const isNil= require('../core/isNil')
-const isString = require('../core/isString')
-
-const lift = (x, def) =>
-  isNil(x) ? def : x
+const either = require('../pointfree/either')
+const identity = require('../combinators/identity')
+const isArray = require('../predicates/isArray')
+const isNil = require('../predicates/isNil')
+const propPath = require('../Maybe/propPath')
 
 // propPathOr : a -> [ String | Integer ] -> b -> c
 function propPathOr(def, keys, target) {
@@ -20,13 +19,8 @@ function propPathOr(def, keys, target) {
     return def
   }
 
-  return keys.reduce((target, key) => {
-    if(!(isString(key) || isInteger(key))) {
-      throw new TypeError('propPathOr: Array of strings or integers required for second argument')
-    }
-
-    return lift(target[key], def)
-  }, target)
+  return either(constant(def), identity, propPath(keys, target))
 }
 
 module.exports = curry(propPathOr)
+

--- a/src/helpers/propPathOr.js
+++ b/src/helpers/propPathOr.js
@@ -17,7 +17,7 @@ function propPathOr(def, keys, target) {
     return def
   }
 
-  return keys.reduce((target, key) => {
+  const value = keys.reduce((target, key) => {
     if (isNil(target)) {
       return target
     }
@@ -27,7 +27,9 @@ function propPathOr(def, keys, target) {
     }
 
     return target[key]
-  }, target) || def
+  }, target)
+
+  return isNil(value) ? def : value
 }
 
 module.exports = curry(propPathOr)

--- a/src/helpers/propPathOr.spec.js
+++ b/src/helpers/propPathOr.spec.js
@@ -13,7 +13,7 @@ test('propPathOr function', t => {
 
   t.ok(isFunction(propPathOr), 'is a function')
 
-  const err = /propPathOr: Array of strings or integers required for second argument/
+  const err = /propPath(Or)?: Array of strings or integers required for (first|second) argument/
   t.throws(p(def, undefined, {}), err, 'throws with undefined in second argument')
   t.throws(p(def, null, {}), err, 'throws with null in second argument')
   t.throws(p(def, 0, {}), err, 'throws with falsey number in second argument')
@@ -66,6 +66,10 @@ test('propPathOr function', t => {
   t.equals(fn(undefined), def, 'returns the default value when data is undefined')
   t.equals(fn(null), def, 'returns the default value when data is null')
   t.equals(fn(NaN), def, 'returns the default value when data is NaN')
+
+  const objDefault =  { b: 1 }
+
+  t.equals(propPathOr(objDefault, [ 'a', 'b' ], { c: { b: 2 } }), objDefault, 'returns the default value when default is an object that has the same property as a nested property in target')
 
   t.end()
 })

--- a/src/helpers/propPathOr.spec.js
+++ b/src/helpers/propPathOr.spec.js
@@ -70,6 +70,7 @@ test('propPathOr function', t => {
   const objDefault =  { b: 1 }
 
   t.equals(propPathOr(objDefault, [ 'a', 'b' ], { c: { b: 2 } }), objDefault, 'returns the default value when default is an object that has the same property as a nested property in target')
+  t.equals(propPathOr(1, [ 'a' ], { a: 0 } ), 0, 'returns found falsy value')
 
   t.end()
 })

--- a/src/helpers/propPathOr.spec.js
+++ b/src/helpers/propPathOr.spec.js
@@ -13,7 +13,7 @@ test('propPathOr function', t => {
 
   t.ok(isFunction(propPathOr), 'is a function')
 
-  const err = /propPath(Or)?: Array of strings or integers required for (first|second) argument/
+  const err = /propPathOr: Array of strings or integers required for second argument/
   t.throws(p(def, undefined, {}), err, 'throws with undefined in second argument')
   t.throws(p(def, null, {}), err, 'throws with null in second argument')
   t.throws(p(def, 0, {}), err, 'throws with falsey number in second argument')


### PR DESCRIPTION
In the previous implementation, if a property in the target is not found,
then the default value would be returned as the accumulator to the next
iteration of reduce. If the default value is an object, then it is
errantly traversed with the next property in the specified path.