### PR TITLE
All Object Traversal Functions Behave the Same

### DIFF
--- a/docs/src/pages/docs/crocks/Maybe.md
+++ b/docs/src/pages/docs/crocks/Maybe.md
@@ -865,8 +865,8 @@ If you want some safety around pulling a value out of an `Object` or `Array`
 with a single key or index, you can always reach for `prop`. Well, as long
 as you are working with non-nested data that is. Just tell `prop` either the key
 or index you are interested in, and you will get back a function that will take
-anything and return a `Just` with the wrapped value if the key/index exists. If
-the key/index does not exist however, you will get back a `Nothing`.
+anything and return a `Just` with the wrapped value if the key/index is defined.
+If the key/index is not defined, you will get back a `Nothing`.
 
 ```javascript
 const composeK = require('crocks/helpers/composeK')
@@ -922,8 +922,8 @@ this situation, just pull in `propPath` and pass it a left-to-right traversal
 path of keys, indices or a combination of both (gross...but possible). This will
 kick you back a function that behaves just like [`prop`](#prop). You pass it
 some data, and it will attempt to resolve your provided path. If the path is
-valid, it will return the value residing there (`null` included!) in a `Just`.
-But if at any point that path "breaks" it will give you back a `Nothing`.
+valid, it will return the value residing there (`null` and `NaN` included!) in
+a `Just`. But if at any point that path "breaks" it will give you back a `Nothing`.
 
 ```javascript
 const composeK = require('crocks/helpers/composeK')

--- a/docs/src/pages/docs/functions/helpers.md
+++ b/docs/src/pages/docs/functions/helpers.md
@@ -851,22 +851,37 @@ If you want some safety around pulling a value out of an Object or Array with a
 single key or index, you can always reach for `propOr`. Well, as long as you are
 working with non-nested data that is. Just tell `propOr` either the key or index
 you are interested in, and you will get back a function that will take anything
-and return the wrapped value if the key/index exists. If the key/index does not
-exist however, you will get back a default value.
+and return the wrapped value if the key/index is defined. If the key/index is not
+defined however, you will get back the provided default value.
 
 ```javascript
-const { get } = require('crocks/State')
 const propOr = require('crocks/helpers/propOr')
 
-const data = { foo: 'bar' }
+const data = {
+  foo: 'bar',
+  null: null,
+  nan: NaN,
+  undef: undefined
+}
 
-get()
-  .map(propOr('default', 'foo'))
-  .evalWith(data) // bar
+// def :: (String | Integer) -> a -> b
+const def =
+  propOr('default')
 
-get()
-  .map(propOr('default', 'baz'))
-  .evalWith(data) // default
+def('foo', data)
+//=> "bar"
+
+def('null', data)
+//=> null
+
+def('nan', data)
+//=> NaN
+
+def('baz', data)
+//=> "default"
+
+def('undef', data)
+//=> "default"
 ```
 
 #### propPathOr
@@ -887,18 +902,39 @@ valid, it will return the value. But if at any point that path "breaks" it will
 give you back the default value.
 
 ```javascript
-const { get } = require('crocks/State')
 const propPathOr = require('crocks/helpers/propPathOr')
 
-const data = { foo: { bar: 'bar' }, baz: null }
+const data = {
+  foo: {
+    bar: 'bar',
+    null: null,
+    nan: NaN,
+    undef: undefined
+  },
+  arr: [ 1, 2 ]
+}
 
-get()
-  .map(propPathOr('default', ['foo', 'bar']))
-  .evalWith(data) // bar
+// def :: [ String | Integer ] -> a -> b
+const def =
+  propPathOr('default')
 
-get()
-  .map(propPathOr('default', ['baz', 'tommy']))
-  .evalWith(data) // default
+def([ 'foo', 'bar' ], data)
+//=> "bar"
+
+def([ 'baz', 'tommy' ], data)
+//=> "default"
+
+def([ 'foo', 'null' ], data)
+//=> null
+
+def([ 'foo', 'nan' ], data)
+//=> NaN
+
+def([ 'foo', 'undef' ], data)
+//=> "default"
+
+def([ 'arr', 'length' ], data)
+//=> 2
 ```
 
 #### tap

--- a/docs/src/pages/docs/functions/predicate-functions.md
+++ b/docs/src/pages/docs/functions/predicate-functions.md
@@ -14,7 +14,8 @@ from `crocks/predicates`.
 Below is a list of all the current predicates that are included with a
 description of their truth:
 
-* `hasProp :: (String | Number) -> a -> Boolean`: an `Array` or `Object` that contains the provided index or key
+* `hasProp :: (String | Integer) -> a -> Boolean`: an `Array` or `Object` that contains the provided index or key
+* `hasPropPath :: [ String | Integer ] -> a -> Boolean`: an `Array` or `Object` that contains the provided index path
 * `isAlt :: a -> Boolean`: an ADT that provides `map` and `alt` methods
 * `isAlternative :: a -> Boolean`: an ADT that provides `alt`, `zero`, `map`, `ap`, `chain` and `of`methods
 * `isApplicative :: a -> Boolean`: an ADT that provides `map`, `ap` and `of` methods
@@ -47,8 +48,8 @@ description of their truth:
 * `isSetoid :: a -> Boolean`: an ADT that provides an `equals` method
 * `isString :: a -> Boolean`: String
 * `isTraversable :: a -> Boolean`: an ADT that provides `map` and `traverse` methods
-* `propEq: (String | Number) -> a -> Object -> Boolean`: an `Object` that contains the provided key
-* `propPathEq :: [String | Number] -> a -> Object -> Boolean`: an `Object` that contains the provided key in the provided traversal path
+* `propEq: (String | Interger) -> a -> Object -> Boolean`: an `Object` that contains the provided key
+* `propPathEq :: [ String | Integer ] -> a -> Object -> Boolean`: an `Object` that contains the provided key in the provided traversal path
 
 [pred]: ../crocks/Pred.html
 [ifelse]: logic-functions.html#ifelse

--- a/src/Maybe/README.md
+++ b/src/Maybe/README.md
@@ -845,8 +845,8 @@ If you want some safety around pulling a value out of an `Object` or `Array`
 with a single key or index, you can always reach for `prop`. Well, as long
 as you are working with non-nested data that is. Just tell `prop` either the key
 or index you are interested in, and you will get back a function that will take
-anything and return a `Just` with the wrapped value if the key/index exists. If
-the key/index does not exist however, you will get back a `Nothing`.
+anything and return a `Just` with the wrapped value if the key/index is defined.
+If the key/index is not defined, you will get back a `Nothing`.
 
 ```javascript
 const composeK = require('crocks/helpers/composeK')
@@ -902,8 +902,8 @@ this situation, just pull in `propPath` and pass it a left-to-right traversal
 path of keys, indices or a combination of both (gross...but possible). This will
 kick you back a function that behaves just like [`prop`](#prop). You pass it
 some data, and it will attempt to resolve your provided path. If the path is
-valid, it will return the value residing there (`null` included!) in a `Just`.
-But if at any point that path "breaks" it will give you back a `Nothing`.
+valid, it will return the value residing there (`null` and `NaN` included!) in
+a `Just`. But if at any point that path "breaks" it will give you back a `Nothing`.
 
 ```javascript
 const composeK = require('crocks/helpers/composeK')

--- a/src/Maybe/prop.js
+++ b/src/Maybe/prop.js
@@ -2,25 +2,28 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const curry = require('../core/curry')
-const isNil= require('../core/isNil')
+const isDefined = require('../core/isDefined')
+const isEmpty = require('../core/isEmpty')
+const isNil = require('../core/isNil')
 const isInteger = require('../core/isInteger')
 const isString = require('../core/isString')
 const { Nothing, Just } = require('../core/Maybe')
 
