### PR TITLE
Add `Max` and `Min` Monoids to the docs

### DIFF
--- a/docs/src/pages/docs/functions/pointfree-functions.md
+++ b/docs/src/pages/docs/functions/pointfree-functions.md
@@ -98,11 +98,11 @@ accepted Datatype):
 | `chain` | `Array`, [`Async`][async-chain], `Const`, `Either`, `Identity`, `IO`, `List`, [`Maybe`][maybe-chain], `Pair`, [`Reader`][reader-chain], `Result`, [`State`][state-chain], `Unit`, `Writer` |
 | `coalesce` | [`Async`][async-coalesce], `Either`, [`Maybe`][maybe-coalesce], `Result` |
 | `compareWith` | [`Equiv`][equiv-compare] |
-| `concat` | [`All`][all-concat], [`Any`][any-concat], `Array`, [`Assign`][assign-concat], `Const`, `Either`, [`Endo`][endo-concat], [`Equiv`][equiv-concat], [`First`][first-concat], `Identity`, [`Last`][last-concat], `List`, `Max`, [`Maybe`][maybe-concat], `Min`, `Pair`, [`Pred`][pred-concat], [`Prod`][prod-concat], `Result`, `String`, [`Sum`][sum-concat], `Unit` |
+| `concat` | [`All`][all-concat], [`Any`][any-concat], `Array`, [`Assign`][assign-concat], `Const`, `Either`, [`Endo`][endo-concat], [`Equiv`][equiv-concat], [`First`][first-concat], `Identity`, [`Last`][last-concat], `List`, [`Max`][max-concat], [`Maybe`][maybe-concat], [`Min`][min-concat], `Pair`, [`Pred`][pred-concat], [`Prod`][prod-concat], `Result`, `String`, [`Sum`][sum-concat], `Unit` |
 | `cons` | `Array`, `List` |
 | `contramap` | [`Arrow`][arrow-contra], [`Equiv`][equiv-contra], [`Pred`][pred-contra], `Star` |
 | `either` | `Either`, [`Maybe`][maybe-either], `Result` |
-| `empty` | [`All`][all-empty], [`Any`][any-empty], `Array`, [`Assign`][assign-empty], [`Endo`][endo-empty], [`Equiv`][equiv-empty], [`First`][first-empty], [`Last`][last-empty], `List`, `Max`, `Min`, `Object`, [`Pred`][pred-empty], [`Prod`][prod-empty], `String`, [`Sum`][sum-empty], `Unit` |
+| `empty` | [`All`][all-empty], [`Any`][any-empty], `Array`, [`Assign`][assign-empty], [`Endo`][endo-empty], [`Equiv`][equiv-empty], [`First`][first-empty], [`Last`][last-empty], `List`, [`Max`][max-empty], [`Min`][min-empty], `Object`, [`Pred`][pred-empty], [`Prod`][prod-empty], `String`, [`Sum`][sum-empty], `Unit` |
 | [`evalWith`][eval] | [`State`][state-eval] |
 | [`execWith`][exec] | [`State`][state-exec] |
 | `extend` | `Pair` |
@@ -128,7 +128,7 @@ accepted Datatype):
 | `swap` | [`Async`][async-swap], `Either`, `Pair`, `Result` |
 | `tail` | `Array`, `List`, `String` |
 | `traverse` | `Array`, `Either`, `Identity`, `List`, [`Maybe`][maybe-traverse], `Pair`, `Result` |
-| `valueOf` | [`All`][all-value], [`Any`][any-value], [`Assign`][assign-value], `Const`, [`Endo`][endo-value], [`Equiv`][equiv-value], [`First`][first-value], `Identity`, [`Last`][last-value], `Max`, `Min`, [`Pred`][pred-value], [`Prod`][prod-value], [`Sum`][sum-value], `Unit`, `Writer` |
+| `valueOf` | [`All`][all-value], [`Any`][any-value], [`Assign`][assign-value], `Const`, [`Endo`][endo-value], [`Equiv`][equiv-value], [`First`][first-value], `Identity`, [`Last`][last-value], [`Max`][max-value], [`Min`][min-value], [`Pred`][pred-value], [`Prod`][prod-value], [`Sum`][sum-value], `Unit`, `Writer` |
 
 [all-concat]: ../monoids/All.html#concat
 [all-empty]: ../monoids/All.html#empty
