### PR TITLE
move over to sanctuary string types

### DIFF
--- a/src/All/All.spec.js
+++ b/src/All/All.spec.js
@@ -5,6 +5,7 @@ const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 
 const All = require('.')
 
@@ -21,7 +22,7 @@ test('All', t => {
 
   t.ok(isFunction(All.empty), 'provides an empty function')
   t.ok(isFunction(All.type), 'provides a type function')
-  t.ok(isFunction(All['@@type']), 'provides a @@type function')
+  t.ok(isString(All['@@type']), 'provides a @@type string')
 
   const err = /All: Non-function value required/
   t.throws(All, err, 'throws with nothing')
@@ -101,9 +102,8 @@ test('All type', t => {
 test('All @@type', t => {
   const m = All(0)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(All['@@type'], m['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/All@1', 'reports crocks/All@1')
+  t.equal(m['@@type'], 'crocks/All@1', 'reports crocks/All@1')
 
   t.end()
 })

--- a/src/Any/Any.spec.js
+++ b/src/Any/Any.spec.js
@@ -5,6 +5,7 @@ const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 
 const Any = require('.')
 
@@ -21,7 +22,7 @@ test('Any', t => {
 
   t.ok(isFunction(Any.empty), 'provides an empty function')
   t.ok(isFunction(Any.type), 'provides a type function')
-  t.ok(isFunction(Any['@@type']), 'provides a @@type function')
+  t.ok(isString(Any['@@type']), 'provides a @@type string')
 
   const err = /Any: Non-function value required/
   t.throws(Any, err, 'throws with nothing')
@@ -98,10 +99,8 @@ test('Any type', t => {
 })
 
 test('Any @@type', t => {
-  t.ok(isFunction(Any(0)['@@type']), 'is a function')
-
   t.equal(Any['@@type'], Any(0)['@@type'], 'static and instance versions are the same')
-  t.equal(Any(0)['@@type'](), 'crocks/Any@1', 'reports crocks/Any@1')
+  t.equal(Any(0)['@@type'], 'crocks/Any@1', 'reports crocks/Any@1')
 
   t.end()
 })

--- a/src/Arrow/Arrow.spec.js
+++ b/src/Arrow/Arrow.spec.js
@@ -6,6 +6,7 @@ const bindFunc = helpers.bindFunc
 
 const _compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
+const isString = require('../core/isString')
 const isObject = require('../core/isObject')
 const unit = require('../core/_unit')
 
@@ -25,7 +26,7 @@ test('Arrow', t => {
 
   t.ok(isFunction(Arrow.id), 'provides an id function')
   t.ok(isFunction(Arrow.type), 'provides a type function')
-  t.ok(isFunction(Arrow['@@type']), 'provides a @@type function')
+  t.ok(isString(Arrow['@@type']), 'provides a @@type string')
 
   t.ok(isObject(Arrow(unit)), 'returns an object')
 
@@ -98,10 +99,8 @@ test('Arrow type', t => {
 test('Arrow @@type', t => {
   const a = Arrow(unit)
 
-  t.ok(isFunction(a['@@type']), 'is a function')
-
   t.equal(a['@@type'], Arrow['@@type'], 'static and instance versions are the same')
-  t.equal(a['@@type'](), 'crocks/Arrow@1', 'reports crocks/Arrow@1')
+  t.equal(a['@@type'], 'crocks/Arrow@1', 'reports crocks/Arrow@1')
 
   t.end()
 })

--- a/src/Assign/Assign.spec.js
+++ b/src/Assign/Assign.spec.js
@@ -5,6 +5,7 @@ const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 
 const Assign = require('.')
 
@@ -21,7 +22,7 @@ test('Assign', t => {
 
   t.ok(isFunction(Assign.empty), 'provides an empty function')
   t.ok(isFunction(Assign.type), 'provides a type function')
-  t.ok(isFunction(Assign['@@type']), 'provides a @@type function')
+  t.ok(isString(Assign['@@type']), 'provides a @@type string')
 
   const err = /Assign: Object required/
   t.throws(Assign, err, 'throws with nothing')
@@ -95,10 +96,8 @@ test('Assign type', t => {
 })
 
 test('Assign @@type', t => {
-  t.ok(isFunction(Assign({})['@@type']), 'is a function')
-
   t.equal(Assign({})['@@type'], Assign['@@type'], 'static and instance versions are the same')
-  t.equal(Assign({})['@@type'](), 'crocks/Assign@1', 'reports crocks/Assign@1')
+  t.equal(Assign({})['@@type'], 'crocks/Assign@1', 'reports crocks/Assign@1')
 
   t.end()
 })

--- a/src/Async/Async.spec.js
+++ b/src/Async/Async.spec.js
@@ -7,8 +7,9 @@ const bindFunc = helpers.bindFunc
 const List = require('../core/List')
 const curry = require('../core/curry')
 const compose = curry(require('../core/compose'))
-const isObject = require('../core/isObject')
 const isFunction = require('../core/isFunction')
+const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 const unit = require('../core/_unit')
 
 const constant = x => () => x
@@ -28,7 +29,7 @@ test('Async', t => {
 
   t.ok(isFunction(Async.of), 'provides an of function')
   t.ok(isFunction(Async.type), 'provides a type function')
-  t.ok(isFunction(Async['@@type']), 'provides a @@type function')
+  t.ok(isString(Async['@@type']), 'provides a @@type string')
 
   t.equals(Async.Resolved(3).constructor, Async, 'provides TypeRep on constructor on Resolved')
   t.equals(Async.Rejected(3).constructor, Async, 'provides TypeRep on constructor on Rejected')
@@ -290,10 +291,8 @@ test('Async type', t => {
 })
 
 test('Async @@type', t => {
-  t.ok(isFunction(Async(unit)['@@type']), 'is a function')
-
   t.equal(Async(unit)['@@type'], Async['@@type'], 'static and instance versions are the same')
-  t.equal(Async(unit)['@@type'](), 'crocks/Async@1', 'returns Async')
+  t.equal(Async(unit)['@@type'], 'crocks/Async@1', 'returns Async')
 
   t.end()
 })

--- a/src/Const/Const.spec.js
+++ b/src/Const/Const.spec.js
@@ -7,8 +7,9 @@ const bindFunc = helpers.bindFunc
 
 const curry = require('../core/curry')
 const compose = curry(require('../core/compose'))
-const isObject = require('../core/isObject')
 const isFunction  = require('../core/isFunction')
+const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 const unit = require('../core/_unit')
 
 const Const = require('.')
@@ -22,7 +23,7 @@ test('Const', t => {
   t.ok(isObject(m), 'returns an object')
 
   t.ok(isFunction(Const.type), 'provides a type function')
-  t.ok(isFunction(Const['@@type']), 'provides a @@type function')
+  t.ok(isString(Const['@@type']), 'provides a @@type string')
 
   t.equals(Const(true).constructor, Const, 'provides TypeRep on constructor')
 
@@ -76,9 +77,8 @@ test('Const type', t => {
 test('Const @@type', t => {
   const m = Const(0)
 
-  t.ok(isFunction(m['@@type']), 'provides a @@type function')
   t.equal(m['@@type'], Const['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Const@1', 'type returns crocks/Const@1')
+  t.equal(m['@@type'], 'crocks/Const@1', 'type returns crocks/Const@1')
 
   t.end()
 })

--- a/src/Either/Either.spec.js
+++ b/src/Either/Either.spec.js
@@ -10,6 +10,7 @@ const compose = curry(require('../core/compose'))
 const isArray = require('../core/isArray')
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 const isSameType = require('../core/isSameType')
 const unit = require('../core/_unit')
 
@@ -37,7 +38,7 @@ test('Either', t => {
   t.ok(isFunction(Either.Left), 'provides a Left function')
   t.ok(isFunction(Either.Right), 'provides a Right function')
   t.ok(isFunction(Either.type), 'provides a type function')
-  t.ok(isFunction(Either['@@type']), 'provides a @@type function')
+  t.ok(isString(Either['@@type']), 'provides a @@type string')
 
   const err = /Either: Must wrap something, try using Left or Right constructors/
   t.throws(Either, err, 'throws with no parameters')
@@ -136,14 +137,11 @@ test('Either type', t => {
 test('Either @@type', t => {
   const { Left, Right } = Either
 
-  t.ok(isFunction(Right(0)['@@type']), 'is a function on Right')
-  t.ok(isFunction(Left(0)['@@type']), 'is a function on Left')
-
   t.equal(Right(0)['@@type'], Either['@@type'], 'static and instance versions are the same for Right')
   t.equal(Left(0)['@@type'], Either['@@type'], 'static and instance versions are the same for Left')
 
-  t.equal(Right(0)['@@type'](), 'crocks/Either@1', 'returns crocks/Either@1 for Right')
-  t.equal(Left(0)['@@type'](), 'crocks/Either@1', 'returns crocks/Either@1 for Left')
+  t.equal(Right(0)['@@type'], 'crocks/Either@1', 'returns crocks/Either@1 for Right')
+  t.equal(Left(0)['@@type'], 'crocks/Either@1', 'returns crocks/Either@1 for Left')
 
   t.end()
 })

--- a/src/Endo/Endo.spec.js
+++ b/src/Endo/Endo.spec.js
@@ -7,6 +7,7 @@ const bindFunc = helpers.bindFunc
 const compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 const isSameType = require('../core/isSameType')
 
 const constant = x => () => x
@@ -24,7 +25,7 @@ test('Endo', t => {
 
   t.ok(isFunction(Endo.empty), 'provides an empty function')
   t.ok(isFunction(Endo.type), 'provides a type function')
-  t.ok(isFunction(Endo['@@type']), 'provides a @@type function')
+  t.ok(isString(Endo['@@type']), 'provides a @@type string')
 
   const err = /Endo: Function value required/
   t.throws(Endo, err, 'throws with nothing')
@@ -112,10 +113,9 @@ test('Endo type', t => {
 
 test('Endo @@type', t => {
   const m = Endo(identity)
-  t.ok(isFunction(m['@@type']), 'is a function')
 
   t.equal(m['@@type'], Endo['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Endo@1', 'reports crocks/Endo@1')
+  t.equal(m['@@type'], 'crocks/Endo@1', 'reports crocks/Endo@1')
 
   t.end()
 })

--- a/src/Equiv/Equiv.spec.js
+++ b/src/Equiv/Equiv.spec.js
@@ -7,6 +7,7 @@ const bindFunc = helpers.bindFunc
 const compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 const unit = require('../core/_unit')
 
 const constant = x => () => x
@@ -24,7 +25,7 @@ test('Equiv', t => {
 
   t.ok(isFunction(Equiv.empty), 'provides an empty function')
   t.ok(isFunction(Equiv.type), 'provides a type function')
-  t.ok(isFunction(Equiv['@@type']), 'provides a @@type function')
+  t.ok(isString(Equiv['@@type']), 'provides a @@type string')
 
   t.ok(isObject(Equiv(isSame)), 'returns an object')
 
@@ -94,10 +95,8 @@ test('Equiv type', t => {
 test('Equiv @@type', t => {
   const m = Equiv(isSame)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
-
   t.equal(m['@@type'], Equiv['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Equiv@1', 'type returns crocks/Equiv@1')
+  t.equal(m['@@type'], 'crocks/Equiv@1', 'type returns crocks/Equiv@1')
 
   t.end()
 })

--- a/src/First/First.spec.js
+++ b/src/First/First.spec.js
@@ -6,6 +6,7 @@ const bindFunc = helpers.bindFunc
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
 const isSameType = require('../core/isSameType')
+const isString = require('../core/isString')
 
 const Maybe = require('../core/Maybe')
 const First = require('.')
@@ -23,7 +24,7 @@ test('First', t => {
 
   t.ok(isFunction(First.empty), 'provides an empty function')
   t.ok(isFunction(First.type), 'provides a type function')
-  t.ok(isFunction(First['@@type']), 'provides a @@type function')
+  t.ok(isString(First['@@type']), 'provides a @@type string')
 
   const err = /First: Requires one argument/
   t.throws(First, err, 'throws when passed nothing')
@@ -97,9 +98,8 @@ test('First type', t => {
 test('First type', t => {
   const m = First(0)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(First['@@type'], m['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/First@1', 'reports crocks/First@1')
+  t.equal(m['@@type'], 'crocks/First@1', 'reports crocks/First@1')
 
   t.end()
 })

--- a/src/IO/IO.spec.js
+++ b/src/IO/IO.spec.js
@@ -8,6 +8,7 @@ const curry = require('../core/curry')
 const compose = curry(require('../core/compose'))
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 const unit = require('../core/_unit')
 
 const constant = x => () => x
@@ -29,7 +30,7 @@ test('IO', t => {
 
   t.ok(isFunction(IO.of), 'provides an of function')
   t.ok(isFunction(IO.type), 'provides a type function')
-  t.ok(isFunction(IO['@@type']), 'provides a @@type function')
+  t.ok(isString(IO['@@type']), 'provides a @@type string')
 
   t.throws(io(), TypeError, 'throws with no parameters')
 
@@ -95,9 +96,8 @@ test('IO type', t => {
 test('IO @@type', t => {
   const m = IO(unit)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(IO['@@type'], m['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/IO@1', 'reports crocks/IO@1')
+  t.equal(m['@@type'], 'crocks/IO@1', 'reports crocks/IO@1')
 
   t.end()
 })

--- a/src/Identity/Identity.spec.js
+++ b/src/Identity/Identity.spec.js
@@ -11,6 +11,7 @@ const isArray = require('../core/isArray')
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
 const isSameType = require('../core/isSameType')
+const isString = require('../core/isString')
 const unit = require('../core/_unit')
 
 const identity = x => x
@@ -30,7 +31,7 @@ test('Identity', t => {
 
   t.ok(isFunction(Identity.of), 'provides an of function')
   t.ok(isFunction(Identity.type), 'provides a type function')
-  t.ok(isFunction(Identity['@@type']), 'provides a @@type function')
+  t.ok(isString(Identity['@@type']), 'provides a @@type string')
 
   const err = /Identity: Must wrap something/
   t.throws(Identity, err, 'throws with no parameters')
@@ -89,9 +90,8 @@ test('Identity type', t => {
 test('Identity @@type', t => {
   const m = Identity(0)
 
-  t.ok(isFunction(m['@@type']), 'provides a @@type function')
   t.equal(Identity['@@type'], m['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Identity@1', '@@type returns Identity')
+  t.equal(m['@@type'], 'crocks/Identity@1', '@@type returns Identity')
 
   t.end()
 })

--- a/src/Last/Last.spec.js
+++ b/src/Last/Last.spec.js
@@ -7,6 +7,7 @@ const Maybe = require('../core/Maybe')
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
 const isSameType = require('../core/isSameType')
+const isString = require('../core/isString')
 
 const constant = x => () => x
 const extract = m => m.option('empty')
@@ -21,7 +22,7 @@ test('Last', t => {
 
   t.ok(isFunction(Last.empty), 'provides an empty function')
   t.ok(isFunction(Last.type), 'provides a type function')
-  t.ok(isFunction(Last['@@type']), 'provides a @@type function')
+  t.ok(isString(Last['@@type']), 'provides a @@type string')
 
   const err = /Last: Requires one argument/
   t.throws(Last, err, 'throws when passed nothing')
@@ -95,9 +96,8 @@ test('Last type', t => {
 test('Last @@type', t => {
   const m = Last(0)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(Last['@@type'], m['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Last@1', 'reports crocks/Last@1')
+  t.equal(m['@@type'], 'crocks/Last@1', 'reports crocks/Last@1')
 
   t.end()
 })

--- a/src/Max/Max.spec.js
+++ b/src/Max/Max.spec.js
@@ -5,6 +5,7 @@ const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 
 const constant = x => () => x
 const identity = x => x
@@ -19,7 +20,7 @@ test('Max', t => {
 
   t.ok(isFunction(Max.empty), 'provides an empty function')
   t.ok(isFunction(Max.type), 'provides a type function')
-  t.ok(isFunction(Max['@@type']), 'provides a @@type function')
+  t.ok(isString(Max['@@type']), 'provides a @@type string')
 
   t.equals(Max(0).constructor, Max, 'provides TypeRep on constructor')
 
@@ -98,9 +99,8 @@ test('Max type', t => {
 test('Max @@type', t => {
   const m = Max(0)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(m['@@type'], Max['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Max@1', 'reports crocks/Max@1')
+  t.equal(m['@@type'], 'crocks/Max@1', 'reports crocks/Max@1')
 
   t.end()
 })

--- a/src/Min/Min.spec.js
+++ b/src/Min/Min.spec.js
@@ -5,6 +5,7 @@ const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 
 const constant = x => () => x
 const identity = x => x
@@ -19,7 +20,7 @@ test('Min', t => {
 
   t.ok(isFunction(Min.empty), 'provides an empty function')
   t.ok(isFunction(Min.type), 'provides a type function')
-  t.ok(isFunction(Min['@@type']), 'provides a @@type function')
+  t.ok(isString(Min['@@type']), 'provides a @@type string')
 
   t.equals(Min(0).constructor, Min, 'provides TypeRep on constructor')
 
@@ -98,9 +99,8 @@ test('Min type', t => {
 test('Min @@type', t => {
   const m = Min(0)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(m['@@type'], Min['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Min@1', 'reports crocks/Min@1')
+  t.equal(m['@@type'], 'crocks/Min@1', 'reports crocks/Min@1')
 
   t.end()
 })

--- a/src/Pred/Pred.spec.js
+++ b/src/Pred/Pred.spec.js
@@ -7,6 +7,7 @@ const bindFunc = helpers.bindFunc
 const compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString  = require('../core/isString')
 const unit = require('../core/_unit')
 
 const constant = x => () => x
@@ -22,7 +23,7 @@ test('Pred', t => {
 
   t.ok(isFunction(Pred.empty), 'provides an empty function')
   t.ok(isFunction(Pred.type), 'provides a type function')
-  t.ok(isFunction(Pred['@@type']), 'provides a @@type function')
+  t.ok(isString(Pred['@@type']), 'provides a @@type string')
 
   t.equals(Pred(unit).constructor, Pred, 'provides TypeRep on constructor')
 
@@ -89,9 +90,8 @@ test('Pred type', t => {
 test('Pred @@type', t => {
   const m = Pred(unit)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(m['@@type'], Pred['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Pred@1', 'reports crocks/Pred@1')
+  t.equal(m['@@type'], 'crocks/Pred@1', 'reports crocks/Pred@1')
 
   t.end()
 })

--- a/src/Prod/Prod.spec.js
+++ b/src/Prod/Prod.spec.js
@@ -5,6 +5,7 @@ const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString = require('../core/isString')
 
 const constant = x => () => x
 const identity = x => x
@@ -21,7 +22,7 @@ test('Prod', t => {
 
   t.ok(isFunction(Prod.empty), 'provides an empty function')
   t.ok(isFunction(Prod.type), 'provides a type function')
-  t.ok(isFunction(Prod['@@type']), 'provides a @@type function')
+  t.ok(isString(Prod['@@type']), 'provides a @@type string')
 
   const err = /Prod: Numeric value required/
   t.throws(s(), err, 'throws with nothing')
@@ -98,9 +99,8 @@ test('Prod type', t => {
 test('Prod @@type', t => {
   const m = Prod(0)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(m['@@type'], Prod['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Prod@1', 'reports crocks/Prod@1')
+  t.equal(m['@@type'], 'crocks/Prod@1', 'reports crocks/Prod@1')
 
   t.end()
 })

--- a/src/Reader/Reader.spec.js
+++ b/src/Reader/Reader.spec.js
@@ -9,6 +9,7 @@ const compose = curry(require('../core/compose'))
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
 const isSameType = require('../core/isSameType')
+const isString = require('../core/isString')
 const unit = require('../core/_unit')
 
 const constant = x => () => x
@@ -31,7 +32,7 @@ test('Reader', t => {
   t.ok(isFunction(Reader.of), 'provides an of function')
   t.ok(isFunction(Reader.ask), 'provides an ask function')
   t.ok(isFunction(Reader.type), 'provides a type function')
-  t.ok(isFunction(Reader['@@type']), 'provides a @@type function')
+  t.ok(isString(Reader['@@type']), 'provides a @@type string')
 
   const err = /Reader: Must wrap a function/
   t.throws(r(), err, 'throws with no parameters')
@@ -96,9 +97,8 @@ test('Reader type', t => {
 test('Reader @@type', t => {
   const m = Reader(unit)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(Reader['@@type'], m['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Reader@1', 'type returns crocks/Reader@1')
+  t.equal(m['@@type'], 'crocks/Reader@1', 'type returns crocks/Reader@1')
   t.end()
 })
 

--- a/src/Reader/ReaderT.js
+++ b/src/Reader/ReaderT.js
@@ -1,9 +1,12 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
+const VERSION = 1
+
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
 const _type = require('../core/types').type('Reader')()
+const _typeString = require('../core/types').typeFn(_type, VERSION)
 const fl = require('../core/flNames')
 
 const curry = require('../core/curry')
@@ -18,6 +21,9 @@ function _ReaderT(Monad) {
 
   const type =
     () => `${_type}( ${Monad.type()} )`
+
+  const typeString =
+    `${_typeString}( ${Monad['@@type']} )`
 
   const of =
     x => ReaderT(() => Monad.of(x))
@@ -116,6 +122,7 @@ function _ReaderT(Monad) {
       [fl.of]: of,
       [fl.map]: map,
       [fl.chain]: chain,
+      ['@@type']: typeString,
       constructor: ReaderT
     }
   }
@@ -127,6 +134,7 @@ function _ReaderT(Monad) {
   ReaderT.liftFn = curry(liftFn)
 
   ReaderT[fl.of] = of
+  ReaderT['@@type'] = typeString
 
   ReaderT['@@implements'] = _implements(
     [ 'ap', 'chain', 'map', 'of' ]

--- a/src/Reader/ReaderT.spec.js
+++ b/src/Reader/ReaderT.spec.js
@@ -10,6 +10,7 @@ const compose = curry(require('../core/compose'))
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
 const isSameType = require('../core/isSameType')
+const isString = require('../core/isString')
 const unit = require('../core/_unit')
 
 const reverseApply =
@@ -53,6 +54,7 @@ test('ReaderT', t => {
   t.ok(isFunction(ReaderMock.ask), 'provides an ask function')
   t.ok(isFunction(ReaderMock.lift), 'provides a lift function')
   t.ok(isFunction(ReaderMock.liftFn), 'provides a liftFn function')
+  t.ok(isString(r['@@type']), 'provides a @@type string')
 
   const err = /Reader\( MockCrock \): MockCrock returning function required/
   t.throws(f(), err, 'throws with no arguments')
@@ -105,6 +107,15 @@ test('ReaderT inspect', t => {
 
 test('ReaderT type', t => {
   t.equal(ReaderMock(unit).type(), 'Reader( MockCrock )', 'type returns Reader( innerType )')
+
+  t.end()
+})
+
+test('ReaderT @@type', t => {
+  const m = ReaderMock(unit)
+
+  t.equal(ReaderMock['@@type'], m['@@type'], 'static and instance versions are the same')
+  t.equal(m['@@type'], 'crocks/Reader@1( crocks/MockCrock@1 )', 'type returns crocks/Reader@1( crocks/MockCrock@1 )')
 
   t.end()
 })

--- a/src/Result/Result.spec.js
+++ b/src/Result/Result.spec.js
@@ -11,6 +11,7 @@ const isArray = require('../core/isArray')
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
 const isSameType = require('../core/isSameType')
+const isString = require('../core/isString')
 const unit = require('../core/_unit')
 
 const constant = x => () => x
@@ -37,7 +38,7 @@ test('Result', t => {
   t.ok(isFunction(Result.Err), 'provides an Err function')
   t.ok(isFunction(Result.Ok), 'provides an Ok function')
   t.ok(isFunction(Result.type), 'provides a type function')
-  t.ok(isFunction(Result['@@type']), 'provides a @@type function')
+  t.ok(isString(Result['@@type']), 'provides a @@type string')
 
   const err = /Result: Must wrap something, try using Err or Ok constructors/
   t.throws(Result, err, 'throws with no parameters')
@@ -142,14 +143,11 @@ test('Result @@type', t => {
   const m = Ok(0)
   const e = Err(0)
 
-  t.ok(isFunction(m['@@type']), 'is a function on Ok')
-  t.ok(isFunction(e['@@type']), 'is a function on Err')
-
   t.equal(Result['@@type'], m['@@type'], 'static and instance versions are the same for Ok')
   t.equal(Result['@@type'], e['@@type'], 'static and instance versions are the same for Err')
 
-  t.equal(m['@@type'](), 'crocks/Result@1', 'reports crocks/Result@1 for Ok')
-  t.equal(e['@@type'](), 'crocks/Result@1', 'reports crocks/Result@1 for Err')
+  t.equal(m['@@type'], 'crocks/Result@1', 'reports crocks/Result@1 for Ok')
+  t.equal(e['@@type'], 'crocks/Result@1', 'reports crocks/Result@1 for Err')
 
   t.end()
 })

--- a/src/Star/Star.spec.js
+++ b/src/Star/Star.spec.js
@@ -9,6 +9,7 @@ const _compose = require('../core/compose')
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
 const isSameType = require('../core/isSameType')
+const isString = require('../core/isString')
 const unit = require('../core/_unit')
 
 const Pair = require('../core/Pair')
@@ -27,7 +28,7 @@ test('Star', t => {
   t.ok(isObject(Star(unit)), 'returns an object')
 
   t.ok(isFunction(Star.type), 'provides a type function')
-  t.ok(isFunction(Star['@@type']), 'provides a @@type function')
+  t.ok(isString(Star['@@type']), 'provides a @@type string')
 
   t.equals(Star(unit).constructor, Star, 'provides TypeRep on constructor')
 
@@ -57,7 +58,7 @@ test('Star construction', t => {
 
   t.ok(isFunction(Star.id), 'provides an id function')
   t.ok(isFunction(Star.type), 'provides a type function')
-  t.ok(isFunction(Star['@@type']), 'provides a @@type function')
+  t.ok(isString(Star['@@type']), 'provides a @@type string')
 
   t.ok(isObject(Star(unit)), 'returns an object')
 
@@ -128,9 +129,8 @@ test('Star type', t => {
 test('Star @@type', t => {
   const m = Star(unit)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(m['@@type'], Star['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Star@1( crocks/MockCrock@1 )', 'reports crocks/Star@1 with embeded type')
+  t.equal(m['@@type'], 'crocks/Star@1( crocks/MockCrock@1 )', 'reports crocks/Star@1 with embeded type')
 
   t.end()
 })

--- a/src/Star/index.js
+++ b/src/Star/index.js
@@ -34,13 +34,13 @@ function _Star(Monad) {
     Monad.type()
 
   const innerFullType =
-    Monad['@@type']()
+    Monad['@@type']
 
   const outerType =
     `${_type()}( ${innerType} )`
 
-  const typeFn =
-    () => `${__type()}( ${innerFullType} )`
+  const typeString =
+    `${__type}( ${innerFullType} )`
 
   const type =
     () => outerType
@@ -178,7 +178,7 @@ function _Star(Monad) {
       [fl.contramap]: contramap,
       [fl.map]: map,
       [fl.promap]: promap,
-      ['@@type']: typeFn,
+      ['@@type']: typeString,
       constructor: Star
     }
   }
@@ -187,7 +187,7 @@ function _Star(Monad) {
   Star.type = type
 
   Star[fl.id] = _id
-  Star['@@type'] = typeFn
+  Star['@@type'] = typeString
 
   Star['@@implements'] = _implements(
     [ 'compose', 'contramap', 'id', 'map', 'promap' ]

--- a/src/State/State.spec.js
+++ b/src/State/State.spec.js
@@ -8,8 +8,9 @@ const Pair = require('../core/Pair')
 const Unit = require('../core/Unit')
 const curry = require('../core/curry')
 const compose = curry(require('../core/compose'))
-const isObject = require('../core/isObject')
 const isFunction = require('../core/isFunction')
+const isObject = require('../core/isObject')
+const isString  = require('../core/isString')
 const unit = require('../core/_unit')
 
 const identity = x => x
@@ -30,7 +31,7 @@ test('State', t => {
   t.ok(isFunction(State.put), 'provides a put function')
   t.ok(isFunction(State.modify), 'provides a modify function')
   t.ok(isFunction(State.type), 'provides a type function')
-  t.ok(isFunction(State['@@type']), 'provides a @@type function')
+  t.ok(isString(State['@@type']), 'provides a @@type string')
 
   const err = /State: Must wrap a function in the form \(s -> Pair a s\)/
   t.throws(s(), err, 'throws with no parameters')
@@ -97,9 +98,8 @@ test('State type', t => {
 test('State @@type', t => {
   const m = State(unit)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(State['@@type'], m['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/State@1', 'reports crocks/State@1')
+  t.equal(m['@@type'], 'crocks/State@1', 'reports crocks/State@1')
 
   t.end()
 })

--- a/src/Sum/Sum.spec.js
+++ b/src/Sum/Sum.spec.js
@@ -5,6 +5,7 @@ const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
+const isString  = require('../core/isString')
 
 const constant = x => () => x
 const identity = x => x
@@ -21,7 +22,7 @@ test('Sum', t => {
 
   t.ok(isFunction(Sum.empty), 'provides an empty function')
   t.ok(isFunction(Sum.type), 'provides a type function')
-  t.ok(isFunction(Sum['@@type']), 'provides a @@type function')
+  t.ok(isString(Sum['@@type']), 'provides a @@type string')
 
   const err = /Sum: Numeric value required/
   t.throws(Sum, err, 'throws with nothing')
@@ -98,9 +99,8 @@ test('Sum type', t => {
 test('Sum @@type', t => {
   const m = Sum(0)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(m['@@type'], Sum['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Sum@1', 'reports crocks/Sum@1')
+  t.equal(m['@@type'], 'crocks/Sum@1', 'reports crocks/Sum@1')
 
   t.end()
 })

--- a/src/Writer/Writer.spec.js
+++ b/src/Writer/Writer.spec.js
@@ -11,6 +11,7 @@ const compose = curry(require('../core/compose'))
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
 const isSameType = require('../core/isSameType')
+const isString = require('../core/isString')
 const unit = require('../core/_unit')
 
 const identity = x => x
@@ -51,7 +52,7 @@ test('Writer', t => {
 
   t.ok(isFunction(Writer.of), 'provides an of function')
   t.ok(isFunction(Writer.type), 'provides a type function')
-  t.ok(isFunction(Writer['@@type']), 'provides a @@type function')
+  t.ok(isString(Writer['@@type']), 'provides a @@type string')
 
   t.throws(f(), TypeError, 'throws with no parameters')
   t.throws(f(0), TypeError, 'throws with one parameter')
@@ -107,9 +108,8 @@ test('Writer type', t => {
 test('Writer @@type', t => {
   const m = Writer(0, 0)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(Writer['@@type'], m['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Writer@1( crocks/Last@1 )', 'returns crocks/Writer@1 with Monoid Type')
+  t.equal(m['@@type'], 'crocks/Writer@1( crocks/Last@1 )', 'returns crocks/Writer@1 with Monoid Type')
 
   t.end()
 })

--- a/src/Writer/index.js
+++ b/src/Writer/index.js
@@ -6,8 +6,8 @@ const VERSION = 1
 const _equals = require('../core/equals')
 const _implements = require('../core/implements')
 const _inspect = require('../core/inspect')
-const __type = require('../core/types').type('Writer')
-const _typeFn = require('../core/types').typeFn(__type(), VERSION)
+const __type = require('../core/types').type('Writer')()
+const _typeString = require('../core/types').typeFn(__type, VERSION)
 const fl = require('../core/flNames')
 
 const Pair = require('../core/Pair')
@@ -27,10 +27,10 @@ function _Writer(Monoid) {
     x => Writer(Monoid.empty().valueOf(), x)
 
   const _type =
-    constant(`${__type()}( ${Monoid.type()} )`)
+    constant(`${__type}( ${Monoid.type()} )`)
 
-  const typeFn =
-    constant(`${_typeFn()}( ${Monoid['@@type']()} )`)
+  const typeString =
+    `${_typeString}( ${Monoid['@@type']} )`
 
   function Writer(entry, val) {
     if(arguments.length !== 2) {
@@ -100,7 +100,7 @@ function _Writer(Monoid) {
       [fl.equals]: equals,
       [fl.map]: map,
       [fl.chain]: chain,
-      ['@@type']: typeFn,
+      ['@@type']: typeString,
       constructor: Writer
     }
   }
@@ -109,7 +109,7 @@ function _Writer(Monoid) {
   Writer.type = _type
 
   Writer[fl.of] = _of
-  Writer['@@type'] = typeFn
+  Writer['@@type'] = typeString
 
   Writer['@@implements'] = _implements(
     [ 'ap', 'chain', 'equals', 'map', 'of' ]

--- a/src/core/List.spec.js
+++ b/src/core/List.spec.js
@@ -10,6 +10,7 @@ const _compose = curry(require('./compose'))
 const isFunction = require('./isFunction')
 const isObject = require('./isObject')
 const isSameType = require('./isSameType')
+const isString = require('./isString')
 const unit = require('./_unit')
 
 const Maybe = require('./Maybe')
@@ -34,7 +35,7 @@ test('List', t => {
   t.ok(isFunction(List.of), 'provides an of function')
   t.ok(isFunction(List.fromArray), 'provides a fromArray function')
   t.ok(isFunction(List.type), 'provides a type function')
-  t.ok(isFunction(List['@@type']), 'provides a @@type function')
+  t.ok(isString(List['@@type']), 'provides a @@type string')
 
   const err = /List: List must wrap something/
   t.throws(List, err, 'throws with no parameters')
@@ -132,10 +133,8 @@ test('List type', t => {
 test('List @@type', t => {
   const m = List([])
 
-  t.ok(isFunction(m['@@type']), 'is a function')
-
   t.equal(m['@@type'], List['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/List@1', 'returns crocks/List@1')
+  t.equal(m['@@type'], 'crocks/List@1', 'returns crocks/List@1')
 
   t.end()
 })

--- a/src/core/Maybe.spec.js
+++ b/src/core/Maybe.spec.js
@@ -11,6 +11,7 @@ const isArray = require('./isArray')
 const isFunction = require('./isFunction')
 const isObject = require('./isObject')
 const isSameType = require('./isSameType')
+const isString = require('./isString')
 const unit = require('./_unit')
 
 const constant = x => () => x
@@ -38,7 +39,7 @@ test('Maybe', t => {
   t.ok(isFunction(Maybe.Nothing), 'provides a Nothing constructor')
   t.ok(isFunction(Maybe.Just), 'provides a Just constructor')
   t.ok(isFunction(Maybe.type), 'provides a type function')
-  t.ok(isFunction(Maybe['@@type']), 'provides a @@type function')
+  t.ok(isString(Maybe['@@type']), 'provides a @@type string')
 
   const err = /Maybe: Must wrap something, try using Nothing or Just constructors/
   t.throws(Maybe, err, 'throws with no parameters')
@@ -120,13 +121,11 @@ test('Maybe type', t => {
 test('Maybe @@type', t => {
   const { Just, Nothing } = Maybe
 
-  t.ok(isFunction(Maybe(0)['@@type']), 'is a function')
-
   t.equal(Just(0)['@@type'], Maybe['@@type'], 'static and instance versions are the same for Just')
   t.equal(Nothing(0)['@@type'], Maybe['@@type'], 'static and instance versions are the same for Nothing')
 
-  t.equal(Just(0)['@@type'](), 'crocks/Maybe@1', 'type returns crocks/Maybe@1 for Just')
-  t.equal(Nothing()['@@type'](), 'crocks/Maybe@1', 'type returns crocks/Maybe@1 for Nothing')
+  t.equal(Just(0)['@@type'], 'crocks/Maybe@1', 'type returns crocks/Maybe@1 for Just')
+  t.equal(Nothing()['@@type'], 'crocks/Maybe@1', 'type returns crocks/Maybe@1 for Nothing')
 
   t.end()
 })

--- a/src/core/Pair.spec.js
+++ b/src/core/Pair.spec.js
@@ -11,6 +11,7 @@ const compose = curry(require('./compose'))
 const isFunction = require('./isFunction')
 const isObject = require('./isObject')
 const isSameType = require('./isSameType')
+const isString = require('./isString')
 const unit = require('./_unit')
 
 const identity = x => x
@@ -30,7 +31,7 @@ test('Pair core', t => {
   t.equals(Pair(0, 0).constructor, Pair, 'provides TypeRep on constructor')
 
   t.ok(isFunction(Pair.type), 'provides a type function')
-  t.ok(isFunction(Pair['@@type']), 'provides a @@type function')
+  t.ok(isString(Pair['@@type']), 'provides a @@type string')
 
   const err = /Pair: Must provide a first and second value/
   t.throws(m(), err, 'throws with no parameters')
@@ -91,10 +92,8 @@ test('Pair type', t => {
 test('Pair @@type', t => {
   const p = Pair(0, 0)
 
-  t.ok(isFunction(p['@@type']), 'is a function')
-
   t.equal(p['@@type'], Pair['@@type'], 'static and instance versions are the same')
-  t.equal(p['@@type'](), 'crocks/Pair@2', 'type returns crocks/Pair@2')
+  t.equal(p['@@type'], 'crocks/Pair@2', 'type returns crocks/Pair@2')
 
   t.end()
 })

--- a/src/core/Unit.spec.js
+++ b/src/core/Unit.spec.js
@@ -7,6 +7,7 @@ const bindFunc = helpers.bindFunc
 
 const isFunction = require('./isFunction')
 const isObject = require('./isObject')
+const isString = require('./isString')
 
 const curry = require('./curry')
 const compose = curry(require('./compose'))
@@ -29,7 +30,7 @@ test('Unit', t => {
 
   t.ok(isFunction(Unit.empty), 'provides an empty function')
   t.ok(isFunction(Unit.type), 'provides a type function')
-  t.ok(isFunction(Unit['@@type']), 'provides a @@type function')
+  t.ok(isString(Unit['@@type']), 'provides a @@type string')
 
   t.doesNotThrow(Unit, 'allows no parameters')
 
@@ -88,9 +89,8 @@ test('Unit type', t => {
 test('Unit @@type', t => {
   const m = Unit(0)
 
-  t.ok(isFunction(m['@@type']), 'is a function')
   t.equal(m['@@type'], Unit['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'](), 'crocks/Unit@1', 'type returns crocks/Unit@1')
+  t.equal(m['@@type'], 'crocks/Unit@1', 'type returns crocks/Unit@1')
 
   t.end()
 })

--- a/src/core/types.js
+++ b/src/core/types.js
@@ -40,7 +40,7 @@ const proxy =
 
 const typeFn = (t, ver) => {
   const typeStr = type(t)()
-  return () => `crocks/${typeStr}@${ver || 0}`
+  return `crocks/${typeStr}@${ver || 0}`
 }
 
 module.exports = {

--- a/src/core/types.spec.js
+++ b/src/core/types.spec.js
@@ -94,7 +94,7 @@ test('typeFn function ', t => {
   const { typeFn } = _types
 
   const fn =
-    (x, v) => typeFn(x, v)()
+    (x, v) => typeFn(x, v)
 
   t.equals(fn('All'), 'crocks/All@0', 'returns `crocks/All@0` for key `All` with no version')
   t.equals(fn('All', 1), 'crocks/All@1', 'returns `crocks/All@1` for key `All` with a version of 1')

--- a/src/test/LastMonoid.js
+++ b/src/test/LastMonoid.js
@@ -4,7 +4,7 @@ const _inspect = require('../core/inspect')
 const constant = x => () => x
 const identity = x => x
 
-const typeFn = constant('crocks/Last@1')
+const typeString = 'crocks/Last@1'
 const _type = constant('Last')
 
 function LastMonoid(x) {
@@ -13,13 +13,13 @@ function LastMonoid(x) {
     concat: identity,
     valueOf: constant(x),
     type: _type,
-    '@@type': typeFn
+    '@@type': typeString
   }
 }
 
 LastMonoid.empty = () => LastMonoid(null)
 LastMonoid.type = _type
-LastMonoid['@@type'] = typeFn
+LastMonoid['@@type'] = typeString
 
 LastMonoid['@@implements'] = _implements(
   [ 'concat', 'empty' ]

--- a/src/test/MockCrock.js
+++ b/src/test/MockCrock.js
@@ -4,7 +4,7 @@ const _equals = require('../core/equals')
 const constant = x => () => x
 
 const _type = constant('MockCrock')
-const typeFn = constant('crocks/MockCrock@1')
+const typeString = 'crocks/MockCrock@1'
 const _of   = x => MockCrock(x)
 
 function MockCrock(x) {
@@ -22,14 +22,14 @@ function MockCrock(x) {
   return {
     valueOf, type, map, ap,
     chain, of, sequence,
-    '@@type': typeFn,
+    '@@type': typeString,
     traverse, equals
   }
 }
 
 MockCrock.of = _of
 MockCrock.type = _type
-MockCrock['@@type'] = typeFn
+MockCrock['@@type'] = typeString
 
 MockCrock['@@implements'] = _implements(
   [ 'ap', 'chain', 'equals', 'map', 'of', 'traverse' ]


### PR DESCRIPTION
## Everywhere I say.
![image](https://user-images.githubusercontent.com/3665793/36294331-e5a1d68e-1294-11e8-935b-1e3030762646.png)

Okay, jumped the gun on Sanctuary integration, this is the first step in getting this to work with Sanctuary Defs. This PR just moves all of the new `@@type` methods over to new `@@type` `String` properties.

This is against [this issue](https://github.com/evilsoft/crocks/issues/215)