### PR TITLE
Allow Array Constructor as TypeRep for sequence and traverse

### DIFF
--- a/src/Either/Either.spec.js
+++ b/src/Either/Either.spec.js
@@ -882,9 +882,20 @@ test('Either sequence with Applicative TypeRep', t => {
   t.ok(isSameType(Either, r.valueOf()), 'Provides an inner type of Either')
   t.equal(r.valueOf().either(constant(0), identity), x, 'Either contains original inner value')
 
-  t.ok(isSameType(MockCrock, l), 'MockCrock', 'Provides an outer type of MockCrock')
+  t.ok(isSameType(MockCrock, l), 'Provides an outer type of MockCrock')
   t.ok(isSameType(Either, l.valueOf()), 'Provides an inner type of Either')
   t.equal(l.valueOf().either(identity, constant(0)), 'Left', 'Either contains original Left value')
+
+  const arR = Right([ x ]).sequence(Array)
+  const arL = Left('Left').sequence(Array)
+
+  t.ok(isSameType(Array, arR), 'Provides an outer type of Array')
+  t.ok(isSameType(Either, arR[0]), 'Provides an inner type of Either')
+  t.equal(arR[0].either(constant(0), identity), x, 'Either contains original inner value')
+
+  t.ok(isSameType(Array, arL), 'Provides an outer type of Array')
+  t.ok(isSameType(Either, arL[0]), 'Provides an inner type of Either')
+  t.equal(arL[0].either(identity, constant(0)), 'Left', 'Either contains original Left value')
 
   t.end()
 })