@@ -179,6 +179,10 @@ accepted Datatype):
 [last-option]: ../monoids/Last.html#option
 [last-value]: ../monoids/Last.html#valueof
 
+[max-concat]: ../monoids/Max.html#concat
+[max-empty]: ../monoids/Max.html#empty
+[max-value]: ../monoids/Max.html#valueof
+
 [maybe-alt]: ../crocks/Maybe.html#alt
 [maybe-ap]: ../crocks/Maybe.html#ap
 [maybe-chain]: ../crocks/Maybe.html#chain
@@ -189,6 +193,10 @@ accepted Datatype):
 [maybe-option]: ../crocks/Maybe.html#option
 [maybe-sequence]: ../crocks/Maybe.html#sequence
 [maybe-traverse]: ../crocks/Maybe.html#traverse
+
+[min-concat]: ../monoids/Min.html#concat
+[min-empty]: ../monoids/Min.html#empty
+[min-value]: ../monoids/Min.html#valueof
 
 [pred-concat]: ../crocks/Pred.html#concat
 [pred-contra]: ../crocks/Pred.html#contramap

--- a/docs/src/pages/docs/monoids/Max.md
+++ b/docs/src/pages/docs/monoids/Max.md
@@ -1,0 +1,137 @@
+---
+title: "Max"
+description: "Max Monoid"
+layout: "guide"
+weight: 70
+---
+
+```haskell
+Max Number
+```
+
+`Max` is a `Monoid` that will combines (2) `Number`s, resulting in the largest
+of the two.
+
+```javascript
+const Max = require('crocks/Max')
+const mconcat = require('crocks/helpers/mconcat')
+
+Max(76)
+//=> Max 76
+
+mconcat(Max, [ 95, 102, 56 ])
+//=> Max 102
+
+Max(100)
+  .concat(Max(10))
+//=> Max 100
+
+Max.empty()
+  .concat(Max(100))
+//=> Max 100
+```
+
+<article id="topic-implements">
+
+## Implements
+
+`Semigroup`, `Monoid`
+
+</article>
+
+<article id="topic-constructor">
+
+## Constructor Methods
+
+#### empty
+
+```haskell
+Max.empty :: () -> Max
+```
+
+`empty` provides the identity for the `Monoid` in that when the value it
+provides is `concat`ed to any other value, it will return the other value. In
+the case of `Max` the result of `empty` is `-Infinity`. `empty` is available on
+both the Constructor and the Instance for convenience.
+
+```javascript
+const Max = require('crocks/Max')
+
+Max.empty()
+//=> Max -Infinity
+
+Max.empty()
+  .concat(Max.empty())
+//=> Max -Infinity
+
+Max(32)
+  .concat(Max.empty())
+//=> Max 32
+
+Max.empty()
+  .concat(Max(34))
+//=> Max 34
+```
+
+</article>
+
+<article id="topic-instance">
+
+## Instance Methods
+
+#### concat
+
+```haskell
+Max ~> Max -> Max
+```
+
+`concat` is used to combine (2) `Semigroup`s of the same type under an
+operation specified by the `Semigroup`. In the case of `Max`, it will result
+in the largest of the (2) `Number`s.
+
+```javascript
+const Max = require('crocks/Max')
+
+Max(23)
+  .concat(Max(13))
+//=> Max 23
+
+Max(-23)
+  .concat(Max(-32))
+//=> Max -23
+
+Max.empty()
+  .concat(Max(Infinity))
+//=> Max Infinity
+```
+
+#### valueOf
+
+```haskell
+Max ~> () -> Number
+```
+
+`valueOf` is used on all `crocks` `Monoid`s as a means of extraction. While the
+extraction is available, types that implement `valueOf` are not necessarily a
+`Comonad`. This function is used primarily for convenience for some of the
+helper functions that ship with `crocks`. Calling `valueOf` on a `Max` instance
+will result in the underlying `Number`.
+
+```javascript
+const Max = require('crocks/Max')
+
+Max(4)
+  .valueOf()
+//=> 4
+
+Max.empty()
+  .valueOf()
+//=> -Infinity
+
+Max(34)
+  .concat(Max(21))
+  .valueOf()
+//=> 34
+```
+
+</article>

