### PR TITLE
Add details tags for the All Monoid signatures [docs]

### DIFF
--- a/src/All/README.md
+++ b/src/All/README.md
@@ -3,9 +3,12 @@
 ```haskell
 All Boolean
 ```
-<details>
-  <summary>Breakdown</summary>
-  The Monoid <code> All </code> outputs type <code> Boolean </code>
+<details style="margin:30px">
+  <summary style="margin-bottom:15px">Breakdown</summary>
+  <dl>
+    <dt><code>All</code></dt><dd>The Monoid container</dd>
+    <dt><code>Boolean</code></dt><dd>The contained type</dd>
+  </dl>
 </details>
 
 `All` is a `Monoid` that will combine (2) values of any type using logical
@@ -48,6 +51,14 @@ allGood([ 'nice', '00', null ])
 ```haskell
 All.empty :: () -> All
 ```
+<details style="margin:30px">
+  <summary style="margin-bottom:15px">Breakdown</summary>
+  <dl>
+    <dt><code>All.empty()</code></dt><dd>The constructor function</dd>
+    <dt><code>All</code></dt><dd>The output type</dd>
+  </dl>
+</details>
+
 <details>
   <summary>Breakdown</summary>
   The constructor <code> All.empty() </code> outputs type <code> All </code>
@@ -74,9 +85,12 @@ All(false).concat(All.empty())  //=> All false
 ```haskell
 All ~> All -> All
 ```
-<details>
-  <summary>Breakdown</summary>
-  <code> All.concat </code> inputs type <code> All </code> and outputs type <code> All </code>
+<details style="margin:30px">
+  <summary style="margin-bottom:15px">Breakdown</summary>
+  <dl>
+    <dt><code>All</code></dt><dd>The input type</dd>
+    <dt><code>All</code></dt><dd>The output type</dd>
+  </dl>
 </details>
 
 `concat` is used to combine (2) `Semigroup`s of the same type under an operation
@@ -97,10 +111,6 @@ All(false).concat(All(false)) //=> All false
 ```haskell
 All ~> () -> Boolean
 ```
-<details>
-  <summary>Breakdown</summary>
-  <code> All.valueOf() </code> outputs type <code> Boolean </code>
-</details>
 
 `valueOf` is used on all `crocks` `Monoid`s as a means of extraction. While the
 extraction is available, types that implement `valueOf` are not necessarily a

--- a/src/All/README.md
+++ b/src/All/README.md
@@ -47,6 +47,7 @@ All.empty :: () -> All
 <details>
   <summary>Breakdown</summary>
   <dl>
+    <dt>unit</dt><dd>Nothing, any passed in parameters are ignored</dd>
     <dt>result</dt><dd><code>All</code> wrapping <code>true</code></dd>
   </dl>
 </details>

--- a/src/All/README.md
+++ b/src/All/README.md
@@ -3,14 +3,6 @@
 ```haskell
 All Boolean
 ```
-<details>
-  <summary>Breakdown</summary>
-  <dl>
-    <dt><code>All</code></dt><dd>The Monoid container</dd>
-    <dt><code>Boolean</code></dt><dd>The contained type</dd>
-  </dl>
-</details>
-<br>
 
 `All` is a `Monoid` that will combine (2) values of any type using logical
 conjunction (AND) on their coerced `Boolean` values, mapping truth-y values to
@@ -56,7 +48,7 @@ All.empty :: () -> All
   <summary>Breakdown</summary>
   <dl>
     <dt><code>All.empty()</code></dt><dd>The constructor function</dd>
-    <dt><code>All</code></dt><dd>The output type</dd>
+    <dt>result</dt><dd><code>All</code> wrapping <code>true</code></dd>
   </dl>
 </details>
 <br>
@@ -85,8 +77,8 @@ All ~> All -> All
 <details>
   <summary>Breakdown</summary>
   <dl>
-    <dt><code>All</code></dt><dd>The input type</dd>
-    <dt><code>All</code></dt><dd>The output type</dd>
+    <dt>value</dt><dd>Value to concat</dd>
+    <dt>result</dt><dd><code>All</code> wrapping the concatenated values</dd>
   </dl>
 </details>
 <br>

--- a/src/All/README.md
+++ b/src/All/README.md
@@ -3,13 +3,14 @@
 ```haskell
 All Boolean
 ```
-<details style="margin:30px">
-  <summary style="margin-bottom:15px">Breakdown</summary>
+<details>
+  <summary>Breakdown</summary>
   <dl>
     <dt><code>All</code></dt><dd>The Monoid container</dd>
     <dt><code>Boolean</code></dt><dd>The contained type</dd>
   </dl>
 </details>