@@ -950,8 +961,7 @@ test('Either traverse errors', t => {
 })
 
 test('Either traverse with Apply function', t => {
-  const Right = Either.Right
-  const Left = Either.Left
+  const { Left, Right } = Either
 
   const x = 98
   const res = 'result'
@@ -985,16 +995,15 @@ test('Either traverse with Apply function', t => {
 })
 
 test('Either traverse with Applicative TypeRep', t => {
-  const Right = Either.Right
-  const Left = Either.Left
+  const { Left, Right } = Either
 
   const x = 98
   const res = 'result'
-  const fn = constant(MockCrock(res))
+  const fn = m => constant(m(res))
 
   const m = MockCrock
-  const r = Right(x).traverse(m, fn)
-  const l = Left('Left').traverse(m, fn)
+  const r = Right(x).traverse(m, fn(MockCrock))
+  const l = Left('Left').traverse(m, fn(MockCrock))
 
   t.ok(isSameType(MockCrock, r), 'Provides an outer type of MockCrock')
   t.ok(isSameType(Either, r.valueOf()), 'Provides an inner type of Either')
@@ -1003,6 +1012,18 @@ test('Either traverse with Applicative TypeRep', t => {
   t.ok(isSameType(MockCrock, l), 'Provides an outer type of MockCrock')
   t.ok(isSameType(Either, l.valueOf()), 'Provides an inner type of Either')
   t.equal(l.valueOf().either(identity, constant(0)), 'Left', 'Either contains original Left value')
+
+  const ar = x => [ x ]
+  const arR = Right(x).traverse(Array, fn(ar))
+  const arL = Left('Left').traverse(Array, fn(ar))
+
+  t.ok(isSameType(Array, arR), 'Provides an outer type of Array')
+  t.ok(isSameType(Either, arR[0]), 'Provides an inner type of Either')
+  t.equal(arR[0].either(constant(0), identity), res, 'Either contains transformed value')
+
+  t.ok(isSameType(Array, arL), 'Provides an outer type of Array')
+  t.ok(isSameType(Either, arL[0]), 'Provides an inner type of Either')
+  t.equal(arL[0].either(identity, constant(0)), 'Left', 'Either contains original Left value')
 
   t.end()
 })

--- a/src/Identity/Identity.spec.js
+++ b/src/Identity/Identity.spec.js
@@ -429,6 +429,12 @@ test('Identity sequence with Applicative TypeRep', t => {
   t.ok(isSameType(Identity, m.valueOf()), 'Provides an inner type of Identity')
   t.equal(m.valueOf().valueOf(), x, 'Identity contains original inner value')
 
+  const arM = Identity([ x ]).sequence(Array)
+
+  t.ok(isSameType(Array, arM), 'Provides an outer type of Array')
+  t.ok(isSameType(Identity, arM[0]), 'Provides an inner type of Identity')
+  t.equal(arM[0].valueOf(), x, 'Identity contains original inner value')
+
   t.end()
 })
 
@@ -501,13 +507,20 @@ test('Identity traverse with Apply function', t => {
 test('Identity traverse with Applicative TypeRep', t => {
   const x = true
   const res = 'result'
-  const fn = constant(MockCrock(res))
+  const fn = m => constant(m(res))
 
-  const m = Identity(x).traverse(MockCrock, fn)
+  const m = Identity(x).traverse(MockCrock, fn(MockCrock))
 
   t.ok(isSameType(MockCrock, m), 'Provides an outer type of MockCrock')
   t.ok(isSameType(Identity, m.valueOf()), 'Provides an inner type of Identity')
   t.equal(m.valueOf().valueOf(), res, 'Identity contains transformed value')
+
+  const ar = x => [ x ]
+  const arM = Identity(x).traverse(Array, fn(ar))
+
+  t.ok(isSameType(Array, arM), 'Provides an outer type of Array')
+  t.ok(isSameType(Identity, arM[0]), 'Provides an inner type of Identity')
+  t.equal(arM[0].valueOf(), res, 'Identity contains transformed value')
 
   t.end()
 })

--- a/src/Result/Result.spec.js
+++ b/src/Result/Result.spec.js
@@ -913,6 +913,17 @@ test('Result sequence with Applicative TypeRep', t => {
   t.ok(isSameType(Result, e.valueOf()), 'Provides an inner type of Result')
   t.equal(e.valueOf().either(identity, constant(0)), 'Err', 'Result contains original Err value')
 
+  const arO = Ok([ x ]).sequence(Array)
+  const arE = Err('Err').sequence(Array)
+
+  t.ok(isSameType(Array, arO), 'Provides an outer type of Array')
+  t.ok(isSameType(Result, arO[0]), 'Provides an inner type of Result')
+  t.equal(arO[0].either(constant(0), identity), x, 'Result contains original inner value')
+
+  t.ok(isSameType(Array, arE), 'Provides an outer type of Array')
+  t.ok(isSameType(Result, arE[0]), 'Provides an inner type of Result')
+  t.equal(arE[0].either(identity, constant(0)), 'Err', 'Result contains original Err value')
+
   t.end()
 })
 
@@ -982,11 +993,11 @@ test('Result traverse with Apply function', t => {
 
   const x = 98
   const res = 'result'
-  const fn = constant(MockCrock(res))
+  const fn = m => constant(m(res))
 
   const f = x => MockCrock(x)
-  const r = Ok(x).traverse(f, fn)
-  const l = Err('Err').traverse(f, fn)
+  const r = Ok(x).traverse(f, fn(MockCrock))
+  const l = Err('Err').traverse(f, fn(MockCrock))
 
   t.ok(isSameType(MockCrock, r), 'Provides an outer type of MockCrock')
   t.ok(isSameType(Result, r.valueOf()), 'Provides an inner type of Result')
@@ -997,12 +1008,12 @@ test('Result traverse with Apply function', t => {
   t.equal(l.valueOf().either(identity, constant(0)), 'Err', 'Result contains original Err value')
 
   const ar = x => [ x ]
-  const arO = Ok(x).traverse(ar, ar)
-  const arE = Err('Err').traverse(ar, ar)
+  const arO = Ok(x).traverse(ar, fn(ar))
+  const arE = Err('Err').traverse(ar, fn(ar))
 
   t.ok(isSameType(Array, arO), 'Provides an outer type of Array')
   t.ok(isSameType(Result, arO[0]), 'Provides an inner type of Result')
-  t.equal(arO[0].either(constant(0), identity), x, 'Result contains original inner value')
+  t.equal(arO[0].either(constant(0), identity), res, 'Result contains original inner value')
 
   t.ok(isSameType(Array, arE), 'Provides an outer type of Array')
   t.ok(isSameType(Result, arE[0]), 'Provides an inner type of Result')
@@ -1017,10 +1028,10 @@ test('Result traverse with Applicative TypeRep', t => {
 
   const x = 98
   const res = false
-  const fn = constant(MockCrock(res))
+  const fn = m => constant(m(res))
 
-  const r = Ok(x).traverse(MockCrock, fn)
-  const l = Err('Err').traverse(MockCrock, fn)
+  const r = Ok(x).traverse(MockCrock, fn(MockCrock))
+  const l = Err('Err').traverse(MockCrock, fn(MockCrock))
 
   t.ok(isSameType(MockCrock, r), 'Provides an outer type of MockCrock')
   t.ok(isSameType(Result, r.valueOf()), 'Provides an inner type of Result')
@@ -1029,6 +1040,18 @@ test('Result traverse with Applicative TypeRep', t => {
   t.ok(isSameType(MockCrock, l), 'Provides an outer type of MockCrock')
   t.ok(isSameType(Result, l.valueOf()), 'Provides an inner type of Result')
   t.equal(l.valueOf().either(identity, constant(0)), 'Err', 'Result contains original Err value')
+
+  const ar = x => [ x ]
+  const arO = Ok(x).traverse(Array, fn(ar))
+  const arE = Err('Err').traverse(Array, fn(ar))
+
+  t.ok(isSameType(Array, arO), 'Provides an outer type of Array')
+  t.ok(isSameType(Result, arO[0]), 'Provides an inner type of Result')
+  t.equal(arO[0].either(constant(0), identity), res, 'Result contains original inner value')
+
+  t.ok(isSameType(Array, arE), 'Provides an outer type of Array')
+  t.ok(isSameType(Result, arE[0]), 'Provides an inner type of Result')
+  t.equal(arE[0].either(identity, constant(0)), 'Err', 'Result contains original Err value')
 
   t.end()
 })

--- a/src/core/List.spec.js
+++ b/src/core/List.spec.js
@@ -693,6 +693,12 @@ test('List sequence with Applicative TypeRep', t => {
   t.ok(isSameType(List, m.valueOf()), 'Provides an inner type of List')
   t.same(m.valueOf().valueOf(), [ x ], 'inner List contains original inner value')
 
+  const ar = List.of([ x ]).sequence(Array)
+
+  t.ok(isSameType(Array, ar), 'Provides an outer type of Array')
+  t.ok(isSameType(List, ar[0]), 'Provides an inner type of List')
+  t.same(ar[0].valueOf(), [ x ], 'inner List contains original inner value')
+
   t.end()
 })
 
@@ -755,13 +761,20 @@ test('List traverse with Apply function', t => {
 test('List traverse with Applicative TypeRep', t => {
   const x = 'string'
   const res = 'result'
-  const fn = constant(MockCrock(res))
+  const fn = m => constant(m(res))
 
-  const m = List.of(x).traverse(MockCrock, fn)
+  const m = List.of(x).traverse(MockCrock, fn(MockCrock))
 
   t.ok(isSameType(MockCrock, m), 'Provides an outer type of MockCrock')
   t.ok(isSameType(List, m.valueOf()), 'Provides an inner type of List')
   t.same(m.valueOf().valueOf(), [ res ], 'inner List contains transformed value')
+
+  const ar = x => [ x ]
+  const arM = List.of(x).traverse(Array, fn(ar))
+
+  t.ok(isSameType(Array, arM), 'Provides an outer type of Array')
+  t.ok(isSameType(List, arM[0]), 'Provides an inner type of List')
+  t.same(arM[0].valueOf(), [ res ], 'inner List contains transformed value')
 
   t.end()
 })

--- a/src/core/Maybe.spec.js
+++ b/src/core/Maybe.spec.js
@@ -692,6 +692,17 @@ test('Maybe sequence with Applicative TypeRep', t => {
   t.ok(isSameType(Maybe, n.valueOf()), 'Provides an inner type of Maybe')
   t.equal(n.valueOf().option('Nothing'), 'Nothing', 'Reports as a Nothing')
 
+  const arS = Maybe.Just([ x ]).sequence(Array)
+  const arN = Maybe.Nothing().sequence(Array)
+
+  t.ok(isSameType(Array, arS), 'Provides an outer type of Array')
+  t.ok(isSameType(Maybe, arS[0]), 'Provides an inner type of Maybe')
+  t.same(arS[0].option('Nothing'), x, 'Maybe contains original inner value')
+
+  t.ok(isSameType(Array, arN), 'Provides an outer type of MockCrock')
+  t.ok(isSameType(Maybe, arN[0]), 'Provides an inner type of Maybe')
+  t.equal(arN[0].option('Nothing'), 'Nothing', 'Reports as a Nothing')
+
   t.end()
 })
 
@@ -788,10 +799,10 @@ test('Maybe traverse with Apply function', t => {
 test('Maybe traverse with Applicative TypeRep', t => {
   const x = 'bubbles'
   const res = 'result'
-  const fn = constant(MockCrock(res))
+  const fn = m => constant(m(res))
 
-  const r = Maybe.Just(x).traverse(MockCrock, fn)
-  const l = Maybe.Nothing().traverse(MockCrock, fn)
+  const r = Maybe.Just(x).traverse(MockCrock, fn(MockCrock))
+  const l = Maybe.Nothing().traverse(MockCrock, fn(MockCrock))
 
   t.ok(isSameType(MockCrock, r), 'Just provides an outer type of MockCrock')
   t.ok(isSameType(Maybe, r.valueOf()), 'Just provides an inner type of Maybe')
@@ -800,6 +811,18 @@ test('Maybe traverse with Applicative TypeRep', t => {
   t.ok(isSameType(MockCrock, l), 'Nothing provides an outer type of MockCrock')
   t.ok(isSameType(Maybe, l.valueOf()), 'Nothing provides an inner type of Maybe')
   t.equal(l.valueOf().option('Nothing'), 'Nothing', 'Maybe is a Nothing')
+
+  const ar = x => [ x ]
+  const arS = Maybe.Just(x).traverse(Array, fn(ar))
+  const arN = Maybe.Nothing().traverse(Array, fn(ar))
+
+  t.ok(isSameType(Array, arS), 'Just provides an outer type of Array')
+  t.ok(isSameType(Maybe, arS[0]), 'Just provides an inner type of Maybe')
+  t.same(arS[0].option('Nothing'), res, 'Maybe contains transformed value')
+
+  t.ok(isSameType(Array, arN), 'Nothing provides an outer type of MockCrock')
+  t.ok(isSameType(Maybe, arN[0]), 'Nothing provides an inner type of Maybe')
+  t.equal(arN[0].option('Nothing'), 'Nothing', 'Reports as a Nothing')
 
   t.end()
 })

--- a/src/core/Pair.spec.js
+++ b/src/core/Pair.spec.js
@@ -557,6 +557,12 @@ test('Pair sequence with Applicative TypeRep', t => {
   t.ok(isSameType(Pair, s.valueOf()), 'Provides an inner type of Pair')
   t.same(s.valueOf().snd(), x, 'Pair contains original inner value')
 
+  const arS = Pair([], [ x ]).sequence(Array)
+
+  t.ok(isSameType(Array, arS), 'Provides an outer type of Array')
+  t.ok(isSameType(Pair, arS[0]), 'Provides an inner type of Pair')
+  t.same(arS[0].snd(), x, 'Pair contains original inner value')
+
   t.end()
 })
 
@@ -618,13 +624,20 @@ test('Pair traverse with Apply function', t => {
 test('Pair traverse with Applicative TypeRep', t => {
   const x = 'blue'
   const res = 'result'
-  const fn = constant(MockCrock(res))
+  const fn = m => constant(m(res))
 
-  const p = Pair([], x).traverse(MockCrock, fn)
+  const p = Pair([], x).traverse(MockCrock, fn(MockCrock))
 
   t.ok(isSameType(MockCrock, p), 'Provides an outer type of MockCrock')
   t.ok(isSameType(Pair, p.valueOf()), 'Provides an inner type of Pair')
   t.equal(p.valueOf().snd(), res, 'Pair contains transformed value')
+
+  const ar = x => [ x ]
+  const arS = Pair([], x).traverse(Array, fn(ar))
+
+  t.ok(isSameType(Array, arS), 'Provides an outer type of Array')
+  t.ok(isSameType(Pair, arS[0]), 'Provides an inner type of Pair')
+  t.same(arS[0].snd(), res, 'Pair contains transformed value')
 
   t.end()
 })

--- a/src/core/apOrFunc.js
+++ b/src/core/apOrFunc.js
@@ -2,8 +2,11 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const isApplicative = require('./isApplicative')
+const isTypeRepOf = require('./isTypeRepOf')
 
 const apOrFunc = af => x =>
-  isApplicative(af) ? af.of(x) : af(x)
+  isApplicative(af)
+    ? af.of(x)
+    : isTypeRepOf(Array, af) ? [ x ] : af(x)
 
 module.exports = apOrFunc

--- a/src/core/array.js
+++ b/src/core/array.js
@@ -7,7 +7,8 @@ const isFunction = require('./isFunction')
 const isSameType = require('./isSameType')
 const apOrFunc = require('./apOrFunc')
 
-const identity = x => x
+const identity =
+  x => x
 
 const concat =
   x => m => x.concat(m)

--- a/src/core/array.spec.js
+++ b/src/core/array.spec.js
@@ -174,6 +174,12 @@ test('array sequence with Applicative TypeRep', t => {
   t.ok(isSameType(Array, m.valueOf()), 'Provides an inner type of array')
   t.same(m.valueOf()[0], x, 'inner List contains original inner value')
 
+  const arM = sequence(Array, [ [ x ] ])
+
+  t.ok(isSameType(Array, arM), 'Provides an outer type of Array')
+  t.ok(isSameType(Array, arM[0]), 'Provides an inner type of Array')
+  t.same(arM[0][0], x, 'inner array contains original inner value')
+
   t.end()
 })
 
@@ -212,13 +218,20 @@ test('array traverse with Apply function', t => {
 test('array traverse with Applicative TypeRep', t => {
   const x = 'string'
   const res = 'result'
-  const fn = constant(MockCrock(res))
+  const fn = m => constant(m(res))
 
-  const m = traverse(MockCrock, fn, [ x ])
+  const m = traverse(MockCrock, fn(MockCrock), [ x ])
 
   t.ok(isSameType(MockCrock, m), 'Provides an outer type of MockCrock')
   t.ok(isSameType(Array, m.valueOf), 'Provides an inner type of Array')
   t.same(m.valueOf()[0], res, 'inner array contains original inner value')
+
+  const ar = Array.of
+  const arM = traverse(Array, fn(ar), [ x ])
+
+  t.ok(isSameType(Array, arM), 'Provides an outer type of Array')
+  t.ok(isSameType(Array, arM[0]), 'Provides an inner type of Array')
+  t.same(arM[0][0], res, 'inner array contains original inner value')
 
   t.end()
 })

--- a/src/core/isTypeRepOf.js
+++ b/src/core/isTypeRepOf.js
@@ -1,0 +1,10 @@
+/** @license ISC License (c) copyright 2018 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const isFunction = require('./isFunction')
+
+const isTypeRepOf = (x, y) =>
+  isFunction(y)
+    && (x === y || x.name === y.name)
+
+module.exports = isTypeRepOf

--- a/src/core/isTypeRepOf.spec.js
+++ b/src/core/isTypeRepOf.spec.js
@@ -1,0 +1,28 @@
+const test = require('tape')
+
+const isFunction = require('./isFunction')
+const unit = require('./_unit')
+
+const isTypeRepOf = require('./isTypeRepOf')
+
+test('isTypeRepOf internal', t => {
+  t.ok(isFunction(isTypeRepOf), 'is a function')
+
+  const fn =
+    x => isTypeRepOf(String, x)
+
+  t.notOk(fn(undefined), 'returns false for undefined value')
+  t.notOk(fn(null), 'returns false for null value')
+  t.notOk(fn(0), 'returns false for falsey number value')
+  t.notOk(fn(1), 'returns false for truthy number value')
+  t.notOk(fn(''), 'returns false for falsey string value')
+  t.notOk(fn('string'), 'returns false for truthy string value')
+  t.notOk(fn(false), 'returns false for false boolean value')
+  t.notOk(fn(true), 'returns false for true boolean value')
+  t.notOk(fn(unit), 'returns false for a function')
+  t.notOk(fn(Array), 'returns false for different constructor')
+
+  t.ok(fn(String), 'returns true for same constructor')
+
+  t.end()
+})


### PR DESCRIPTION
## Represent!!
![image](https://user-images.githubusercontent.com/3665793/37239454-654decd4-23f1-11e8-802c-1a6a1ddd04f3.png)

This PR allows using the Array 🌽structor for traverse and sequence by using a new internal helper to determine if a constructor matches a target. Well really it is checking if the name is the same. As this is an internal function, it should be just fine, as we will be providing the parameters.

This is the final bit of functionality needed to complete out [this issue](https://github.com/evilsoft/crocks/issues/233).