### PR TITLE
Make inspect method stringify objects (#251)

### DIFF
--- a/src/Assign/Assign.spec.js
+++ b/src/Assign/Assign.spec.js
@@ -71,7 +71,7 @@ test('Assign inspect', t => {
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
   t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
-  t.equal(m.inspect(), 'Assign {}', 'returns inspect string')
+  t.equal(m.inspect(), 'Assign { great: true }', 'returns inspect string')
 
   t.end()
 })

--- a/src/core/inspect.js
+++ b/src/core/inspect.js
@@ -27,7 +27,9 @@ function inspect(x) {
   }
 
   if(isObject(x)) {
-    return ' {}'
+    return ` { ${Object.keys(x).reduce((acc, key) => {
+      return acc.concat([ `${key}:${inspect(x[key])}` ])
+    }, []).join(', ')} }`
   }
 
   if(isString(x)) {

--- a/src/core/inspect.spec.js
+++ b/src/core/inspect.spec.js
@@ -1,25 +1,26 @@
 const test = require('tape')
-
+const Mock = require('../test/MockCrock')
 const isFunction = require('./isFunction')
 const unit = require('./_unit')
-
-const constant = x => () => x
 
 const inspect = require('./inspect')
 
 test('inspect internal function', t => {
-  const m = { inspect: constant('inspect') }
+  const m = Mock.of(42)
 
   t.ok(isFunction(inspect), 'is a function')
 
-  t.equal(inspect(m), ' inspect', 'calls inspect on containers')
+  t.equal(inspect(m), ' Mock 42', 'calls inspect on containers')
   t.equal(inspect(unit), ' Function', 'outputs as a function')
-  t.equal(inspect({ obj: true }), ' {}', 'outputs as an object')
   t.equal(inspect([]), ' [ ]', 'outputs as an array')
   t.equal(inspect([ 1, 2 ]), ' [ 1, 2 ]', 'outputs as an array')
   t.equal(inspect(0), ' 0', 'outputs as a number')
   t.equal(inspect('string'), ' "string"', 'outputs as a string wrapped in quotes')
   t.equal(inspect(true), ' true', 'outputs as a boolean')
+  t.equals(inspect({ a: 5 }), ' { a: 5 }', 'outputs object contents')
+  t.equals(inspect({ a: 5, b: { c: '5' } }), ' { a: 5, b: { c: "5" } }', 'outputs object contents (nested)')
+  t.equals(inspect({ a: m }), ' { a: Mock 42 }', 'calls inspect on properties which are containers')
+  t.equals(inspect({ a: Mock.of({ b: m }) }), ' { a: Mock { b: Mock 42 } }', 'calls inspect on properties which are containers (nested)')
 
   t.end()
 })

--- a/src/test/MockCrock.js
+++ b/src/test/MockCrock.js
@@ -1,4 +1,5 @@
 const _implements = require('../core/implements')
+const _inspect = require('../core/inspect')
 const _equals = require('../core/equals')
 
 const constant = x => () => x
@@ -16,6 +17,7 @@ function MockCrock(x) {
   const of        = _of
   const sequence  = () => x.map(MockCrock)
   const traverse  = (_, f) => f(x).map(MockCrock)
+  const inspect   = () => `Mock${_inspect(x)}`
   const equals =
     m => _equals(m.valueOf(), x)
 
@@ -23,7 +25,7 @@ function MockCrock(x) {
     valueOf, type, map, ap,
     chain, of, sequence,
     ['@@type']: typeString,
-    traverse, equals
+    traverse, inspect, equals
   }
 }
 


### PR DESCRIPTION
This PR fixes #251 by recursively calling `inspect` on object properties.