### PR TITLE
Allow `sequence` and `traverse` to accept an `Applicatve TypeRep`

### DIFF
--- a/docs/src/pages/docs/crocks/Maybe.md
+++ b/docs/src/pages/docs/crocks/Maybe.md
@@ -586,14 +586,16 @@ fullName({ first: 'Lizzy' })
 #### sequence
 
 ```haskell
-Applicative f => Maybe (f a) ~> (a -> f a) -> f (Maybe a)
+Applicative TypeRep t, Apply f => Maybe (f a) ~> (t | (b -> f b)) -> f (Maybe a)
 ```
 
-When an instance of `Maybe` wraps a possible `Applicative` instance, `sequence`
-can be used to "swap" the "type sequence". `sequence` requires that the `of`,
-or `Applicative` function of the wrapped `Applicative` instance is provided for
-the case of when the `Maybe` instance is a `Nothing`. `sequence` can be derived
-from [`traverse`](#traverse) by passing it an `identity` function (`x => x`).
+When an instance of `Maybe` wraps an `Apply` instance, `sequence` can be used to
+swap the type sequence. `sequence` requires either an `Applicative TypeRep` or
+an `Apply` returning function is provided for its argument. This will be used in
+the case that the `Maybe` instance is a `Nothing`.
+
+`sequence` can be derived from [`traverse`](#traverse) by passing it an
+`identity` function (`x => x`).
 
 ```javascript
 import Maybe from 'crocks/Maybe'
@@ -605,7 +607,7 @@ const { Nothing, Just } = Maybe
 
 // seqId :: Maybe Identity a -> Identity Maybe a
 const seqId =
-  sequence(Identity.of)
+  sequence(Identity)
 
 seqId(Just(Identity(34)))
 //=> Identity Just 34
@@ -617,17 +619,19 @@ seqId(Nothing())
 #### traverse
 
 ```haskell
-Applicative f => Maybe a ~> ((a -> f a), (a -> f b)) -> f Maybe b
+Applicative TypeRep t, Apply f => Maybe a ~> ((t | (c -> f c)), (a -> f b)) -> f Maybe b
 ```
 
-Used to apply the "effect" of an `Applicative` to a value inside of a `Maybe`,
-`traverse`, combines both the "effects" of the `Applicative` and the `Maybe` by
-returning a new instance of the `Applicative` wrapping the result of the
-`Applicative`s "effect" on the value in the `Maybe`.
+Used to apply the "effect" of an `Apply` to a value inside of a `Maybe`,
+`traverse` combines both the "effects" of the `Apply` and the `Maybe` by
+returning a new instance of the `Apply`, wrapping the result of the
+`Apply`s "effect" on the value in the `Maybe`.
 
-`traverse` requires the `of` function of the target `Applicative` and a function
-that is used to apply the `Applicative` to the value inside of the `Maybe`. Both
-functions must return an instance of the `Applicative`.
+`traverse` requires either an `Applicative TypeRep` or an `Apply` returning
+function as its first argument and a function that is used to apply the "effect"
+of the target  `Apply` to the value inside of the `Maybe`. This will be used in
+the case that the `Maybe` instance is a `Nothing`. Both arguments must provide
+an instance of the target `Apply`.
 
 ```javascript
 import IO from 'crocks/IO'
@@ -637,6 +641,7 @@ import isNumber from 'crocks/predicates/isNumber'
 import safe from 'crocks/Maybe/safe'
 import traverse from 'crocks/pointfree/traverse'
 
+// someGlobal :: Number
 let someGlobal = 10
 
 // addToGlobal :: Number -> IO Number
@@ -647,7 +652,7 @@ const addToGlobal = x => IO(function() {
 
 // safeAddToGlobal :: a -> IO (Maybe Number)
 const safeAddToGlobal = compose(
-  traverse(IO.of, addToGlobal),
+  traverse(IO, addToGlobal),
   safe(isNumber)
 )
 

--- a/docs/src/pages/docs/functions/pointfree-functions.md
+++ b/docs/src/pages/docs/functions/pointfree-functions.md
@@ -81,11 +81,11 @@ accepted Datatype):
 | `run` | `m a -> b` | `crocks/pointfree` |
 | `runWith` | `a -> m -> b` | `crocks/pointfree` |
 | `second` | `m (a -> b) -> m (Pair c a -> Pair c b)` | `crocks/pointfree` |
-| `sequence` | `Applicative f => (b -> f b) -> m (f a) -> f (m a)` | `crocks/pointfree` |
+| `sequence` | <code>Applicative TypeRep t, Apply f => (t &#124; (b -> f b)) -> m (f a) -> f (m a)</code> | `crocks/pointfree` |
 | `snd` | `m a b -> b` | `crocks/Pair` |
 | `swap` | `(c -> d) -> (a -> b) -> m c a -> m b d` | `crocks/pointfree` |
 | `tail` | `m a -> Maybe (m a)` | `crocks/pointfree` |
-| `traverse` | `Applicative f => (c -> f c) -> (a -> f b) -> m (f a) -> f (m b)` | `crocks/pointfree` |
+| `traverse` | <code>Applicative TypeRep t, Apply f => (t &#124; (c -> f c)) -> (a -> f b) -> m (f a) -> f (m b)</code> | `crocks/pointfree` |
 | `valueOf` | `m a -> a` | `crocks/pointfree` |
 
 ##### Datatypes

--- a/src/Either/index.js
+++ b/src/Either/index.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const VERSION = 1
+const VERSION = 2
 
 const _defineUnion = require('../core/defineUnion')
 const _equals = require('../core/equals')
@@ -12,13 +12,16 @@ const type = require('../core/types').type('Either')
 const _type = require('../core/types').typeFn(type(), VERSION)
 const fl = require('../core/flNames')
 
+const apOrFunc = require('../core/apOrFunc')
 const compose = require('../core/compose')
 const isArray = require('../core/isArray')
+const isApplicative = require('../core/isApplicative')
 const isApply = require('../core/isApply')
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
 
-const constant = x => () => x
+const constant =
+  x => () => x
 
 const _either =
   _defineUnion({ Left: [ 'a' ], Right: [ 'b' ] })
@@ -39,7 +42,7 @@ function runSequence(x) {
     throw new TypeError('Either.sequence: Must wrap an Apply')
   }
 
-  return x.map(v => Either.of(v))
+  return x.map(_of)
 }
 
 function Either(u) {
@@ -167,10 +170,15 @@ function Either(u) {
     return m
   }
 
-  function sequence(af) {
-    if(!isFunction(af)) {
-      throw new TypeError('Either.sequence: Apply returning function required')
+  function sequence(f) {
+    if(!(isApplicative(f) || isFunction(f))) {
+      throw new TypeError(
+        'Either.sequence: Applicative TypeRep or Apply returning function required'
+      )
     }
+
+    const af =
+      apOrFunc(f)
 
     return either(
       compose(af, Either.Left),
@@ -178,20 +186,34 @@ function Either(u) {
     )
   }
 
-  function traverse(af, f) {
-    if(!isFunction(f) || !isFunction(af)) {
-      throw new TypeError('Either.traverse: Apply returning functions required for both arguments')
+  function traverse(f, fn) {
+    if(!(isApplicative(f) || isFunction(f))) {
+      throw new TypeError(
+        'Either.traverse: Applicative TypeRep or Apply returning function required for first argument'
+      )
     }
 
-    const m = either(compose(af, Either.Left), f)
+    if(!isFunction(fn)) {
+      throw new TypeError(
+        'Either.traverse: Apply returning function required for second argument'
+      )
+    }
+
+    const af =
+      apOrFunc(f)
+
+    const m =
+      either(compose(af, Either.Left), fn)
 
     if(!(isApply(m) || isArray(m))) {
-      throw new TypeError('Either.traverse: Both functions must return an Apply')
+      throw new TypeError(
+        'Either.traverse: Both functions must return an Apply of the same type'
+      )
     }
 
     return either(
       constant(m),
-      constant(m.map(v => Either.of(v)))
+      constant(m.map(_of))
     )
   }
 

--- a/src/Identity/index.js
+++ b/src/Identity/index.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const VERSION = 1
+const VERSION = 2
 
 const _equals = require('../core/equals')
 const _implements = require('../core/implements')
@@ -13,6 +13,7 @@ const fl = require('../core/flNames')
 
 const isArray = require('../core/isArray')
 const isApply = require('../core/isApply')
+const isApplicative = require('../core/isApplicative')
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
 
@@ -79,30 +80,42 @@ function Identity(x) {
     return m
   }
 
-  function sequence(af) {
-    if(!isFunction(af)) {
-      throw new TypeError('Identity.sequence: Apply function required')
+  function sequence(f) {
+    if(!(isApplicative(f) || isFunction(f))) {
+      throw new TypeError(
+        'Identity.sequence: Applicative TypeRep or Apply returning function required'
+      )
     }
 
-    else if(!(isApply(x) || isArray(x))) {
+    if(!(isApply(x) || isArray(x))) {
       throw new TypeError('Identity.sequence: Must wrap an Apply')
     }
 
-    return x.map(v => Identity(v))
+    return x.map(_of)
   }
 
-  function traverse(af, f) {
-    if(!isFunction(f) || !isFunction(af)) {
-      throw new TypeError('Identity.traverse: Apply returning functions required for both arguments')
+  function traverse(f, fn) {
+    if(!(isApplicative(f) || isFunction(f))) {
+      throw new TypeError(
+        'Identity.traverse: Applicative TypeRep or Apply returning function required for first argument'
+      )
     }
 
-    const m = f(x)
+    if(!isFunction(fn)) {
+      throw new TypeError(
+        'Identity.traverse: Apply returning functions required for second argument'
+      )
+    }
+
+    const m = fn(x)
 
     if(!(isApply(m) || isArray(m))) {
-      throw new TypeError('Identity.traverse: Both functions must return an Apply')
+      throw new TypeError(
+        'Identity.traverse: Both functions must return an Apply of the same type'
+      )
     }
 
-    return m.map(v => Identity(v))
+    return m.map(_of)
   }
 
   return {

--- a/src/core/Pair.js
+++ b/src/core/Pair.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const VERSION = 2
+const VERSION = 3
 
 const _equals = require('./equals')
 const _implements = require('./implements')
@@ -10,6 +10,7 @@ const type = require('./types').type('Pair')
 const _type = require('./types').typeFn(type(), VERSION)
 const fl = require('./flNames')
 
+const isApplicative = require('./isApplicative')
 const isApply = require('./isApply')
 const isArray = require('./isArray')
 const isFunction = require('./isFunction')
@@ -145,28 +146,41 @@ function Pair(l, r) {
     )
   }
 
-  function sequence(af) {
-    if(!isFunction(af)) {
-      throw new TypeError('Pair.sequence: Apply returning function required')
+  function sequence(f) {
+    if(!(isApplicative(f) || isFunction(f))) {
+      throw new TypeError(
+        'Pair.sequence: Applicative TypeRep or Apply returning function required'
+      )
     }
 
     if(!(isApply(r) || isArray(r))) {
-      throw new TypeError('Pair.sequence: Must wrap an Apply in the second')
+      throw new TypeError(
+        'Pair.sequence: Must wrap an Apply in the second'
+      )
     }
 
     return r.map(v => Pair(l, v))
-
   }
 
-  function traverse(af, f) {
-    if(!isFunction(f) || !isFunction(af)) {
-      throw new TypeError('Pair.traverse: Apply returning functions required for both arguments')
+  function traverse(f, fn) {
+    if(!(isApplicative(f) || isFunction(f))) {
+      throw new TypeError(
+        'Pair.traverse: Applicative TypeRep or Apply returning function required for first argument'
+      )
     }
 
-    const m = f(r)
+    if(!isFunction(fn)) {
+      throw new TypeError(
+        'Pair.traverse: Apply returning function required for second argument'
+      )
+    }
+
+    const m = fn(r)
 
     if(!(isApply(m) || isArray(m))) {
-      throw new TypeError('Pair.traverse: Both functions must return an Apply of the same type')
+      throw new TypeError(
+        'Pair.traverse: Both functions must return an Apply of the same type'
+      )
     }
 
     return m.map(v => Pair(l, v))

--- a/src/core/apOrFunc.js
+++ b/src/core/apOrFunc.js
@@ -1,0 +1,9 @@
+/** @license ISC License (c) copyright 2018 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const isApplicative = require('./isApplicative')
+
+const apOrFunc = af => x =>
+  isApplicative(af) ? af.of(x) : af(x)
+
+module.exports = apOrFunc

--- a/src/core/apOrFunc.spec.js
+++ b/src/core/apOrFunc.spec.js
@@ -1,0 +1,33 @@
+const test = require('tape')
+const sinon = require('sinon')
+
+const isFunction = require('./isFunction')
+const apOrFunc = require('./apOrFunc')
+
+const MockCrock = require('../test/MockCrock')
+
+const oldFn = MockCrock.of
+
+test('apOrFunc internal', t => {
+  t.ok(isFunction(apOrFunc), 'is a function')
+
+  const f = sinon.spy()
+  MockCrock.of = sinon.spy()
+
+  const fn = apOrFunc(f)
+  const rep = apOrFunc(MockCrock)
+
+  t.ok(isFunction(fn), 'calling with a function returns a function')
+  t.ok(isFunction(rep), 'calling with a TypeRep returns a function')
+
+  fn('func')
+  rep('typerep')
+
+  t.ok(f.calledWith('func'), 'calls the function, passing the argument')
+  t.ok(MockCrock.of.calledWith('typerep'), 'calls `of` on the TypeRep, passing the argument')
+
+  // reset mock
+  MockCrock.of = oldFn
+
+  t.end()
+})

--- a/src/core/array.js
+++ b/src/core/array.js
@@ -5,6 +5,7 @@ const isApply = require('./isApply')
 const isArray = require('./isArray')
 const isFunction = require('./isFunction')
 const isSameType = require('./isSameType')
+const apOrFunc = require('./apOrFunc')
 
 const identity = x => x
 
@@ -16,7 +17,7 @@ function runTraverse(name, fn) {
     const m = fn(x)
 
     if(!((isApply(acc) || isArray(acc)) && isSameType(acc, m))) {
-      throw new TypeError(`Array.${name}: Must wrap Applys`)
+      throw new TypeError(`Array.${name}: Must wrap Applys of the same type`)
     }
 
     if(isArray(m)) {
@@ -55,11 +56,13 @@ function chain(f, m) {
   }, [])
 }
 
-function sequence(af, m) {
-  return m.reduceRight(runTraverse('sequence', identity), af([]))
+function sequence(f, m) {
+  const fn = apOrFunc(f)
+  return m.reduceRight(runTraverse('sequence', identity), fn([]))
 }
 
-function traverse(af, fn, m) {
+function traverse(f, fn, m) {
+  const af = apOrFunc(f)
   return m.reduceRight(runTraverse('traverse', fn), af([]))
 }
 

--- a/src/pointfree/sequence.js
+++ b/src/pointfree/sequence.js
@@ -4,11 +4,14 @@
 const array = require('../core/array')
 const curry = require('../core/curry')
 const isArray = require('../core/isArray')
+const isApplicative = require('../core/isApplicative')
 const isFunction = require('../core/isFunction')
 
 function sequence(af, m) {
-  if(!isFunction(af)) {
-    throw new TypeError('sequence: Apply function required for first argument')
+  if(!(isApplicative(af) || isFunction(af))) {
+    throw new TypeError(
+      'sequence: Applicative TypeRep or Apply returning function required for first argument'
+    )
   }
 
   if(m && isFunction(m.sequence)) {

--- a/src/pointfree/sequence.spec.js
+++ b/src/pointfree/sequence.spec.js
@@ -7,6 +7,7 @@ const bindFunc = helpers.bindFunc
 
 const isArray = require('../core/isArray')
 const isFunction = require('../core/isFunction')
+const isSameType = require('../core/isSameType')
 const unit = require('../core/_unit')
 
 const constant = x => () => x
@@ -20,7 +21,7 @@ test('sequence pointfree', t => {
 
   t.ok(isFunction(seq), 'is a function')
 
-  const err = /sequence: Apply function required for first argument/
+  const err = /sequence: Applicative TypeRep or Apply returning function required for first argument/
   t.throws(seq(undefined, m), err, 'throws if first arg is undefined')
   t.throws(seq(null, m), err, 'throws if first arg is null')
   t.throws(seq(0, m), err, 'throws if first arg is a falsey number')
@@ -43,9 +44,6 @@ test('sequence pointfree', t => {
   t.throws(seq(unit, true), noTrav, 'throws if second arg is true')
   t.throws(seq(unit, {}), noTrav, 'throws if second arg is an object')
 
-  t.doesNotThrow(seq(unit, m), 'allows a function and Traverable')
-  t.doesNotThrow(seq(unit, []), 'allows a function and an Array')
-
   t.end()
 })
 
@@ -66,7 +64,7 @@ test('sequence with Array', t => {
   const outer = sequence(MockCrock.of, [ MockCrock(12), MockCrock(23) ])
   const inner = outer.valueOf()
 
-  t.equal(outer.type(), 'MockCrock', 'outer container is a MockCrock')
+  t.ok(isSameType(MockCrock, outer), 'outer container is a MockCrock')
   t.ok(isArray(inner), 'inner container is an Array')
   t.equal(inner.length, 2, 'inner array maintains structure')
 

--- a/src/pointfree/traverse.js
+++ b/src/pointfree/traverse.js
@@ -3,16 +3,21 @@
 
 const array = require('../core/array')
 const curry = require('../core/curry')
+const isApplicative = require('../core/isApplicative')
 const isArray = require('../core/isArray')
 const isFunction = require('../core/isFunction')
 
 function traverse(af, fn, m) {
-  if(!isFunction(af)) {
-    throw new TypeError('traverse: Apply function required for first argument')
+  if(!(isApplicative(af) || isFunction(af))) {
+    throw new TypeError(
+      'traverse: Applicative TypeRep or Apply returning function required for first argument'
+    )
   }
 
   if(!isFunction(fn)) {
-    throw new TypeError('traverse: Apply returning function required for second argument')
+    throw new TypeError(
+      'traverse: Apply returning function required for second argument'
+    )
   }
 
   if(m && isFunction(m.traverse)) {

--- a/src/pointfree/traverse.spec.js
+++ b/src/pointfree/traverse.spec.js
@@ -7,6 +7,7 @@ const bindFunc = helpers.bindFunc
 
 const isArray = require('../core/isArray')
 const isFunction = require('../core/isFunction')
+const isSameType = require('../core/isSameType')
 const unit = require('../core/_unit')
 
 const constant = x => () => x
@@ -21,7 +22,7 @@ test('traverse pointfree', t => {
 
   t.ok(isFunction(traverse), 'is a function')
 
-  const err = /traverse: Apply function required for first argument/
+  const err = /traverse: Applicative TypeRep or Apply returning function required for first argument/
   t.throws(trav(undefined, unit, m), err, 'throws if first arg is undefined')
   t.throws(trav(null, unit, m), err, 'throws if first arg is null')
   t.throws(trav(0, unit, m), err, 'throws if first arg is a falsey number')
@@ -56,10 +57,6 @@ test('traverse pointfree', t => {
   t.throws(trav(unit, unit, true), noTrav, 'throws if third arg is true')
   t.throws(trav(unit, unit, {}), noTrav, 'throws if third arg is an object')
 
-  t.doesNotThrow(trav(unit, unit, m), 'allows two functions and a Traverable')
-  t.doesNotThrow(trav(unit, unit, []), 'allows two functions and an Array')
-  t.doesNotThrow(trav(MockCrock.of, MockCrock.of, [ 1, 2, 3 ]), 'allows two applicative returning functions and an Array ')
-
   t.end()
 })
 
@@ -83,7 +80,7 @@ test('traverse with Array', t => {
   const outer = traverse(MockCrock.of, f, [ 12, 23 ])
   const inner = outer.valueOf()
 
-  t.equal(outer.type(), 'MockCrock', 'outer container is a MockCrock')
+  t.ok(isSameType(MockCrock, outer), 'outer container is a MockCrock')
   t.ok(isArray(inner), 'inner container is an Array')
   t.same(inner, [ 14, 25 ], 'mapping/lifting function applied to every element')
 


### PR DESCRIPTION
## As we continue down the path to Fantasy Land
![image](https://user-images.githubusercontent.com/3665793/36952967-19fc1abe-1fcb-11e8-9785-e516de1c543c.png)

This is another step in getting us Fantasy Land compliant for `fantasy-land/traverse` and `fantasy-land/ap`. This PR accepts a `crocks` based `Appicative TypeRep` or a `crocks` based `Apply` returning function as the single argument to `sequence` and the first argument to `traverse`. This is needed to account for what the FL spec calls for, but still retains the nimbleness of the `Apply` returning function.

This is the first part of [this issue](https://github.com/evilsoft/crocks/issues/233).

The reason we are locked to `crocks` based in this PR is for a couple reasons that will be addressed in subsequent PRs:
* `isApplicative` uses the `@@implements` implementation on the `TypeRep` which is not part of the FL spec. It also makes sure that `map` and `ap` are defined on instances of the `TypeRep` as you can **really** have just a pointed Functor that is not an Applicative, but still uses `of` for its pointing. This is NOT the case in the current FL spec, so the `isApplicative` function will need to be altered to check if `fantasy-land/of` or `constructor['fantasy-land/of']` exist on the data in question.
* We are using (in `List` and `Array)` the public `ap` method which is not guaranteed but types outside of crocks to behave in what we are calling the unbiased form. We will need to have `fantasy-land/ap` implemented using the current biased form. In order to get `fantasy-land/ap`, we will need to implement the public `applyTo` on all Apply types and map that to `fantasy-land/ap`. Then we can replace the `traverse` and `sequence` implementations in `List` and `Array` to always just use `fantasy-land/ap` and thus removing the :corn:flicts.

***NOTE:*** you will notice that this PR does not accept `Array` as a TypeRep. The next PR for this implementation around the issue will address that and allow one to `traverse(Array, x => [ x + 1 ])`