-const lift = x =>
-  !isNil(x) ? Just(x) : Nothing()
-
 // prop : (String | Integer) -> a -> Maybe b
 function prop(key, target) {
-  if(!(isString(key) || isInteger(key))) {
-    throw new TypeError('prop: String or integer required for first argument')
+  if(!((isString(key) && !isEmpty(key)) || isInteger(key))) {
+    throw new TypeError('prop: Non-empty String or Integer required for first argument')
   }
 
   if(isNil(target)) {
     return Nothing()
   }
 
-  return lift(target[key])
+  const value = target[key]
+
+  return isDefined(value)
+    ? Just(value)
+    : Nothing()
 }
 
 module.exports = curry(prop)

--- a/src/Maybe/prop.spec.js
+++ b/src/Maybe/prop.spec.js
@@ -4,6 +4,7 @@ const helpers = require('../test/helpers')
 const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
+const equals = require('../core/equals')
 
 const prop = require('./prop')
 
@@ -12,39 +13,44 @@ test('prop function', t => {
 
   t.ok(isFunction(prop), 'is a function')
 
-  const err = /prop: String or integer required for first argument/
+  const err = /prop: Non-empty String or Integer required for first argument/
   t.throws(p(undefined, {}), err, 'throws with undefined in first argument')
   t.throws(p(null, {}), err, 'throws with null in first argument')
   t.throws(p(false, {}), err, 'throws with false in first argument')
   t.throws(p(true, {}), err, 'throws with true in first argument')
+  t.throws(p('', {}), err, 'throws with empty string in first argument')
   t.throws(p(1.5, {}), err, 'throws with float in first argument')
   t.throws(p([], {}), err, 'throws with an array in first argument')
   t.throws(p({}, {}), err, 'throws with an object in first argument')
 
   const value = 'Bobby Joe'
-  const obj = { a: value, bad: null, worse: NaN }
+  const obj = { a: value, null: null, noNum: NaN, undef: undefined }
 
   const objGood = prop('a')(obj)
   const objBad = prop('b', obj)
-  const objNull = prop('bad')
-  const objNaN = prop('worse')
+  const objUndef = prop('undef')
+  const objNull = prop('null')
+  const objNaN = prop('noNum')
 
   t.equals(objGood.option('nothing'), value, 'returns a Just with the value when key is found')
   t.equals(objBad.option('nothing'), 'nothing', 'returns a Nothing when key is not found')
-  t.equals(objNull(obj).option('nothing'), 'nothing', 'returns a Nothing when key is found and value is null')
-  t.equals(objNaN(obj).option('nothing'), 'nothing', 'returns a Nothing when key is found and value is NaN')
+  t.equals(objUndef(obj).option('nothing'), 'nothing', 'returns a Nothing when key is found and value is undefined')
+  t.equals(objNull(obj).option('nothing'), null, 'returns a Just when key is found and value is null')
+  t.ok(equals(objNaN(obj).option('nothing'), NaN), 'returns a Just when key is found and value is NaN')
 
-  const arr = [ value, null, NaN ]
+  const arr = [ value, null, NaN, undefined ]
 
   const arrGood = prop(0, arr)
   const arrBad = prop(5)(arr)
+  const arrUndef = prop(4)
   const arrNull = prop(1)
   const arrNaN = prop(2)
 
   t.equals(arrGood.option('nothing'), value, 'returns a Just with the value when index is found')
   t.equals(arrBad.option('nothing'), 'nothing', 'returns a Nothing when index is not found')
-  t.equals(arrNull(arr).option('nothing'), 'nothing', 'returns a Nothing when index is found and value is null')
-  t.equals(arrNaN(arr).option('nothing'), 'nothing', 'returns a Nothing when index is found and value is NaN')
+  t.equals(arrUndef(arr).option('nothing'), 'nothing', 'returns a Nothing when index is found and value is undefined')
+  t.equals(arrNull(arr).option('nothing'), null, 'returns a Just when index is found and value is null')
+  t.ok(equals(arrNaN(arr).option('nothing'), NaN), 'returns a Just when index is found and value is NaN')
 
   const fn =
     x => prop('key', x).option('nothing')

--- a/src/Maybe/prop.spec.js
+++ b/src/Maybe/prop.spec.js
@@ -9,55 +9,62 @@ const equals = require('../core/equals')
 const prop = require('./prop')
 
 test('prop function', t => {
-  const p = bindFunc(prop)
-
-  t.ok(isFunction(prop), 'is a function')
-
-  const err = /prop: Non-empty String or Integer required for first argument/
-  t.throws(p(undefined, {}), err, 'throws with undefined in first argument')
-  t.throws(p(null, {}), err, 'throws with null in first argument')
-  t.throws(p(false, {}), err, 'throws with false in first argument')
-  t.throws(p(true, {}), err, 'throws with true in first argument')
-  t.throws(p('', {}), err, 'throws with empty string in first argument')
-  t.throws(p(1.5, {}), err, 'throws with float in first argument')
-  t.throws(p([], {}), err, 'throws with an array in first argument')
-  t.throws(p({}, {}), err, 'throws with an object in first argument')
-
-  const value = 'Bobby Joe'
-  const obj = { a: value, null: null, noNum: NaN, undef: undefined }
-
-  const objGood = prop('a')(obj)
-  const objBad = prop('b', obj)
-  const objUndef = prop('undef')
-  const objNull = prop('null')
-  const objNaN = prop('noNum')
-
-  t.equals(objGood.option('nothing'), value, 'returns a Just with the value when key is found')
-  t.equals(objBad.option('nothing'), 'nothing', 'returns a Nothing when key is not found')
-  t.equals(objUndef(obj).option('nothing'), 'nothing', 'returns a Nothing when key is found and value is undefined')
-  t.equals(objNull(obj).option('nothing'), null, 'returns a Just when key is found and value is null')
-  t.ok(equals(objNaN(obj).option('nothing'), NaN), 'returns a Just when key is found and value is NaN')
-
-  const arr = [ value, null, NaN, undefined ]
-
-  const arrGood = prop(0, arr)
-  const arrBad = prop(5)(arr)
-  const arrUndef = prop(4)
-  const arrNull = prop(1)
-  const arrNaN = prop(2)
-
-  t.equals(arrGood.option('nothing'), value, 'returns a Just with the value when index is found')
-  t.equals(arrBad.option('nothing'), 'nothing', 'returns a Nothing when index is not found')
-  t.equals(arrUndef(arr).option('nothing'), 'nothing', 'returns a Nothing when index is found and value is undefined')
-  t.equals(arrNull(arr).option('nothing'), null, 'returns a Just when index is found and value is null')
-  t.ok(equals(arrNaN(arr).option('nothing'), NaN), 'returns a Just when index is found and value is NaN')
-
   const fn =
     x => prop('key', x).option('nothing')
+
+  t.ok(isFunction(prop), 'is a function')
 
   t.equals(fn(undefined), 'nothing', 'returns Nothing when data is undefined')
   t.equals(fn(null), 'nothing', 'returns Nothing when data is null')
   t.equals(fn(NaN), 'nothing', 'returns Nothing when data is NaN')
+
+  t.end()
+})
+
+test('prop errors', t => {
+  const fn = bindFunc(x => prop(x, {}))
+
+  const err = /prop: Non-empty String or Integer required for first argument/
+  t.throws(fn(undefined), err, 'throws with undefined in first argument')
+  t.throws(fn(null), err, 'throws with null in first argument')
+  t.throws(fn(false), err, 'throws with false in first argument')
+  t.throws(fn(true), err, 'throws with true in first argument')
+  t.throws(fn(''), err, 'throws with empty string in first argument')
+  t.throws(fn(1.5), err, 'throws with float in first argument')
+  t.throws(fn([]), err, 'throws with an array in first argument')
+  t.throws(fn({}), err, 'throws with an object in first argument')
+
+  t.end()
+})
+
+test('prop object traversal', t => {
+  const fn = x =>
+    prop('a', x).option('nothing')
+
+  t.equals(fn({ a: false }), false, 'returns a Just with the value when key is found')
+  t.equals(fn({ a: null }), null, 'returns a Just when key is found and value is null')
+  t.ok(equals(fn({ a: NaN }), NaN), 'returns a Just when key is found and value is NaN')
+
+  t.equals(fn({ b: null }), 'nothing', 'returns a Nothing when key is not found')
+  t.equals(fn({ a: undefined }), 'nothing', 'returns a Nothing when key is found and value is undefined')
+
+  t.end()
+})
+
+test('prop array traversal', t => {
+  const fn = x =>
+    prop(1, x).option('nothing')
+
+  const string = x =>
+    prop('1', x).option('nothing')
+
+  t.equals(fn([ null, false ]), false, 'returns a Just with the value when index is found')
+  t.equals(string([ null, false ]), false, 'returns a Just with the value when string index is found')
+  t.equals(fn([ undefined, null ]), null, 'returns a Just when index is found and value is null')
+  t.ok(equals(fn([ 0, NaN ]), NaN), 'returns a Just when index is found and value is NaN')
+
+  t.equals(fn([ 'string' ]), 'nothing', 'returns a Nothing when index is not found')
+  t.equals(fn([ 1, undefined ]), 'nothing', 'returns a Nothing when index is found and value is undefined')
 
   t.end()
 })

--- a/src/Maybe/propPath.js
+++ b/src/Maybe/propPath.js
@@ -1,33 +1,42 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const Maybe = require('../core/Maybe')
-const { Nothing, Just } = Maybe
+const { Nothing, Just } = require('../core/Maybe')
 
 const curry = require('../core/curry')
 const isArray = require('../core/isArray')
+const isDefined = require('../core/isDefined')
+const isEmpty = require('../core/isEmpty')
 const isInteger = require('../core/isInteger')
-const isNil= require('../core/isNil')
+const isNil = require('../core/isNil')
 const isString = require('../core/isString')
-
-const lift = x =>
-  !isNil(x) ? Just(x) : Nothing()
 
 // propPath : [ String | Integer ] -> a -> Maybe b
 function propPath(keys, target) {
   if(!isArray(keys)) {
-    throw new TypeError('propPath: Array of strings or integers required for first argument')
+    throw new TypeError('propPath: Array of Non-empty Strings or Integers required for first argument')
   }
 
   if(isNil(target)) {
     return Nothing()
   }
-  return keys.reduce((maybe, key) => {
-    if(!(isString(key) || isInteger(key))) {
-      throw new TypeError('propPath: Array of strings or integers required for first argument')
+
+  let value = target
+  for(let i = 0; i < keys.length; i++) {
+    const key = keys[i]
+
+    if(!((isString(key) && !isEmpty(key)) || isInteger(key))) {
+      throw new TypeError('propPath: Array of Non-empty Strings or Integers required for first argument')
     }
-    return maybe.chain(x => lift(x[key]))
-  }, Maybe.of(target))
+
+    value = value[key]
+
+    if(!isDefined(value)) {
+      return Nothing()
+    }
+  }
+
+  return Just(value)
 }
 
 module.exports = curry(propPath)

--- a/src/Maybe/propPath.js
+++ b/src/Maybe/propPath.js
@@ -29,6 +29,10 @@ function propPath(keys, target) {
       throw new TypeError('propPath: Array of Non-empty Strings or Integers required for first argument')
     }
 
+    if(isNil(value)) {
+      return Nothing()
+    }
+
     value = value[key]
 
     if(!isDefined(value)) {

--- a/src/Maybe/propPath.spec.js
+++ b/src/Maybe/propPath.spec.js
@@ -4,6 +4,7 @@ const helpers = require('../test/helpers')
 const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
+const equals = require('../core/equals')
 
 const propPath = require('./propPath')
 
@@ -12,7 +13,7 @@ test('propPath function', t => {
 
   t.ok(isFunction(propPath), 'is a function')
 
-  const err = /propPath: Array of strings or integers required for first argument/
+  const err = /propPath: Array of Non-empty Strings or Integers required for first argument/
   t.throws(p(undefined, {}), err, 'throws with undefined in first argument')
   t.throws(p(null, {}), err, 'throws with null in first argument')
   t.throws(p(0, {}), err, 'throws with falsey number in first argument')
@@ -25,36 +26,44 @@ test('propPath function', t => {
 
   t.throws(p([ undefined ], {}), err, 'throws with an array of undefined in first argument')
   t.throws(p([ null ], {}), err, 'throws with array of null in first argument')
-  t.throws(p(false, {}), err, 'throws with an array of false in first argument')
-  t.throws(p(true, {}), err, 'throws with an array of true in first argument')
+  t.throws(p([ false ], {}), err, 'throws with an array of false in first argument')
+  t.throws(p([ true ], {}), err, 'throws with an array of true in first argument')
+  t.throws(p([ '' ], {}), err, 'throws with an array of empty String in first argument')
   t.throws(p([ {} ], {}), err, 'throws with an array of objects in first argument')
   t.throws(p([ [ 'key' ] ], {}), err, 'throws with a nested array in first argument')
 
   const value = 'Cry Clown Cry'
-  const obj = { a: { b: value }, bad: { thing: null, stuff: NaN } }
+  const obj = { a: { b: value }, bad: { undef: undefined, null: null, nonNum: NaN } }
 
   const objGood = propPath([ 'a', 'b' ])(obj)
   const objBad = propPath([ 'b', 'c' ], obj)
-  const objNull = propPath([ 'bad', 'thing' ])
-  const objNaN = propPath([ 'bad', 'stuff' ])
+
+  const objUndef = propPath([ 'bad', 'undef' ])
+  const objNull = propPath([ 'bad', 'null' ])
+  const objNaN = propPath([ 'bad', 'nonNum' ])
 
   t.equals(objGood.option('nothing'), value, 'returns a Just with the value when key path is found')
   t.equals(objBad.option('nothing'), 'nothing', 'returns a Nothing when key path is not found')
-  t.equals(objNull(obj).option('nothing'), 'nothing', 'returns a Nothing when keypath is found and value is null')
-  t.equals(objNaN(obj).option('nothing'), 'nothing', 'returns a Nothing when keypath is found and value is NaN')
 
-  const arr = [ [ 'blank', value ], [ null, 'crazy' ], [ NaN ] ]
+  t.equals(objUndef(obj).option('nothing'), 'nothing', 'returns a Nothing when keypath is found and value is undefined')
+  t.equals(objNull(obj).option('nothing'), null, 'returns a Just when keypath is found and value is null')
+  t.ok(equals(objNaN(obj).option('nothing'), NaN), 'returns a Just when keypath is found and value is NaN')
+
+  const arr = [ [ 'blank', value ], [ null, 'crazy', undefined ], [ NaN ] ]
 
   const arrGood = propPath([ 0, 1 ], arr)
   const arrBad = propPath([ 5 ])(arr)
   const arrNull = propPath([ 1, 0 ])
+  const arrUndef = propPath([ 1, 2 ])
   const arrNaN = propPath([ 2, 0 ])
 
   t.equals(arrGood.option('nothing'), value, 'returns a Just with the value when index is found')
   t.equals(arrBad.option('nothing'), 'nothing', 'returns a Nothing when index is not found')
-  t.equals(arrNull(arr).option('nothing'), 'nothing', 'returns a Nothing when index is found and value is null')
-  t.equals(arrNaN(arr).option('nothing'), 'nothing', 'returns a Nothing when index is found and value is NaN')
   t.same(propPath([], arr).option('nothing'), arr, 'returns a Just with original value when an empty array is provided as path')
+
+  t.equals(arrUndef(arr).option('nothing'), 'nothing', 'returns a Nothing when index is found and value is undefined')
+  t.equals(arrNull(arr).option('nothing'), null, 'returns a Just when index is found and value is null')
+  t.ok(equals(arrNaN(arr).option('nothing'), NaN), 'returns a Just when index is found and value is NaN')
 
   const mixed = { things: [ 1, 45, value, 10 ] }
 

--- a/src/Maybe/propPath.spec.js
+++ b/src/Maybe/propPath.spec.js
@@ -9,72 +9,105 @@ const equals = require('../core/equals')
 const propPath = require('./propPath')
 
 test('propPath function', t => {
-  const p = bindFunc(propPath)
-
-  t.ok(isFunction(propPath), 'is a function')
-
-  const err = /propPath: Array of Non-empty Strings or Integers required for first argument/
-  t.throws(p(undefined, {}), err, 'throws with undefined in first argument')
-  t.throws(p(null, {}), err, 'throws with null in first argument')
-  t.throws(p(0, {}), err, 'throws with falsey number in first argument')
-  t.throws(p(1, {}), err, 'throws with truthy number in first argument')
-  t.throws(p('', {}), err, 'throws with falsey string in first argument')
-  t.throws(p('string', {}), err, 'throws with truthy string in first argument')
-  t.throws(p(false, {}), err, 'throws with false in first argument')
-  t.throws(p(true, {}), err, 'throws with true in first argument')
-  t.throws(p({}, {}), err, 'throws with an object in first argument')
-
-  t.throws(p([ undefined ], {}), err, 'throws with an array of undefined in first argument')
-  t.throws(p([ null ], {}), err, 'throws with array of null in first argument')
-  t.throws(p([ false ], {}), err, 'throws with an array of false in first argument')
-  t.throws(p([ true ], {}), err, 'throws with an array of true in first argument')
-  t.throws(p([ '' ], {}), err, 'throws with an array of empty String in first argument')
-  t.throws(p([ {} ], {}), err, 'throws with an array of objects in first argument')
-  t.throws(p([ [ 'key' ] ], {}), err, 'throws with a nested array in first argument')
-
-  const value = 'Cry Clown Cry'
-  const obj = { a: { b: value }, bad: { undef: undefined, null: null, nonNum: NaN } }
-
-  const objGood = propPath([ 'a', 'b' ])(obj)
-  const objBad = propPath([ 'b', 'c' ], obj)
-
-  const objUndef = propPath([ 'bad', 'undef' ])
-  const objNull = propPath([ 'bad', 'null' ])
-  const objNaN = propPath([ 'bad', 'nonNum' ])
-
-  t.equals(objGood.option('nothing'), value, 'returns a Just with the value when key path is found')
-  t.equals(objBad.option('nothing'), 'nothing', 'returns a Nothing when key path is not found')
-
-  t.equals(objUndef(obj).option('nothing'), 'nothing', 'returns a Nothing when keypath is found and value is undefined')
-  t.equals(objNull(obj).option('nothing'), null, 'returns a Just when keypath is found and value is null')
-  t.ok(equals(objNaN(obj).option('nothing'), NaN), 'returns a Just when keypath is found and value is NaN')
-
-  const arr = [ [ 'blank', value ], [ null, 'crazy', undefined ], [ NaN ] ]
-
-  const arrGood = propPath([ 0, 1 ], arr)
-  const arrBad = propPath([ 5 ])(arr)
-  const arrNull = propPath([ 1, 0 ])
-  const arrUndef = propPath([ 1, 2 ])
-  const arrNaN = propPath([ 2, 0 ])
-
-  t.equals(arrGood.option('nothing'), value, 'returns a Just with the value when index is found')
-  t.equals(arrBad.option('nothing'), 'nothing', 'returns a Nothing when index is not found')
-  t.same(propPath([], arr).option('nothing'), arr, 'returns a Just with original value when an empty array is provided as path')
-
-  t.equals(arrUndef(arr).option('nothing'), 'nothing', 'returns a Nothing when index is found and value is undefined')
-  t.equals(arrNull(arr).option('nothing'), null, 'returns a Just when index is found and value is null')
-  t.ok(equals(arrNaN(arr).option('nothing'), NaN), 'returns a Just when index is found and value is NaN')
-
-  const mixed = { things: [ 1, 45, value, 10 ] }
-
-  t.equals(propPath([ 'things', 2 ], mixed).option('nothing'), value, 'allows for traversal with a mixed path on a mixed structure')
-
   const fn =
     x => propPath([ 'key' ], x).option('nothing')
+
+  const empty =
+    x => propPath([], x).option('nothing')
+
+  t.ok(isFunction(propPath), 'is a function')
 
   t.equals(fn(undefined), 'nothing', 'returns Nothing when data is undefined')
   t.equals(fn(null), 'nothing', 'returns Nothing when data is null')
   t.equals(fn(NaN), 'nothing', 'returns Nothing when data is NaN')
+
+  t.equals(empty(undefined), 'nothing', 'returns Nothing when data is undefined')
+  t.equals(empty(null), 'nothing', 'returns Nothing when data is null')
+  t.equals(empty(NaN), 'nothing', 'returns Nothing when data is NaN')
+
+  t.end()
+})
+
+test('propPath errors', t => {
+  const fn = bindFunc(x => propPath(x, {}))
+
+  const err = /propPath: Array of Non-empty Strings or Integers required for first argument/
+  t.throws(fn(undefined), err, 'throws with undefined in first argument')
+  t.throws(fn(null), err, 'throws with null in first argument')
+  t.throws(fn(0), err, 'throws with falsey number in first argument')
+  t.throws(fn(1), err, 'throws with truthy number in first argument')
+  t.throws(fn(''), err, 'throws with falsey string in first argument')
+  t.throws(fn('string'), err, 'throws with truthy string in first argument')
+  t.throws(fn(false), err, 'throws with false in first argument')
+  t.throws(fn(true), err, 'throws with true in first argument')
+  t.throws(fn({}), err, 'throws with an object in first argument')
+
+  t.throws(fn([ undefined ]), err, 'throws with an array of undefined in first argument')
+  t.throws(fn([ null ]), err, 'throws with array of null in first argument')
+  t.throws(fn([ false ]), err, 'throws with an array of false in first argument')
+  t.throws(fn([ true ]), err, 'throws with an array of true in first argument')
+  t.throws(fn([ '' ]), err, 'throws with an array of empty String in first argument')
+  t.throws(fn([ 1.234 ]), err, 'throws with an array of float in first argument')
+  t.throws(fn([ {} ]), err, 'throws with an array of objects in first argument')
+  t.throws(fn([ [ 'key' ] ]), err, 'throws with a nested array in first argument')
+
+  t.end()
+})
+
+test('propPath object traversal', t => {
+  const fn = x =>
+    propPath([ 'a', 'b' ], x).option('nothing')
+
+  const empty = x =>
+    propPath([], x).option('nothing')
+
+  t.equals(fn({ a: { b: 0 } }), 0, 'returns a Just with the value when key path is found')
+  t.equals(fn({ a: { b: null } }), null, 'returns a Just when keypath is found and value is null')
+  t.ok(equals(fn({ a: { b: NaN } }), NaN), 'returns a Just when keypath is found and value is NaN')
+
+  t.equals(fn({ c: { b: 15 } }), 'nothing', 'returns a Nothing when key path is not found')
+  t.equals(fn({ a: { b: undefined } }), 'nothing', 'returns a Nothing when keypath is found and value is undefined')
+
+  t.equals(fn({ a: undefined }), 'nothing', 'returns a Nothing with undefined in keypath')
+  t.equals(fn({ a: null }), 'nothing', 'returns a Nothing with null in keypath')
+  t.equals(fn({ a: NaN }), 'nothing', 'returns a Nothing with NaN in keypath')
+
+  t.same(empty({ b: 'string' }), { b: 'string' }, 'returns original object when path empty')
+
+  t.end()
+})
+
+test('propPath array traversal', t => {
+  const fn = x =>
+    propPath([ 0, '1' ], x).option('nothing')
+
+  const empty = x =>
+    propPath([], x).option('nothing')
+
+  t.equals(fn([ [ null, false ] ]), false, 'returns a Just with the value when index is found')
+  t.equals(fn([ [ false, null ] ]), null, 'returns a Just when index is found and value is null')
+  t.ok(equals(fn([ [ '', NaN ] ]), NaN), 'returns a Just when index is found and value is NaN')
+
+  t.equals(fn([ true ]), 'nothing', 'returns a Nothing when index is not found')
+  t.equals(fn([ [ 2, undefined ] ]), 'nothing', 'returns a Nothing when index is found and value is undefined')
+
+  t.equals(fn([ undefined ]), 'nothing', 'returns a Nothing with undefined in keypath')
+  t.equals(fn([ null ]), 'nothing', 'returns a Nothing with null in keypath')
+  t.equals(fn([ NaN ]), 'nothing', 'returns a Nothing with NaN in keypath')
+
+
+  t.same(empty([ [ 23 ] ]), [ [ 23 ] ], 'returns a Just with original value when an empty array is provided as path')
+
+  t.end()
+})
+
+test('propPath mixed traversal', t => {
+  const fn = x =>
+    propPath([ 0, 'a' ], x).option('nothing')
+
+  t.equals(fn([ { a: '' } ]), '', 'allows for traversal with a mixed path on a mixed structure')
+  t.equals(fn([ { b: '' } ]), 'nothing', 'returns Nothin when not found with mixed path')
+
 
   t.end()
 })

--- a/src/helpers/propOr.js
+++ b/src/helpers/propOr.js
@@ -1,25 +1,29 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Henrique Limas */
+/** @author Ian Hofmann-Hicks */
 
 const curry = require('../core/curry')
-const isNil= require('../core/isNil')
+const isDefined = require('../core/isDefined')
+const isEmpty = require('../core/isEmpty')
+const isNil = require('../core/isNil')
 const isInteger = require('../core/isInteger')
 const isString = require('../core/isString')
 
-const lift = (x, def) =>
-  isNil(x) ? def : x
-
 // propOr : a -> String | Integer -> b -> c
 function propOr(def, key, target) {
-  if(!(isString(key) || isInteger(key))) {
-    throw new TypeError('propOr: String or integer required for second argument')
+  if(!((isString(key) && !isEmpty(key)) || isInteger(key))) {
+    throw new TypeError('propOr: Non-empty String or Integer required for second argument')
   }
 
   if(isNil(target)) {
     return def
   }
 
-  return lift(target[key], def)
+  const value = target[key]
+
+  return isDefined(value)
+    ? value
+    : def
 }
 
 module.exports = curry(propOr)

--- a/src/helpers/propOr.spec.js
+++ b/src/helpers/propOr.spec.js
@@ -9,58 +9,63 @@ const isFunction = require('../core/isFunction')
 const propOr = require('./propOr')
 
 test('propOr function', t => {
-  const p = bindFunc(propOr)
   const def = 'default value'
+  const fn = propOr(def, 'key')
 
   t.ok(isFunction(propOr), 'is a function')
-
-  const err = /propOr: Non-empty String or Integer required for second argument/
-  t.throws(p(def, undefined, {}), err, 'throws with undefined in second argument')
-  t.throws(p(def, null, {}), err, 'throws with null in second argument')
-  t.throws(p(def, false, {}), err, 'throws with false in second argument')
-  t.throws(p(def, true, {}), err, 'throws with true in second argument')
-  t.throws(p(def, 1.5, {}), err, 'throws with float in second argument')
-  t.throws(p(def, '', {}), err, 'throws with empty string in second argument')
-  t.throws(p(def, [], {}), err, 'throws with an array in second argument')
-  t.throws(p(def, {}, {}), err, 'throws with an object in second argument')
-
-  const value = 'Bobby Joe'
-  const obj = { a: value, null: null, nonNum: NaN, undef: undefined }
-
-  const objGood = propOr(def)('a')(obj)
-  const objBad = propOr(def)('b', obj)
-
-  const objUndef = propOr(def)('undefined')
-  const objNull = propOr(def)('null')
-  const objNaN = propOr(def)('nonNum')
-
-  t.equals(objGood, value, 'returns the value when key is found')
-  t.equals(objBad, def, 'returns default value when key is not found')
-  t.equals(objUndef(obj), def, 'returns default value when key is found and value is null')
-  t.equals(objNull(obj), null, 'returns null when key is found and value is null')
-  t.ok(equals(objNaN(obj), NaN), 'returns NaN when key is found and value is NaN')
-
-  const arr = [ value, null, NaN, undefined ]
-
-  const arrGood = propOr(def, 0, arr)
-  const arrBad = propOr(def, 5)(arr)
-
-  const arrNull = propOr(def, 1)
-  const arrNaN = propOr(def, 2)
-  const arrUndef = propOr(def, 3)
-
-  t.equals(arrGood, value, 'returns the value when index is found')
-  t.equals(arrBad, def, 'returns default value when index is not found')
-
-  t.equals(arrUndef(arr), def, 'returns default value when index is found and value is undefined')
-  t.equals(arrNull(arr), null, 'returns null when index is found and value is null')
-  t.ok(equals(arrNaN(arr), NaN), 'returns NaN when index is found and value is NaN')
-
-  const fn = propOr(def, 'key')
 
   t.equals(fn(undefined), def, 'returns default value when data is undefined')
   t.equals(fn(null), def, 'returns default value when data is null')
   t.equals(fn(NaN), def, 'returns default value when data is NaN')
+
+  t.end()
+})
+
+test('propOr errors', t => {
+  const fn = bindFunc(x => propOr(0, x, {}))
+
+  const err = /propOr: Non-empty String or Integer required for second argument/
+  t.throws(fn(undefined), err, 'throws with undefined in second argument')
+  t.throws(fn(null), err, 'throws with null in second argument')
+  t.throws(fn(false), err, 'throws with false in second argument')
+  t.throws(fn(true), err, 'throws with true in second argument')
+  t.throws(fn(1.5), err, 'throws with float in second argument')
+  t.throws(fn(''), err, 'throws with empty string in second argument')
+  t.throws(fn([]), err, 'throws with an array in second argument')
+  t.throws(fn({}), err, 'throws with an object in second argument')
+
+  t.end()
+})
+
+test('propOr object traversal', t => {
+  const def = { b: 1 }
+  const value = 'value'
+
+  const fn = propOr(def, 'a')
+
+  t.equals(fn({ a: value }), value, 'returns the value when key is found')
+  t.equals(fn({ a: null }), null, 'returns null when key is found and value is null')
+  t.ok(equals(fn({ a: NaN }), NaN), 'returns NaN when key is found and value is NaN')
+
+  t.equals(fn({ b: 'bad' }), def, 'returns default value when key is not found')
+  t.equals(fn({ a: undefined }), def, 'returns default value when key is found and value is undefined')
+
+  t.end()
+})
+
+test('propOr array traversal', t => {
+  const def = 33
+
+  const fn = propOr(def, 1)
+  const string = propOr(def, '1')
+
+  t.equals(fn([ 0, false ]), false, 'returns the value when index is found')
+  t.equals(string([ 0, '' ]), '', 'returns the value when string index is found')
+  t.equals(fn([ 0, null ]), null, 'returns null when index is found and value is null')
+  t.ok(equals(fn([ 0, NaN ]), NaN), 'returns NaN when index is found and value is NaN')
+
+  t.equals(fn([ 0, undefined ]), def, 'returns default value when index is found and value is undefined')
+  t.equals(fn([ 0 ]), def, 'returns default value when index is not found')
 
   t.end()
 })

--- a/src/helpers/propOr.spec.js
+++ b/src/helpers/propOr.spec.js
@@ -3,6 +3,7 @@ const helpers = require('../test/helpers')
 
 const bindFunc = helpers.bindFunc
 
+const equals = require('../core/equals')
 const isFunction = require('../core/isFunction')
 
 const propOr = require('./propOr')
@@ -13,39 +14,47 @@ test('propOr function', t => {
 
   t.ok(isFunction(propOr), 'is a function')
 
-  const err = /propOr: String or integer required for second argument/
+  const err = /propOr: Non-empty String or Integer required for second argument/
   t.throws(p(def, undefined, {}), err, 'throws with undefined in second argument')
   t.throws(p(def, null, {}), err, 'throws with null in second argument')
   t.throws(p(def, false, {}), err, 'throws with false in second argument')
   t.throws(p(def, true, {}), err, 'throws with true in second argument')
   t.throws(p(def, 1.5, {}), err, 'throws with float in second argument')
+  t.throws(p(def, '', {}), err, 'throws with empty string in second argument')
   t.throws(p(def, [], {}), err, 'throws with an array in second argument')
   t.throws(p(def, {}, {}), err, 'throws with an object in second argument')
 
   const value = 'Bobby Joe'
-  const obj = { a: value, bad: null, worse: NaN }
+  const obj = { a: value, null: null, nonNum: NaN, undef: undefined }
 
   const objGood = propOr(def)('a')(obj)
   const objBad = propOr(def)('b', obj)
-  const objNull = propOr(def)('bad')
-  const objNaN = propOr(def)('worse')
+
+  const objUndef = propOr(def)('undefined')
+  const objNull = propOr(def)('null')
+  const objNaN = propOr(def)('nonNum')
 
   t.equals(objGood, value, 'returns the value when key is found')
   t.equals(objBad, def, 'returns default value when key is not found')
-  t.equals(objNull(obj), def, 'returns default value when key is found and value is null')
-  t.equals(objNaN(obj), def, 'returns default value when key is found and value is NaN')
+  t.equals(objUndef(obj), def, 'returns default value when key is found and value is null')
+  t.equals(objNull(obj), null, 'returns null when key is found and value is null')
+  t.ok(equals(objNaN(obj), NaN), 'returns NaN when key is found and value is NaN')
 
-  const arr = [ value, null, NaN ]
+  const arr = [ value, null, NaN, undefined ]
 
   const arrGood = propOr(def, 0, arr)
   const arrBad = propOr(def, 5)(arr)
+
   const arrNull = propOr(def, 1)
   const arrNaN = propOr(def, 2)
+  const arrUndef = propOr(def, 3)
 
   t.equals(arrGood, value, 'returns the value when index is found')
   t.equals(arrBad, def, 'returns default value when index is not found')
-  t.equals(arrNull(arr), def, 'returns default value when index is found and value is null')
-  t.equals(arrNaN(arr), def, 'returns default value when index is found and value is NaN')
+
+  t.equals(arrUndef(arr), def, 'returns default value when index is found and value is undefined')
+  t.equals(arrNull(arr), null, 'returns null when index is found and value is null')
+  t.ok(equals(arrNaN(arr), NaN), 'returns NaN when index is found and value is NaN')
 
   const fn = propOr(def, 'key')
 

--- a/src/helpers/propPathOr.js
+++ b/src/helpers/propPathOr.js
@@ -1,31 +1,45 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Henrique Limas */
+/** @author Ian Hofmann-Hicks */
 
 const curry = require('../core/curry')
 const isArray = require('../core/isArray')
+const isEmpty = require('../core/isEmpty')
 const isInteger = require('../core/isInteger')
-const isNil= require('../core/isNil')
+const isDefined = require('../core/isDefined')
+const isNil = require('../core/isNil')
 const isString = require('../core/isString')
 
 // propPathOr : a -> [ String | Integer ] -> b -> c
 function propPathOr(def, keys, target) {
   if(!isArray(keys)) {
-    throw new TypeError('propPathOr: Array of strings or integers required for second argument')
+    throw new TypeError(
+      'propPathOr: Array of Non-empty Strings or Integers required for second argument'
+    )
   }
 
-  const value = keys.reduce((target, key) => {
-    if (isNil(target)) {
-      return target
+  if(isNil(target)) {
+    return def
+  }
+
+  let value = target
+  for(let i = 0; i < keys.length; i++) {
+    const key = keys[i]
+
+    if(!((isString(key) && !isEmpty(key)) || isInteger(key))) {
+      throw new TypeError(
+        'propPathOr: Array of Non-empty Strings or Integers required for second argument'
+      )
     }
 
-    if(!(isString(key) || isInteger(key))) {
-      throw new TypeError('propPathOr: Array of strings or integers required for second argument')
+    value = value[key]
+
+    if(!isDefined(value)) {
+      return def
     }
+  }
 
-    return target[key]
-  }, target)
-
-  return isNil(value) ? def : value
+  return value
 }
 
 module.exports = curry(propPathOr)

--- a/src/helpers/propPathOr.js
+++ b/src/helpers/propPathOr.js
@@ -32,6 +32,10 @@ function propPathOr(def, keys, target) {
       )
     }
 
+    if(isNil(value)) {
+      return def
+    }
+
     value = value[key]
 
     if(!isDefined(value)) {

--- a/src/helpers/propPathOr.spec.js
+++ b/src/helpers/propPathOr.spec.js
@@ -5,81 +5,109 @@ const bindFunc = helpers.bindFunc
 
 const equals = require('../core/equals')
 const isFunction = require('../core/isFunction')
+const unit = require('../core/_unit')
 
 const propPathOr = require('./propPathOr')
 
 test('propPathOr function', t => {
-  const p = bindFunc(propPathOr)
   const def = 'default value'
+  const fn = propPathOr(def, [ 'key' ])
+  const empty = propPathOr(def, [])
 
   t.ok(isFunction(propPathOr), 'is a function')
-
-  const err = /propPathOr: Array of Non-empty Strings or Integers required for second argument/
-  t.throws(p(def, undefined, {}), err, 'throws with undefined in second argument')
-  t.throws(p(def, null, {}), err, 'throws with null in second argument')
-  t.throws(p(def, 0, {}), err, 'throws with falsey number in second argument')
-  t.throws(p(def, 1, {}), err, 'throws with truthy number in second argument')
-  t.throws(p(def, '', {}), err, 'throws with falsey string in second argument')
-  t.throws(p(def, 'string', {}), err, 'throws with truthy string in second argument')
-  t.throws(p(def, false, {}), err, 'throws with false in second argument')
-  t.throws(p(def, true, {}), err, 'throws with true in second argument')
-  t.throws(p(def, {}, {}), err, 'throws with an object in second argument')
-
-  t.throws(p(def, [ undefined ], {}), err, 'throws with an array of undefined in second argument')
-  t.throws(p(def, [ null ], {}), err, 'throws with array of null in second argument')
-  t.throws(p(def, [ false ], {}), err, 'throws with an array of false in second argument')
-  t.throws(p(def, [ true ], {}), err, 'throws with an array of true in second argument')
-  t.throws(p(def, [ '' ], {}), err, 'throws with an array of empty in second argument')
-  t.throws(p(def, [ {} ], {}), err, 'throws with an array of objects in second argument')
-  t.throws(p(def, [ [ 'key' ] ], {}), err, 'throws with a nested array in second argument')
-
-  const value = 'Cry Clown Cry'
-  const obj = { a: { b: value }, bad: { null: null, nonNum: NaN, undef: undefined } }
-
-  const objGood = propPathOr(def, [ 'a', 'b' ])(obj)
-  const objBad = propPathOr(def, [ 'b', 'c' ], obj)
-  const objNull = propPathOr(def, [ 'bad', 'null' ])
-  const objNaN = propPathOr(def, [ 'bad', 'nonNum' ])
-  const objUndef = propPathOr(def, [ 'bad', 'undef' ])
-
-  t.equals(objGood, value, 'returns the value when key path is found')
-  t.equals(objBad, def, 'returns the default value when key path is not found')
-
-  t.equals(objUndef(obj), def, 'returns the default value when keypath is found and value is undefined')
-  t.equals(objNull(obj), null, 'returns null when keypath is found and value is null')
-  t.ok(equals(objNaN(obj), NaN), 'returns NaN when keypath is found and value is NaN')
-
-  const arr = [ [ 'blank', value ], [ null, NaN, undefined ] ]
-
-  const arrGood = propPathOr(def, [ 0, 1 ], arr)
-  const arrBad = propPathOr(def, [ 5 ])(arr)
-  const arrNull = propPathOr(def, [ 1, 0 ])
-  const arrNaN = propPathOr(def, [ 1, 1 ])
-  const arrUndef = propPathOr(def, [ 1, 2 ])
-
-  t.equals(arrGood, value, 'returns the value when index is found')
-  t.equals(arrBad, def, 'returns the default value when index is not found')
-
-  t.equals(arrUndef(arr), def, 'returns the default value when index is found and value is undefined')
-  t.equals(arrNull(arr), null , 'returns null when index is found and value is null')
-  t.ok(equals(arrNaN(arr), NaN), 'returns NaN when index is found and value is NaN')
-
-  t.same(propPathOr(def, [], arr), arr, 'returns the original value when an empty array is provided as path')
-
-  const mixed = { things: [ 1, 45, value, 10 ] }
-
-  t.equals(propPathOr(def, [ 'things', 2 ], mixed), value, 'allows for traversal with a mixed path on a mixed structure')
-
-  const fn = propPathOr(def, [ 'key' ])
 
   t.equals(fn(undefined), def, 'returns the default value when data is undefined')
   t.equals(fn(null), def, 'returns the default value when data is null')
   t.equals(fn(NaN), def, 'returns the default value when data is NaN')
 
-  const objDefault =  { b: 1 }
+  t.equals(empty(undefined), def, 'returns default with empty path and undefined')
+  t.equals(empty(null), def, 'returns default with empty path and null')
+  t.equals(empty(NaN), def, 'returns default with empty path and NaN')
 
-  t.equals(propPathOr(objDefault, [ 'a', 'b' ], { c: { b: 2 } }), objDefault, 'returns the default value when default is an object that has the same property as a nested property in target')
-  t.equals(propPathOr(1, [ 'a' ], { a: 0 } ), 0, 'returns found falsy value')
+  t.end()
+})
+
+test('propPathOr errors', t => {
+  const def = 'default value'
+  const fn = bindFunc(x => propPathOr(def, x, {}))
+
+  const err = /propPathOr: Array of Non-empty Strings or Integers required for second argument/
+  t.throws(fn(def, undefined, {}), err, 'throws with undefined in second argument')
+  t.throws(fn(def, null, {}), err, 'throws with null in second argument')
+  t.throws(fn(def, 0, {}), err, 'throws with falsey number in second argument')
+  t.throws(fn(def, 1, {}), err, 'throws with truthy number in second argument')
+  t.throws(fn(def, '', {}), err, 'throws with falsey string in second argument')
+  t.throws(fn(def, 'string', {}), err, 'throws with truthy string in second argument')
+  t.throws(fn(def, false, {}), err, 'throws with false in second argument')
+  t.throws(fn(def, true, {}), err, 'throws with true in second argument')
+  t.throws(fn(def, {}, {}), err, 'throws with an object in second argument')
+  t.throws(fn(def, unit, {}), err, 'throws with an function in second argument')
+
+  t.throws(fn([ undefined ]), err, 'throws with an array of undefined in second argument')
+  t.throws(fn([ null ]), err, 'throws with array of null in second argument')
+  t.throws(fn([ false ]), err, 'throws with an array of false in second argument')
+  t.throws(fn([ true ]), err, 'throws with an array of true in second argument')
+  t.throws(fn([ '' ]), err, 'throws with an array of empty string in second argument')
+  t.throws(fn([ 1.543 ]), err, 'throws with an array of float in second argument')
+  t.throws(fn([ {} ]), err, 'throws with an array of object in second argument')
+  t.throws(fn([ unit ]), err, 'throws with an array of function in second argument')
+  t.throws(fn([ [ 'key' ] ], {}), err, 'throws with a nested array in second argument')
+
+  t.end()
+})
+
+test('propPathOr object traversal', t => {
+  const def = { b: 1 }
+
+  const fn = propPathOr(def, [ 'a', 'b' ])
+  const empty = propPathOr(def, [])
+
+  t.same(fn({ a: { b: { c: 32 } } }), { c: 32 }, 'returns the value when keypath is found')
+  t.equals(fn({ a: { b: null } }), null, 'returns null when keypath is found and value is null')
+  t.ok(equals(fn({ a: { b: NaN } }), NaN), 'returns NaN when keypath is found and value is NaN')
+
+  t.equals(fn({ a: { c: true } }), def, 'returns the default value when keypath is not found')
+  t.equals(fn({ a: { b: undefined } }), def, 'returns the default value when keypath is found and value is undefined')
+
+  t.equals(fn({ a: undefined }), def, 'returns the default value when keypath contains an undefined')
+  t.equals(fn({ a: null }), def, 'returns the default value when keypath contains a null')
+  t.equals(fn({ a: NaN }), def, 'returns the default value when keypath contains a NaN')
+
+  t.same(empty({ a: 32 }), { a: 32 }, 'returns the original object when an empty array is provided as path')
+
+  t.same(fn({ c: { b: 2 } }), def, 'returns the default value when default is an object that has the same property as a nested property in target')
+
+  t.end()
+})
+
+test('propPathOr array traversal', t => {
+  const def = 99
+
+  const fn = propPathOr(def, [ 0, '1' ])
+  const empty = propPathOr(def, [])
+
+  t.equals(fn([ [ '', 13 ] ]), 13, 'returns the value when index is found')
+  t.equals(fn([ [ false, null ] ]), null , 'returns null when index is found and value is null')
+  t.ok(equals(fn([ [ false, NaN ] ]), NaN), 'returns NaN when index is found and value is NaN')
+
+  t.equals(fn([ true ]), def, 'returns the default value when index is not found')
+  t.equals(fn([ [ 0, undefined ] ]), def, 'returns the default value when index is found and value is undefined')
+
+  t.equals(fn([ undefined ]), def, 'returns the default value when key path contains a null')
+  t.equals(fn([ null ]), def, 'returns the default value when key path contains a null')
+  t.equals(fn([ NaN ]), def, 'returns the default value when key path contains a NaN')
+
+  t.same(empty([ 1, { a: 23 } ]), [ 1, { a: 23 } ], 'returns the original array when an empty array is provided as path')
+
+  t.end()
+})
+
+test('propPathOr mixed traversal', t => {
+  const def = 'default value'
+  const fn = propPathOr(def, [ 'a', 1 ])
+
+  t.equals(fn({ a: [ 0, false ] }), false, 'returns value when found with mixed path')
+  t.equals(fn({ c: [ true ] }), def, 'returns default when not found with mixed path')
 
   t.end()
 })

--- a/src/helpers/propPathOr.spec.js
+++ b/src/helpers/propPathOr.spec.js
@@ -3,6 +3,7 @@ const helpers = require('../test/helpers')
 
 const bindFunc = helpers.bindFunc
 
+const equals = require('../core/equals')
 const isFunction = require('../core/isFunction')
 
 const propPathOr = require('./propPathOr')
@@ -13,7 +14,7 @@ test('propPathOr function', t => {
 
   t.ok(isFunction(propPathOr), 'is a function')
 
-  const err = /propPathOr: Array of strings or integers required for second argument/
+  const err = /propPathOr: Array of Non-empty Strings or Integers required for second argument/
   t.throws(p(def, undefined, {}), err, 'throws with undefined in second argument')
   t.throws(p(def, null, {}), err, 'throws with null in second argument')
   t.throws(p(def, 0, {}), err, 'throws with falsey number in second argument')
@@ -26,35 +27,43 @@ test('propPathOr function', t => {
 
   t.throws(p(def, [ undefined ], {}), err, 'throws with an array of undefined in second argument')
   t.throws(p(def, [ null ], {}), err, 'throws with array of null in second argument')
-  t.throws(p(def, false, {}), err, 'throws with an arrau of false in second argument')
-  t.throws(p(def, true, {}), err, 'throws with an array of true in second argument')
+  t.throws(p(def, [ false ], {}), err, 'throws with an array of false in second argument')
+  t.throws(p(def, [ true ], {}), err, 'throws with an array of true in second argument')
+  t.throws(p(def, [ '' ], {}), err, 'throws with an array of empty in second argument')
   t.throws(p(def, [ {} ], {}), err, 'throws with an array of objects in second argument')
   t.throws(p(def, [ [ 'key' ] ], {}), err, 'throws with a nested array in second argument')
 
   const value = 'Cry Clown Cry'
-  const obj = { a: { b: value }, bad: { thing: null, news: NaN } }
+  const obj = { a: { b: value }, bad: { null: null, nonNum: NaN, undef: undefined } }
 
   const objGood = propPathOr(def, [ 'a', 'b' ])(obj)
   const objBad = propPathOr(def, [ 'b', 'c' ], obj)
-  const objNull = propPathOr(def, [ 'bad', 'thing' ])
-  const objNaN = propPathOr(def, [ 'bad', 'news' ])
+  const objNull = propPathOr(def, [ 'bad', 'null' ])
+  const objNaN = propPathOr(def, [ 'bad', 'nonNum' ])
+  const objUndef = propPathOr(def, [ 'bad', 'undef' ])
 
   t.equals(objGood, value, 'returns the value when key path is found')
   t.equals(objBad, def, 'returns the default value when key path is not found')
-  t.equals(objNull(obj), def, 'returns the default value when keypath is found and value is null')
-  t.equals(objNaN(obj), def, 'returns the default value when keypath is found and value is NaN')
 
-  const arr = [ [ 'blank', value ], [ null, 'crazy', NaN ] ]
+  t.equals(objUndef(obj), def, 'returns the default value when keypath is found and value is undefined')
+  t.equals(objNull(obj), null, 'returns null when keypath is found and value is null')
+  t.ok(equals(objNaN(obj), NaN), 'returns NaN when keypath is found and value is NaN')
+
+  const arr = [ [ 'blank', value ], [ null, NaN, undefined ] ]
 
   const arrGood = propPathOr(def, [ 0, 1 ], arr)
   const arrBad = propPathOr(def, [ 5 ])(arr)
   const arrNull = propPathOr(def, [ 1, 0 ])
-  const arrNaN = propPathOr(def, [ 1, 2 ])
+  const arrNaN = propPathOr(def, [ 1, 1 ])
+  const arrUndef = propPathOr(def, [ 1, 2 ])
 
   t.equals(arrGood, value, 'returns the value when index is found')
   t.equals(arrBad, def, 'returns the default value when index is not found')
-  t.equals(arrNull(arr), def, 'returns the default value when index is found and value is null')
-  t.equals(arrNaN(arr), def, 'returns the default value when index is found and value is NaN')
+
+  t.equals(arrUndef(arr), def, 'returns the default value when index is found and value is undefined')
+  t.equals(arrNull(arr), null , 'returns null when index is found and value is null')
+  t.ok(equals(arrNaN(arr), NaN), 'returns NaN when index is found and value is NaN')
+
   t.same(propPathOr(def, [], arr), arr, 'returns the original value when an empty array is provided as path')
 
   const mixed = { things: [ 1, 45, value, 10 ] }

--- a/src/index.js
+++ b/src/index.js
@@ -146,6 +146,7 @@ const pointfree = {
 
 const predicates = {
   hasProp: require('./predicates/hasProp'),
+  hasPropPath: require('./predicates/hasPropPath'),
   isAlt: require('./predicates/isAlt'),
   isAlternative: require('./predicates/isAlternative'),
   isApplicative: require('./predicates/isApplicative'),

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -139,6 +139,7 @@ const valueOf = require('./pointfree/valueOf')
 
 // predicates
 const hasProp = require('./predicates/hasProp')
+const hasPropPath = require('./predicates/hasPropPath')
 const isAlt = require('./predicates/isAlt')
 const isAlternative = require('./predicates/isAlternative')
 const isApplicative = require('./predicates/isApplicative')
@@ -345,6 +346,7 @@ test('entry', t => {
 
   // predicates
   t.equal(crocks.hasProp, hasProp, 'provides the hasProp predicate')
+  t.equal(crocks.hasPropPath, hasPropPath, 'provides the hasPropPath predicate')
   t.equal(crocks.isAlt, isAlt, 'provides the isAlt predicate')
   t.equal(crocks.isAlternative, isAlternative, 'provides the isAlternative predicate')
   t.equal(crocks.isApply, isApply, 'provides the isApply predicate')

--- a/src/predicates/hasProp.js
+++ b/src/predicates/hasProp.js
@@ -2,16 +2,25 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const curry = require('../core/curry')
-const isString = require('../core/isString')
+const isDefined = require('../core/isDefined')
+const isEmpty = require('../core/isEmpty')
 const isInteger = require('../core/isInteger')
+const isNil = require('../core/isNil')
+const isString = require('../core/isString')
 
-// hasProp : (String | Number) -> a -> Boolean
+// hasProp : (String | Integer) -> a -> Boolean
 function hasProp(key, x) {
-  if(!(isString(key) || isInteger(key))) {
-    throw new TypeError('hasProp: Number or String required for first argument')
+  if(!((isString(key) && !isEmpty(key)) || isInteger(key))) {
+    throw new TypeError(
+      'hasProp: Non-empty String or Integer required for first argument'
+    )
   }
 
-  return (!!x && x[key] !== undefined)
+  if(isNil(x)) {
+    return false
+  }
+
+  return isDefined(x[key])
 }
 
 module.exports = curry(hasProp)

--- a/src/predicates/hasProp.spec.js
+++ b/src/predicates/hasProp.spec.js
@@ -13,28 +13,31 @@ test('hasProp function', t => {
 
   t.ok(isFunction(hasProp), 'is a function')
 
-  const err = /hasProp: Number or String required for first argument/
+  const err = /hasProp: Non-empty String or Integer required for first argument/
   t.throws(f(undefined, {}), err, 'throws with undefined in first argument')
   t.throws(f(null, {}), err, 'throws with null in first argument')
+  t.throws(f(NaN, {}), err, 'throws with NaN in first argument')
   t.throws(f(false, {}), err, 'throws with false in first argument')
   t.throws(f(true, {}), err, 'throws with true number in first argument')
   t.throws(f({}, {}), err, 'throws with object in first argument')
   t.throws(f([], {}), err, 'throws with array in first argument')
   t.throws(f(unit, {}), err, 'throws with function in first argument')
+  t.throws(f('', {}), err, 'throws with empty string in first argument')
+  t.throws(f(1.265, {}), err, 'throws with float in first argument')
 
   const key = 'something'
   const val = 'thirty-six'
-  const obj = { [key]: val }
   const arr = [ 1, 2, 3 ]
 
   t.equals(hasProp(key, undefined), false, 'returns false for undefined')
   t.equals(hasProp(key, null), false, 'returns false for null')
+  t.equals(hasProp(key, NaN), false, 'returns false for NaN')
   t.equals(hasProp(key, 0), false, 'returns false for falsey number')
   t.equals(hasProp(key, 1), false, 'returns false for truthy number')
   t.equals(hasProp(key, ''), false, 'returns false for falsey string')
   t.equals(hasProp(key, 'string'), false, 'returns false for truthy string')
 
-  t.equals(hasProp(key, obj), true, 'returns true when key exists on object')
+  t.equals(hasProp(key, { [key]: val }), true, 'returns true when key exists on object')
   t.equals(hasProp(key, {}), false, 'returns false when key does not exist on object')
 
   t.equals(hasProp(2, arr), true, 'returns true when index exists in array')

--- a/src/predicates/hasProp.spec.js
+++ b/src/predicates/hasProp.spec.js
@@ -9,40 +9,61 @@ const unit = require('../core/_unit')
 const hasProp = require('./hasProp')
 
 test('hasProp function', t => {
-  const f = bindFunc(hasProp)
+  const fn = hasProp('a')
 
   t.ok(isFunction(hasProp), 'is a function')
 
+  t.equals(fn(undefined), false, 'returns false for undefined')
+  t.equals(fn(null), false, 'returns false for null')
+  t.equals(fn(NaN), false, 'returns false for NaN')
+
+  t.end()
+})
+
+test('hasProp errors', t => {
+  const fn = bindFunc(hasProp)
+
   const err = /hasProp: Non-empty String or Integer required for first argument/
-  t.throws(f(undefined, {}), err, 'throws with undefined in first argument')
-  t.throws(f(null, {}), err, 'throws with null in first argument')
-  t.throws(f(NaN, {}), err, 'throws with NaN in first argument')
-  t.throws(f(false, {}), err, 'throws with false in first argument')
-  t.throws(f(true, {}), err, 'throws with true number in first argument')
-  t.throws(f({}, {}), err, 'throws with object in first argument')
-  t.throws(f([], {}), err, 'throws with array in first argument')
-  t.throws(f(unit, {}), err, 'throws with function in first argument')
-  t.throws(f('', {}), err, 'throws with empty string in first argument')
-  t.throws(f(1.265, {}), err, 'throws with float in first argument')
+  t.throws(fn(undefined, {}), err, 'throws with undefined in first argument')
+  t.throws(fn(null, {}), err, 'throws with null in first argument')
+  t.throws(fn(NaN, {}), err, 'throws with NaN in first argument')
+  t.throws(fn(false, {}), err, 'throws with false in first argument')
+  t.throws(fn(true, {}), err, 'throws with true number in first argument')
+  t.throws(fn({}, {}), err, 'throws with object in first argument')
+  t.throws(fn([], {}), err, 'throws with array in first argument')
+  t.throws(fn(unit, {}), err, 'throws with function in first argument')
+  t.throws(fn('', {}), err, 'throws with empty string in first argument')
+  t.throws(fn(1.265, {}), err, 'throws with float in first argument')
 
-  const key = 'something'
-  const val = 'thirty-six'
-  const arr = [ 1, 2, 3 ]
+  t.end()
+})
 
-  t.equals(hasProp(key, undefined), false, 'returns false for undefined')
-  t.equals(hasProp(key, null), false, 'returns false for null')
-  t.equals(hasProp(key, NaN), false, 'returns false for NaN')
-  t.equals(hasProp(key, 0), false, 'returns false for falsey number')
-  t.equals(hasProp(key, 1), false, 'returns false for truthy number')
-  t.equals(hasProp(key, ''), false, 'returns false for falsey string')
-  t.equals(hasProp(key, 'string'), false, 'returns false for truthy string')
+test('hasProp object traversal', t => {
+  const fn = hasProp('a')
 
-  t.equals(hasProp(key, { [key]: val }), true, 'returns true when key exists on object')
-  t.equals(hasProp(key, {}), false, 'returns false when key does not exist on object')
+  t.equals(fn({ a: 10 }), true, 'returns true when key exists on object')
+  t.equals(fn({ a: null }), true, 'returns true when key exists on object with a null value')
+  t.equals(fn({ a: NaN }), true, 'returns true when key exists on object with a NaN value')
 
-  t.equals(hasProp(2, arr), true, 'returns true when index exists in array')
-  t.equals(hasProp('1', arr), true, 'returns true when string index exists in array')
-  t.equals(hasProp(-1, arr), false, 'returns false when index does not exist in array')
+  t.equals(fn({ b: 10 }), false, 'returns false when key does not exist on object')
+  t.equals(fn({ a: undefined }), false, 'returns false when key exists on object with undefined value')
+
+  t.end()
+})
+
+test('hasProp array traversal', t => {
+  const fn = hasProp(1)
+  const string = hasProp('1')
+
+  const value = 0
+
+  t.equals(fn([ 10, 0 ]), true, 'returns true when index exists in array')
+  t.equals(string([ 0, false ]), true, 'returns true when string index exists in array')
+  t.equals(fn([ 0, null ]), true, 'returns true when string index exists in array with null value')
+  t.equals(fn([ 0, NaN ]), true, 'returns true when string index exists in array with NaN value')
+
+  t.equals(hasProp(1, [ value ]), false, 'returns false when index does not exist in array')
+  t.equals(fn([ 0, undefined ]), false, 'returns false when index exists in array with undefined value')
 
   t.end()
 })

--- a/src/predicates/hasPropPath.js
+++ b/src/predicates/hasPropPath.js
@@ -17,11 +17,12 @@ function hasPropPath(keys, target) {
     )
   }
 
-  if (isNil(target)) {
+  if(isNil(target)) {
     return false
   }
 
   let value = target
+
   for(let i = 0; i < keys.length; i++) {
     const key = keys[i]
 
@@ -31,13 +32,16 @@ function hasPropPath(keys, target) {
       )
     }
 
+    if(isNil(value)) {
+      return false
+    }
+
     value = value[key]
 
     if(!isDefined(value)) {
       return false
     }
   }
-
 
   return true
 }

--- a/src/predicates/hasPropPath.js
+++ b/src/predicates/hasPropPath.js
@@ -1,21 +1,19 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
-/** @author Karthik Iyengar (karthikiyengar) */
-/** @author Ian Hofmann-Hicks */
+/** @author Ian Hofmann-Hicks (evil) */
 
 const curry = require('../core/curry')
-const equals = require('../core/equals')
 const isArray = require('../core/isArray')
 const isDefined = require('../core/isDefined')
-const isEmpty  = require('../core/isEmpty')
+const isEmpty = require('../core/isEmpty')
 const isInteger = require('../core/isInteger')
 const isNil = require('../core/isNil')
 const isString = require('../core/isString')
 
-// propPathEq :: [ String | Number ] -> a -> Object -> Boolean
-function propPathEq(keys, value, target) {
+// hasPropPath : [ String | Integer ] -> a -> Boolean
+function hasPropPath(keys, target) {
   if(!isArray(keys)) {
     throw new TypeError(
-      'propPathEq: Array of Non-empty Strings or Integers required for first argument'
+      'hasPropPath: Array of Non-empty Strings or Integers required for first argument'
     )
   }
 
@@ -23,24 +21,25 @@ function propPathEq(keys, value, target) {
     return false
   }
 
-  let acc = target
+  let value = target
   for(let i = 0; i < keys.length; i++) {
     const key = keys[i]
 
     if(!((isString(key) && !isEmpty(key)) || isInteger(key))) {
       throw new TypeError(
-        'propPathEq: Array of Non-empty Strings or Integers required for first argument'
+        'hasPropPath: Array of Non-empty Strings or Integers required for first argument'
       )
     }
 
-    acc = acc[key]
+    value = value[key]
 
-    if(!isDefined(acc)) {
+    if(!isDefined(value)) {
       return false
     }
   }
 
-  return equals(acc, value)
+
+  return true
 }
 
-module.exports = curry(propPathEq)
+module.exports = curry(hasPropPath)

--- a/src/predicates/hasPropPath.spec.js
+++ b/src/predicates/hasPropPath.spec.js
@@ -1,0 +1,67 @@
+const test = require('tape')
+const helpers = require('../test/helpers')
+
+const bindFunc = helpers.bindFunc
+
+const isFunction = require('../core/isFunction')
+const unit = require('../core/_unit')
+
+const hasPropPath = require('./hasPropPath')
+
+test('hasPropPath function', t => {
+  const f = bindFunc(hasPropPath)
+
+  t.ok(isFunction(hasPropPath), 'is a function')
+
+  const err = /hasPropPath: Array of Non-empty Strings or Integers required for first argument/
+  t.throws(f(undefined, {}), err, 'throws with undefined in first argument')
+  t.throws(f(null, {}), err, 'throws with null in first argument')
+  t.throws(f(NaN, {}), err, 'throws with NaN in first argument')
+  t.throws(f(false, {}), err, 'throws with false in first argument')
+  t.throws(f(true, {}), err, 'throws with true number in first argument')
+  t.throws(f('', {}), err, 'throws with falsey string in first argument')
+  t.throws(f('string', {}), err, 'throws with truthy string in first argument')
+  t.throws(f(0, {}), err, 'throws with falsey number in first argument')
+  t.throws(f(1, {}), err, 'throws with truthy number in first argument')
+  t.throws(f({}, {}), err, 'throws with object in first argument')
+  t.throws(f(unit, {}), err, 'throws with function in first argument')
+
+  t.throws(f([ undefined ], {}), err, 'throws with array of undefined in first argument')
+  t.throws(f([ null ], {}), err, 'throws with array of null in first argument')
+  t.throws(f([ NaN ], {}), err, 'throws with array of NaN in first argument')
+  t.throws(f([ false ], {}), err, 'throws with array of false in first argument')
+  t.throws(f([ true ], {}), err, 'throws with array of true number in first argument')
+  t.throws(f([ {} ], {}), err, 'throws with array of object in first argument')
+  t.throws(f([ unit ], {}), err, 'throws with array of function in first argument')
+  t.throws(f([ '' ], {}), err, 'throws with array of empty string in first argument')
+  t.throws(f([ 1.265 ], {}), err, 'throws with array of float in first argument')
+
+  const path = [ 'a', 'b' ]
+  const arr = [ [ 1, 2, 3 ], [ null, NaN, undefined ] ]
+
+  t.equals(hasPropPath(path, undefined), false, 'returns false for undefined')
+  t.equals(hasPropPath(path, null), false, 'returns false for null')
+  t.equals(hasPropPath(path, NaN), false, 'returns false for NaN')
+  t.equals(hasPropPath(path, 0), false, 'returns false for falsey number')
+  t.equals(hasPropPath(path, 1), false, 'returns false for truthy number')
+  t.equals(hasPropPath(path, ''), false, 'returns false for falsey string')
+  t.equals(hasPropPath(path, 'string'), false, 'returns false for truthy string')
+  t.equals(hasPropPath(path, unit), false, 'returns false for function')
+
+  t.equals(hasPropPath(path, { a: { b: 'value' } }), true, 'returns true when key exists on object')
+  t.equals(hasPropPath(path, { a: { b: null } }), true, 'returns true when key does exist on object with null value')
+  t.equals(hasPropPath(path, { a: { b: NaN } }), true, 'returns true when key does exist on object with NaN value')
+
+  t.equals(hasPropPath(path, {}), false, 'returns false when key does not exist on object')
+  t.equals(hasPropPath(path, { a: { b: undefined } }), false, 'returns false when key does exist on object with undefined value')
+
+  t.equals(hasPropPath([ 0, 1 ], arr), true, 'returns true when index exists in array')
+  t.equals(hasPropPath([ 0, '1' ], arr), true, 'returns true when string index exists in array')
+  t.equals(hasPropPath([ 1, 0 ], arr), true, 'returns true when value is null')
+  t.equals(hasPropPath([ 1, 1 ], arr), true, 'returns true when value is NaN')
+
+  t.equals(hasPropPath([ -1 ], arr), false, 'returns false when index does not exist in array')
+  t.equals(hasPropPath([ 1, 2 ], arr), false, 'returns false when value is undefined')
+
+  t.end()
+})

--- a/src/predicates/hasPropPath.spec.js
+++ b/src/predicates/hasPropPath.spec.js
@@ -9,9 +9,24 @@ const unit = require('../core/_unit')
 const hasPropPath = require('./hasPropPath')
 
 test('hasPropPath function', t => {
-  const f = bindFunc(hasPropPath)
+  const fn = hasPropPath([ 'a', 'b' ])
+  const empty = hasPropPath([])
 
   t.ok(isFunction(hasPropPath), 'is a function')
+
+  t.equals(fn(undefined), false, 'returns false for undefined')
+  t.equals(fn(null), false, 'returns false for null')
+  t.equals(fn(NaN), false, 'returns false for NaN')
+
+  t.equals(empty(undefined), false, 'returns false for empty path and undefined')
+  t.equals(empty(null), false, 'returns false for empty path and null')
+  t.equals(empty(NaN), false, 'returns false for empty path and NaN')
+
+  t.end()
+})
+
+test('hasPropPath errors', t => {
+  const f = bindFunc(hasPropPath)
 
   const err = /hasPropPath: Array of Non-empty Strings or Integers required for first argument/
   t.throws(f(undefined, {}), err, 'throws with undefined in first argument')
@@ -31,37 +46,58 @@ test('hasPropPath function', t => {
   t.throws(f([ NaN ], {}), err, 'throws with array of NaN in first argument')
   t.throws(f([ false ], {}), err, 'throws with array of false in first argument')
   t.throws(f([ true ], {}), err, 'throws with array of true number in first argument')
-  t.throws(f([ {} ], {}), err, 'throws with array of object in first argument')
-  t.throws(f([ unit ], {}), err, 'throws with array of function in first argument')
   t.throws(f([ '' ], {}), err, 'throws with array of empty string in first argument')
   t.throws(f([ 1.265 ], {}), err, 'throws with array of float in first argument')
+  t.throws(f([ {} ], {}), err, 'throws with array of object in first argument')
+  t.throws(f([ [ 'key' ] ], {}), err, 'throws with nested arrays in first argument')
+  t.throws(f([ unit ], {}), err, 'throws with array of function in first argument')
 
-  const path = [ 'a', 'b' ]
-  const arr = [ [ 1, 2, 3 ], [ null, NaN, undefined ] ]
+  t.end()
+})
 
-  t.equals(hasPropPath(path, undefined), false, 'returns false for undefined')
-  t.equals(hasPropPath(path, null), false, 'returns false for null')
-  t.equals(hasPropPath(path, NaN), false, 'returns false for NaN')
-  t.equals(hasPropPath(path, 0), false, 'returns false for falsey number')
-  t.equals(hasPropPath(path, 1), false, 'returns false for truthy number')
-  t.equals(hasPropPath(path, ''), false, 'returns false for falsey string')
-  t.equals(hasPropPath(path, 'string'), false, 'returns false for truthy string')
-  t.equals(hasPropPath(path, unit), false, 'returns false for function')
+test('hasPropPath object traversal', t => {
+  const fn = hasPropPath([ 'a', 'b' ])
+  const empty = hasPropPath([])
 
-  t.equals(hasPropPath(path, { a: { b: 'value' } }), true, 'returns true when key exists on object')
-  t.equals(hasPropPath(path, { a: { b: null } }), true, 'returns true when key does exist on object with null value')
-  t.equals(hasPropPath(path, { a: { b: NaN } }), true, 'returns true when key does exist on object with NaN value')
+  t.equals(fn({ a: { b: 0 } }), true, 'returns true when keypath exists')
+  t.equals(fn({ a: { b: null } }), true, 'returns true when keypath exists with null value')
+  t.equals(fn({ a: { b: NaN } }), true, 'returns true when keypath exists with NaN value')
 
-  t.equals(hasPropPath(path, {}), false, 'returns false when key does not exist on object')
-  t.equals(hasPropPath(path, { a: { b: undefined } }), false, 'returns false when key does exist on object with undefined value')
+  t.equals(fn({ a: { c: 0 } }), false, 'returns false when keypath does not exist')
+  t.equals(fn({ a: { b: undefined } }), false, 'returns false when key does exist on object with undefined value')
 
-  t.equals(hasPropPath([ 0, 1 ], arr), true, 'returns true when index exists in array')
-  t.equals(hasPropPath([ 0, '1' ], arr), true, 'returns true when string index exists in array')
-  t.equals(hasPropPath([ 1, 0 ], arr), true, 'returns true when value is null')
-  t.equals(hasPropPath([ 1, 1 ], arr), true, 'returns true when value is NaN')
+  t.equals(fn({ a: undefined }), false, 'returns false when keypath contains an undefined')
+  t.equals(fn({ a: null }), false, 'returns false when keypath contains a null value')
+  t.equals(fn({ a: NaN }), false, 'returns false when keypath contains a NaN value')
 
-  t.equals(hasPropPath([ -1 ], arr), false, 'returns false when index does not exist in array')
-  t.equals(hasPropPath([ 1, 2 ], arr), false, 'returns false when value is undefined')
+  t.equals(empty({ a: 0 }), true, 'returns true when path is empty')
+
+  t.end()
+})
+
+test('hasPropPath array traversal', t => {
+  const value = false
+  const fn = hasPropPath([ 0, '1' ])
+
+  t.equals(fn([ [ 0, value ] ]), true, 'returns true when index exists')
+  t.equals(fn([ [ 0, null ] ]), true, 'returns true when index exists with null')
+  t.equals(fn([ [ 0, NaN ] ]), true, 'returns true when index exists with NaN')
+
+  t.equals(fn([ [ '' ] ]), false, 'returns false when index does not exist')
+  t.equals(fn([ [ 0, undefined ] ]), false, 'returns false when value is undefined')
+
+  t.equals(fn([ undefined ]), false, 'returns the default value when key path contains a null')
+  t.equals(fn([ null ]), false, 'returns the default value when key path contains a null')
+  t.equals(fn([ NaN ]), false, 'returns the default value when key path contains a NaN')
+
+  t.end()
+})
+
+test('hasPropPath mixed traversal', t => {
+  const fn = hasPropPath([ 'a', 1 ])
+
+  t.equals(fn({ a: [ 99, 0 ] }), true, 'returns true when found on mixed path')
+  t.equals(fn({ b: NaN }), false, 'returns false when not found on mixed path')
 
   t.end()
 })

--- a/src/predicates/propEq.js
+++ b/src/predicates/propEq.js
@@ -3,14 +3,27 @@
 
 const curry = require('../core/curry')
 const equals = require('../core/equals')
-const isObject = require('../core/isObject')
+const isDefined = require('../core/isDefined')
+const isEmpty = require('../core/isEmpty')
+const isInteger = require('../core/isInteger')
+const isNil = require('../core/isNil')
+const isString = require('../core/isString')
 
-// propEq: (String | Number) -> a -> Object -> Boolean
+// propEq: (String | Integer) -> a -> b -> Boolean
 function propEq(key, value, x) {
-  if (!isObject(x)) {
-    throw new TypeError('propEq: Object required for third argument')
+  if(!((isString(key) && !isEmpty(key)) || isInteger(key))) {
+    throw new TypeError(
+      'propEq: Non-empty String or Integer required for first argument'
+    )
   }
-  return equals(x[key], value)
+
+  if(isNil(x)) {
+    return false
+  }
+
+  const target = x[key]
+
+  return isDefined(target) && equals(target, value)
 }
 
 module.exports = curry(propEq)

--- a/src/predicates/propEq.spec.js
+++ b/src/predicates/propEq.spec.js
@@ -7,12 +7,19 @@ const unit = require('../core/_unit')
 const propEq = require('./propEq')
 
 test('propEq function', t => {
-  const key = 'something'
-  const val = 'thirty-six'
-
-  const fn = bindFunc(x => propEq(x, val, key))
+  const fn = propEq('a')
 
   t.ok(isFunction(propEq), 'is a function')
+
+  t.equals(fn(null, null), false, 'returns false when target is null')
+  t.equals(fn(NaN, NaN), false, 'returns false when target is NaN')
+  t.equals(fn(undefined, undefined), false, 'returns false when target is undefined')
+
+  t.end()
+})
+
+test('propEq errors', t => {
+  const fn = bindFunc(x => propEq(x, 'val', 'key'))
 
   const err = /propEq: Non-empty String or Integer required for first argument/
   t.throws(fn(undefined), err, 'throws with undefined as first argument')
@@ -26,29 +33,36 @@ test('propEq function', t => {
   t.throws(fn([]), err, 'throws with Array as first argument')
   t.throws(fn(unit), err, 'throws with Function as first argument')
 
-  t.equals(propEq(key, val, null), false, 'returns false when target is null')
-  t.equals(propEq(key, val, NaN), false, 'returns false when target is NaN')
-  t.equals(propEq(key, val, undefined), false, 'returns false when target is undefined')
+  t.end()
+})
 
-  t.equals(propEq(key, val, {}), false, 'returns false when value does not exist on object')
-  t.equals(propEq(key, true, { [key]: false }), false, 'returns false when values are not equal')
-  t.equals(propEq(key, undefined, { [key]: undefined }), false, 'returns false when undefined compared')
+test('propEq object traversal', t => {
+  const fn = propEq('a')
 
-  t.equals(propEq(key, 42, { [key]: 42 }), true, 'returns true when value exists on object')
-  t.equals(propEq(key, null, { [key]: null }), true, 'returns true when null compared')
-  t.equals(propEq(key, NaN, { [key]: NaN }), true, 'returns true when NaN compared')
-  t.equals(propEq(key, { a: 32 }, { [key]: { a: 32 } }), true, 'returns true when a deep matching object exists on object')
+  t.equals(fn({ b: 32 }, { a: { b: 32 } }), true, 'returns true when value exists on object')
+  t.equals(fn(null, { a: null }), true, 'returns true when null compared')
+  t.equals(fn(NaN, { a: NaN }), true, 'returns true when NaN compared')
 
-  const arr = [ 97, null, NaN, undefined, { a: [ 'string' ] } ]
+  t.equals(fn(3, { b: 3 }), false, 'returns false when value does not exist on object')
+  t.equals(fn(true, { a: false }), false, 'returns false when values are not equal')
+  t.equals(fn(undefined, { a: undefined }), false, 'returns false when undefined compared')
 
-  t.equals(propEq(5, val, arr), false, 'returns false when value does not exist on object')
-  t.equals(propEq(0, '97', arr), false, 'returns false when values are not equal')
-  t.equals(propEq(3, undefined, arr), false, 'returns false when undefined compared')
+  t.end()
+})
 
-  t.equals(propEq(0, 97, arr), true, 'returns true when value exists on object')
-  t.equals(propEq(1, null, arr), true, 'returns true when null compared')
-  t.equals(propEq(2, NaN, arr), true, 'returns true when NaN compared')
-  t.equals(propEq(4, { a: [ 'string' ] }, arr), true, 'returns true when a deep matching object exists on object')
+test('propEq array traversal', t => {
+  const fn = propEq(1)
+  const string = propEq('1')
+
+  t.equals(fn(false, [ undefined, false ]), true, 'returns true when index found is equal to value')
+  t.equals(string(false, [ undefined, false ]), true, 'returns true when string index found is equal to value')
+  t.equals(fn({ a: [ undefined ] }, [ false, { a: [ undefined ] } ]), true, 'returns true when a deep matching object exists on object')
+  t.equals(fn(null, [ 0, null ]), true, 'returns true when found null compared')
+  t.equals(fn(NaN, [ '', NaN ]), true, 'returns true when found NaN compared')
+
+  t.equals(fn('', [ '' ]), false, 'returns false when value does not exist on object')
+  t.equals(fn('97', [ false, 97 ]), false, 'returns false when values are not equal')
+  t.equals(fn(undefined, [ NaN, undefined ]), false, 'returns false when undefined compared')
 
   t.end()
 })

--- a/src/predicates/propPathEq.js
+++ b/src/predicates/propPathEq.js
@@ -19,7 +19,7 @@ function propPathEq(keys, value, target) {
     )
   }
 
-  if (isNil(target)) {
+  if(isNil(target)) {
     return false
   }
 
@@ -31,6 +31,10 @@ function propPathEq(keys, value, target) {
       throw new TypeError(
         'propPathEq: Array of Non-empty Strings or Integers required for first argument'
       )
+    }
+
+    if(isNil(acc)) {
+      return false
     }
 
     acc = acc[key]

--- a/src/predicates/propPathEq.spec.js
+++ b/src/predicates/propPathEq.spec.js
@@ -60,7 +60,6 @@ test('propPathEq object traversal', t => {
   t.equals(fn('', { a: { b: '' } }), true, 'returns true when keypath found and values are equal')
   t.equals(fn(null, { a: { b: null } }), true, 'returns true when comparing to null values that are present')
   t.equals(fn(NaN, { a: { b: NaN } }), true, 'returns true when comparing to NaN values that are present')
-  t.equals(empty({ a: 23 }, { a: 23 }), true, 'returns true when value matchs object to traverse when path is empty')
 
   t.equals(fn(true, { a: { c: true } }), false, 'returns false when keypath not found')
   t.equals(fn('0', { a: { b: 0 } }), false, 'returns false when keypath is found and values are not equal')
@@ -70,6 +69,8 @@ test('propPathEq object traversal', t => {
   t.equals(fn(undefined, { a: undefined }), false, 'returns false when undefined in keypath')
   t.equals(fn(null, { a: null }), false, 'returns false when null in keypath')
   t.equals(fn(NaN, { a: NaN }), false, 'returns false when NaN in keypath')
+
+  t.equals(empty({ a: 23 }, { a: 23 }), true, 'returns true when value matchs object to traverse when path is empty')
 
   t.end()
 })

--- a/src/predicates/propPathEq.spec.js
+++ b/src/predicates/propPathEq.spec.js
@@ -8,38 +8,53 @@ const bindFunc = helpers.bindFunc
 const propPathEq = require('./propPathEq')
 
 test('propPathEq function', t => {
-  const p = bindFunc(propPathEq)
 
   t.ok(isFunction(propPathEq), 'is a function')
 
-  const err = /propPathEq: Array of strings or integers required for first argument/
   const val = 5
 
-  t.throws(p(undefined, val, {}), err, 'throws with undefined in first argument')
-  t.throws(p(null, val, {}), err, 'throws with null in first argument')
-  t.throws(p(0, val, {}), err, 'throws with falsey number in first argument')
-  t.throws(p(1, val, {}), err, 'throws with truthy number in first argument')
-  t.throws(p('', val, {}), err, 'throws with falsey string in first argument')
-  t.throws(p('string', val, {}), err, 'throws with truthy string in first argument')
-  t.throws(p(false, val, {}), err, 'throws with false in first argument')
-  t.throws(p(true, val, {}), err, 'throws with true in first argument')
-  t.throws(p(unit, val, {}), err, 'throws with function in third argument')
-  t.throws(p({}, {}, val, {}), err, 'throws with an object in first argument')
+  const p = bindFunc(propPathEq)
+
+  const err = /propPathEq: Array of Non-empty Strings or Integers required for first argument/
+  t.throws(p(undefined, {}, {}), err, 'throws with undefined in first argument')
+  t.throws(p(null, {}, {}), err, 'throws with null in first argument')
+  t.throws(p(0, {}, {}), err, 'throws with falsey number in first argument')
+  t.throws(p(1, {}, {}), err, 'throws with truthy number in first argument')
+  t.throws(p('', {}, {}), err, 'throws with falsey string in first argument')
+  t.throws(p('string', {}, {}), err, 'throws with truthy string in first argument')
+  t.throws(p(false, {}, {}), err, 'throws with false in first argument')
+  t.throws(p(true, {}, {}), err, 'throws with true in first argument')
+  t.throws(p(unit, {}, {}), err, 'throws with function in first argument')
+  t.throws(p({}, {}, {}), err, 'throws with an object in first argument')
+
+  t.throws(p([ undefined ], {}, {}), err, 'throws with undefined in first argument array')
+  t.throws(p([ null ], {}, {}), err, 'throws with null in first argument array')
+  t.throws(p([ NaN ], {}, {}), err, 'throws with NaN in first argument array')
+  t.throws(p([ false ], {}, {}), err, 'throws with false in first argument array')
+  t.throws(p([ true ], {}, {}), err, 'throws with true in first argument array')
+  t.throws(p([ 1.2345 ], {}, {}), err, 'throws with float in first argument array')
+  t.throws(p([ '' ], {}, {}), err, 'throws with empty string in first argument array')
+  t.throws(p([ unit ], {}, {}), err, 'throws with function in first argument array')
+  t.throws(p([ [] ], {}, {}), err, 'throws with Array in first argument array')
+  t.throws(p([ {} ], {}, {}), err, 'throws with Object in first argument array')
 
   const obj = { some: { key: val, null: null, nan: NaN, undefined: undefined } }
+
   const goodPath = [ 'some', 'key' ]
   const badPath = [ 'this', 'is', 'really', 'bad' ]
 
   t.equals(propPathEq(goodPath, val, obj), true, 'returns true on correct path')
   t.equals(propPathEq([ 'some', 'null' ], null, obj), true, 'returns true when comparing to null values that are present')
   t.equals(propPathEq([ 'some', 'nan' ], NaN, obj), true, 'returns true when comparing to NaN values that are present')
-  t.equals(propPathEq([ 'some', 'undefined' ], undefined, obj), true, 'returns true when comparing to undefined values that are present')
-  t.equals(propPathEq([ 'some', 'wrong', null, {}, [] ], undefined, { some: NaN }), true, 'returns true when comparing early-exited paths with an undefined')
 
   t.equals(propPathEq(badPath, val, obj), false, 'returns false on incorrect path')
   t.equals(propPathEq([ 'some', 'undefined' ], NaN, obj), false, 'returns false for falsey matches (nan)')
   t.equals(propPathEq([ 'some', 'null' ], NaN, obj), false, 'returns false for falsey matches (null)')
-  t.equals(propPathEq([ 'some', 'undefined' ], null, obj), false, 'returns false for falsey matches (undefined)')
+  t.equals(propPathEq([ 'some', 'undefined' ], undefined, obj), false, 'returns false when comparing to undefined values that are present')
+  t.equals(propPathEq([ 'some', 'wrong', null, {}, [] ], undefined, { some: NaN }), false, 'returns false when comparing early-exited paths with an undefined')
+  t.equals(propPathEq([ 'a' ], val, undefined), false, 'returns false with undefined as third argument')
+  t.equals(propPathEq([ 'a' ], val, null), false, 'returns false with null as third argument')
+  t.equals(propPathEq([ 'a' ], val, NaN), false, 'returns false with NaN as third argument')
 
   t.end()
 })

--- a/src/test/LastMonoid.js
+++ b/src/test/LastMonoid.js
@@ -13,7 +13,7 @@ function LastMonoid(x) {
     concat: identity,
     valueOf: constant(x),
     type: _type,
-    '@@type': typeString
+    ['@@type']: typeString
   }
 }
 

--- a/src/test/MockCrock.js
+++ b/src/test/MockCrock.js
@@ -22,7 +22,7 @@ function MockCrock(x) {
   return {
     valueOf, type, map, ap,
     chain, of, sequence,
-    '@@type': typeString,
+    ['@@type']: typeString,
     traverse, equals
   }
 }


### PR DESCRIPTION
## Rein in for 🌽sistency
![image](https://user-images.githubusercontent.com/3665793/36362651-733e3444-14eb-11e8-97bc-9ccd9c5240c6.png)

A lot of work on the last release was focused around some of the Object Traversal Functions provided by `crocks`. This forced me to look at some inconsistencies  between these functions and how `undefined` values are treated through out the library as a whole.

This PR brings them all inline and has them behave the same way across the board:

* The key/paths MUST be `(String | Integer)` or `[ String | Integer ]`. All functions will throw a `TypeError` if this condition is not met. This lets values like `null` and `undefined` to be rejected and avoid String coercion when traversing keys. A key of 'null' or 'undefined' will HAVE to be supplied to access keys of those names.
* Any traversable value/instance (except `NaN`) can be provided as the object of traversal.  Any non-traversable values (`undefined` and `null`) will behave as though the key/path is not defined. While `NaN` is traversable, due to its special nature, it is treated as non-traversable in this case one case. This allow things like:
```js
// safeLength :: a -> Maybe Number
const safeLength =
  prop('length')

safeLength('nice')
//=> Just 4

safeLength([ 1, 2, 3 ])
//=> Just 3

safeLength((x, y) => x + y)
//=> Just 2

safeLength(4)
//=> Nothing
```
* All values in a defined key/path will be treated as defined, except for `undefined`. When a valid key/path to an `undefined` value exists, it will be treated as not being defined. This matches the theme of `undefined` throughout the library as a whole. So these are valid:
```js
const data = { 
  a: {
    null: null,
    nan: NaN
  }
}

hasPropPath([ 'a', 'null' ], data)
//=> true

propPath([ 'a', 'nan' ], data)
//=>Just NaN
```
* All deep path traversals will use a `for` loop to allow for early exit on large path lists. It is more imperative, but will save those few extra cycles.

Also this adds the function: `hasPropPath` just to round out `hasProp`.