--- a/docs/src/pages/docs/monoids/Min.md
+++ b/docs/src/pages/docs/monoids/Min.md
@@ -1,0 +1,137 @@
+---
+title: "Min"
+description: "Min Monoid"
+layout: "guide"
+weight: 80
+---
+
+```haskell
+Min Number
+```
+
+`Min` is a `Monoid` that will combines (2) `Number`s, resulting in the smallest
+of the two.
+
+```javascript
+const Min = require('crocks/Min')
+const mconcat = require('crocks/helpers/mconcat')
+
+Min(76)
+//=> Min 76
+
+mconcat(Min, [ 95, 12, 56 ])
+//=> Min 12
+
+Min(100)
+  .concat(Min(10))
+//=> Min 10
+
+Min.empty()
+  .concat(Min(100))
+//=> Min 100
+```
+
+<article id="topic-implements">
+
+## Implements
+
+`Semigroup`, `Monoid`
+
+</article>
+
+<article id="topic-constructor">
+
+## Constructor Methods
+
+#### empty
+
+```haskell
+Min.empty :: () -> Min
+```
+
+`empty` provides the identity for the `Monoid` in that when the value it
+provides is `concat`ed to any other value, it will return the other value. In
+the case of `Min` the result of `empty` is `Infinity`. `empty` is available on
+both the Constructor and the Instance for convenience.
+
+```javascript
+const Min = require('crocks/Min')
+
+Min.empty()
+//=> Min Infinity
+
+Min.empty()
+  .concat(Min.empty())
+//=> Min Infinity
+
+Min(32)
+  .concat(Min.empty())
+//=> Min 32
+
+Min.empty()
+  .concat(Min(34))
+//=> Min 34
+```
+
+</article>
+
+<article id="topic-instance">
+
+## Instance Methods
+
+#### concat
+
+```haskell
+Min ~> Min -> Min
+```
+
+`concat` is used to combine (2) `Semigroup`s of the same type under an
+operation specified by the `Semigroup`. In the case of `Min`, it will result
+in the smallest of the (2) `Number`s.
+
+```javascript
+const Min = require('crocks/Min')
+
+Min(50)
+  .concat(Min(24))
+//=> Min 24
+
+Min(-120)
+  .concat(Min(-50))
+//=> Min -120
+
+Min.empty()
+  .concat(Min(-Infinity))
+//=> Min -Infinity
+```
+
+#### valueOf
+
+```haskell
+Min ~> () -> Number
+```
+
+`valueOf` is used on all `crocks` `Monoid`s as a means of extraction. While the
+extraction is available, types that implement `valueOf` are not necessarily a
+`Comonad`. This function is used primarily for convenience for some of the
+helper functions that ship with `crocks`. Calling `valueOf` on a `Min` instance
+will result in the underlying `Number`.
+
+```javascript
+const Min = require('crocks/Min')
+
+Min(33)
+  .valueOf()
+//=> 33
+
+Min.empty()
+  .valueOf()
+//=> Infinity
+
+Min(35)
+  .concat(Min(20))
+  .valueOf()
+//=> 20
+```
+
+</article>

--- a/docs/src/pages/docs/monoids/index.md
+++ b/docs/src/pages/docs/monoids/index.md
@@ -27,8 +27,8 @@ as the following Instance Functions: `valueOf`, `empty` and `concat`.
 | [`Endo`][Endo] | Function | `compose` | `identity` |
 | [`First`][First] | [`Maybe`][Maybe] | `First` [`Just`][just] | [`Nothing`][nothing] |
 | [`Last`][Last] | [`Maybe`][Maybe] | `Last` [`Just`][just] | [`Nothing`][nothing] |
-| `Max` | Number | `Math.max` | `-Infinity` |
-| `Min` | Number | `Math.min` | `Infinity` |
+| [`Max`][Max] | Number | `Math.max` | `-Infinity` |
+| [`Min`][`Min`] | Number | `Math.min` | `Infinity` |
 | [`Prod`][Prod] | Number | Multiplication | `1` |
 | [`Sum`][Sum] | Number | Addition | `0` |
 
@@ -48,5 +48,7 @@ as the following Instance Functions: `valueOf`, `empty` and `concat`.
 [Endo]: Endo.html
 [First]: First.html
 [Last]: Last.html
+[Max]: Max.html
+[Min]: Min.html
 [Prod]: Prod.html
 [Sum]: Sum.html


### PR DESCRIPTION
## Done and doner!
![image](https://user-images.githubusercontent.com/3665793/36348378-1ce9a754-1423-11e8-9124-137b33d4ced7.png)

These are the last (2) Docs that round out the Monoids!!
At this point all Monoids that ship with `crocks` are fully documented...