+<br>
 
 `All` is a `Monoid` that will combine (2) values of any type using logical
 conjunction (AND) on their coerced `Boolean` values, mapping truth-y values to
@@ -51,18 +52,14 @@ allGood([ 'nice', '00', null ])
 ```haskell
 All.empty :: () -> All
 ```
-<details style="margin:30px">
-  <summary style="margin-bottom:15px">Breakdown</summary>
+<details>
+  <summary>Breakdown</summary>
   <dl>
     <dt><code>All.empty()</code></dt><dd>The constructor function</dd>
     <dt><code>All</code></dt><dd>The output type</dd>
   </dl>
 </details>
-
-<details>
-  <summary>Breakdown</summary>
-  The constructor <code> All.empty() </code> outputs type <code> All </code>
-</details>
+<br>
 
 `empty` provides the identity for the `Monoid` in that when the value it
 provides is `concat`ed to any other value, it will return the other value. In
@@ -85,13 +82,14 @@ All(false).concat(All.empty())  //=> All false
 ```haskell
 All ~> All -> All
 ```
-<details style="margin:30px">
-  <summary style="margin-bottom:15px">Breakdown</summary>
+<details>
+  <summary>Breakdown</summary>
   <dl>
     <dt><code>All</code></dt><dd>The input type</dd>
     <dt><code>All</code></dt><dd>The output type</dd>
   </dl>
 </details>
+<br>
 
 `concat` is used to combine (2) `Semigroup`s of the same type under an operation
 specified by the `Semigroup`. In the case of `All`, it will combine the (2)

--- a/src/All/README.md
+++ b/src/All/README.md
@@ -3,6 +3,10 @@
 ```haskell
 All Boolean
 ```
+<details>
+  <summary>Breakdown</summary>
+  The Monoid <code> All </code> outputs type <code> Boolean </code>
+</details>
 
 `All` is a `Monoid` that will combine (2) values of any type using logical
 conjunction (AND) on their coerced `Boolean` values, mapping truth-y values to
@@ -44,6 +48,10 @@ allGood([ 'nice', '00', null ])
 ```haskell
 All.empty :: () -> All
 ```
+<details>
+  <summary>Breakdown</summary>
+  The constructor <code> All.empty() </code> outputs type <code> All </code>
+</details>
 
 `empty` provides the identity for the `Monoid` in that when the value it
 provides is `concat`ed to any other value, it will return the other value. In
@@ -66,6 +74,10 @@ All(false).concat(All.empty())  //=> All false
 ```haskell
 All ~> All -> All
 ```
+<details>
+  <summary>Breakdown</summary>
+  <code> All.concat </code> inputs type <code> All </code> and outputs type <code> All </code>
+</details>
 
 `concat` is used to combine (2) `Semigroup`s of the same type under an operation
 specified by the `Semigroup`. In the case of `All`, it will combine the (2)
@@ -85,6 +97,10 @@ All(false).concat(All(false)) //=> All false
 ```haskell
 All ~> () -> Boolean
 ```
+<details>
+  <summary>Breakdown</summary>
+  <code> All.valueOf() </code> outputs type <code> Boolean </code>
+</details>
 
 `valueOf` is used on all `crocks` `Monoid`s as a means of extraction. While the
 extraction is available, types that implement `valueOf` are not necessarily a

--- a/src/All/README.md
+++ b/src/All/README.md
@@ -4,6 +4,20 @@
 All Boolean
 ```
 
+## Constructor
+
+```haskell
+All :: a -> All Boolean
+```
+<details>
+  <summary>Breakdown</summary>
+  <dl>
+    <dt>value</dt><dd>Value to wrap</dd>
+    <dt>result</dt><dd><code>All</code> wrapping the coerced `Boolean` value</dd>
+  </dl>
+</details>
+<br>
+
 `All` is a `Monoid` that will combine (2) values of any type using logical
 conjunction (AND) on their coerced `Boolean` values, mapping truth-y values to
 `true` and false-y values to `false`.

--- a/src/All/README.md
+++ b/src/All/README.md
@@ -47,7 +47,6 @@ All.empty :: () -> All
 <details>
   <summary>Breakdown</summary>
   <dl>
-    <dt><code>All.empty()</code></dt><dd>The constructor function</dd>
     <dt>result</dt><dd><code>All</code> wrapping <code>true</code></dd>
   </dl>
 </details>


### PR DESCRIPTION
This adds a sample taste for using `details` tags for alternative explanations the documentation.

This tag is not currently supported by IE or edge browsers.