### PR TITLE
Add Fantasy Land Compliance for Associated Predicates

### DIFF
--- a/src/core/hasAlg.js
+++ b/src/core/hasAlg.js
@@ -2,8 +2,17 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const isFunction = require('./isFunction')
+const fl = require('./flNames')
+
+const check = (alg, m) =>
+  isFunction(m[fl[alg]]) || isFunction(m[alg])
+
+const checkRep = (alg, m) =>
+  !!m.constructor && isFunction(m.constructor[fl[alg]])
+    || isFunction(m.constructor[alg])
 
 const hasAlg = (alg, m) =>
-  isFunction(m[alg]) || isFunction(m['@@implements']) && !!m['@@implements'](alg)
+  !!m && (check(alg, m) || checkRep(alg, m))
+    || isFunction(m['@@implements']) && !!m['@@implements'](alg)
 
 module.exports = hasAlg

--- a/src/core/hasAlg.spec.js
+++ b/src/core/hasAlg.spec.js
@@ -2,6 +2,7 @@ const test = require('tape')
 const sinon = require('sinon')
 
 const isFunction = require('./isFunction')
+const fl = require('./flNames')
 
 const constant = x => () => x
 const identity = x => x
@@ -17,6 +18,24 @@ test('hasAlg', t => {
   t.equal(hasAlg('contramap', inst), false, 'returns false when alg is not on the instance')
   t.equal(hasAlg('nope', inst), false, 'returns false when alg is not a function on the instance')
 
+  t.end()
+})
+
+test('hasAlg fantasy-land', t => {
+  const keys = Object.keys(fl)
+
+  t.plan(keys.length * 2)
+
+  keys.forEach(k => {
+    const inst = { [fl[k]]: identity }
+    const noFunc = { [fl[k]]: true }
+
+    t.ok(hasAlg(k, inst, `returns true for ${k}, when ${fl[k]} is a function`))
+    t.notOk(hasAlg(k, noFunc, `returns false for ${k}, when ${fl[k]} is not a function`))
+  })
+})
+
+test('hasAlg @@implements', t => {
   const arg = 'wut'
   const res = 'result'
   const func = sinon.spy(constant(res))

--- a/src/core/isAlt.spec.js
+++ b/src/core/isAlt.spec.js
@@ -27,8 +27,18 @@ test('isAlt predicate function', t => {
   t.equal(isAlt([]), false, 'returns false for an array')
   t.equal(isAlt(identity), false, 'returns false for function')
 
-  t.equal(isAlt(Fake), true, 'returns true when an Alt Constuctor is passed')
-  t.equal(isAlt(fake), true, 'returns true when an Alt is passed')
+  t.equal(isAlt(Fake), true, 'returns true when Alt Constuctor is passed')
+  t.equal(isAlt(fake), true, 'returns true when Alt is passed')
+
+  t.end()
+})
+
+test('isAlt fantasy-land', t => {
+  const Fake = makeFake([ 'alt', 'map' ], true)
+  const fake = Fake()
+
+  t.equal(isAlt(Fake), false, 'returns false when Alt Constuctor is passed')
+  t.equal(isAlt(fake), true, 'returns true when Alt is passed')
 
   t.end()
 })

--- a/src/core/isApplicative.spec.js
+++ b/src/core/isApplicative.spec.js
@@ -38,7 +38,7 @@ test('isApplicative fantasy-land', t => {
   const fake = Fake()
 
   t.equal(isApplicative(Fake), false, 'returns false when Applicative Constructor is passed')
-  t.equal(isApplicative(fake), true, 'returns true when Applicative is passed')
+  t.equal(isApplicative(fake), false, 'returns false when Applicative is passed')
 
   t.end()
 })

--- a/src/core/isApplicative.spec.js
+++ b/src/core/isApplicative.spec.js
@@ -27,8 +27,18 @@ test('isApplicative predicate function', t => {
   t.equal(isApplicative([]), false, 'returns false for an array')
   t.equal(isApplicative(identity), false, 'returns false for function')
 
-  t.equal(isApplicative(Fake), true, 'returns true when an Applicative Constructor is passed')
-  t.equal(isApplicative(fake), true, 'returns true when an Applicative is passed')
+  t.equal(isApplicative(Fake), true, 'returns true when Applicative Constructor is passed')
+  t.equal(isApplicative(fake), true, 'returns true when Applicative is passed')
+
+  t.end()
+})
+
+test('isApplicative fantasy-land', t => {
+  const Fake = makeFake([ 'ap', 'map', 'of' ], true)
+  const fake = Fake()
+
+  t.equal(isApplicative(Fake), false, 'returns false when Applicative Constructor is passed')
+  t.equal(isApplicative(fake), true, 'returns true when Applicative is passed')
 
   t.end()
 })

--- a/src/core/isApply.spec.js
+++ b/src/core/isApply.spec.js
@@ -25,8 +25,19 @@ test('isApply core', t => {
   t.equal(isApply([]), false, 'returns false for an array')
   t.equal(isApply(identity), false, 'returns false for function')
 
-  t.equal(isApply(Fake), true, 'returns true when an Apply Constructor is passed')
-  t.equal(isApply(fake), true, 'returns true when an Apply is passed')
+  t.equal(isApply(Fake), true, 'returns true when Apply Constructor is passed')
+  t.equal(isApply(fake), true, 'returns true when Apply is passed')
+
+  t.ok(isFunction(isApply))
+  t.end()
+})
+
+test('isApply fantasy-land', t => {
+  const Fake = makeFake([ 'ap', 'map' ], true)
+  const fake = Fake()
+
+  t.equal(isApply(Fake), false, 'returns false when Apply Constructor is passed')
+  t.equal(isApply(fake), true, 'returns true when Apply is passed')
 
   t.ok(isFunction(isApply))
   t.end()

--- a/src/core/isApply.spec.js
+++ b/src/core/isApply.spec.js
@@ -37,7 +37,7 @@ test('isApply fantasy-land', t => {
   const fake = Fake()
 
   t.equal(isApply(Fake), false, 'returns false when Apply Constructor is passed')
-  t.equal(isApply(fake), true, 'returns true when Apply is passed')
+  t.equal(isApply(fake), false, 'returns false when Apply is passed')
 
   t.ok(isFunction(isApply))
   t.end()

--- a/src/core/isBifunctor.spec.js
+++ b/src/core/isBifunctor.spec.js
@@ -25,9 +25,19 @@ test('isBifunctor predicate function', t => {
   t.equal(isBifunctor([]), false, 'returns false for an array')
   t.equal(isBifunctor(identity), false, 'returns false for function')
 
-  t.equal(isBifunctor(Fake), true, 'returns true when a Bifunctor Constructor is passed')
-  t.equal(isBifunctor(fake), true, 'returns true when a Bifunctor is passed')
+  t.equal(isBifunctor(Fake), true, 'returns true when Bifunctor Constructor is passed')
+  t.equal(isBifunctor(fake), true, 'returns true when Bifunctor is passed')
 
   t.ok(isFunction(isBifunctor))
+  t.end()
+})
+
+test('isBifunctor fantasy-land', t => {
+  const Fake = makeFake([ 'bimap', 'map' ], true)
+  const fake = Fake()
+
+  t.equal(isBifunctor(Fake), false , 'returns false when Bifunctor Constructor is passed')
+  t.equal(isBifunctor(fake), true, 'returns true when Bifunctor is passed')
+
   t.end()
 })

--- a/src/core/isChain.spec.js
+++ b/src/core/isChain.spec.js
@@ -25,9 +25,19 @@ test('isChain core', t => {
   t.equal(isChain([]), false, 'returns false for an array')
   t.equal(isChain(identity), false, 'returns false for function')
 
-  t.equal(isChain(Fake), true, 'returns true when a Chain Constructor is passed')
-  t.equal(isChain(fake), true, 'returns true when a Chain is passed')
+  t.equal(isChain(Fake), true, 'returns true when Chain Constructor is passed')
+  t.equal(isChain(fake), true, 'returns true when Chain is passed')
 
   t.ok(isFunction(isChain))
+  t.end()
+})
+
+test('isChain fantasy-land', t => {
+  const Fake = makeFake([ 'ap', 'chain', 'map' ], true)
+  const fake = Fake()
+
+  t.equal(isChain(Fake), false, 'returns false when Chain Constructor is passed')
+  t.equal(isChain(fake), true, 'returns true when Chain is passed')
+
   t.end()
 })

--- a/src/core/isChain.spec.js
+++ b/src/core/isChain.spec.js
@@ -37,7 +37,7 @@ test('isChain fantasy-land', t => {
   const fake = Fake()
 
   t.equal(isChain(Fake), false, 'returns false when Chain Constructor is passed')
-  t.equal(isChain(fake), true, 'returns true when Chain is passed')
+  t.equal(isChain(fake), false, 'returns false when Chain is passed')
 
   t.end()
 })

--- a/src/core/isContravariant.spec.js
+++ b/src/core/isContravariant.spec.js
@@ -1,33 +1,44 @@
 const test = require('tape')
 const helpers = require('../test/helpers')
 
-const makeFake = helpers.makeFake
-
 const isFunction = require('./isFunction')
+
+const makeFake = helpers.makeFake
 
 const identity = x => x
 
-const isContravariant = require('./isContravariant')
+const isExtend = require('./isExtend')
 
-test('isContravariant predicate function', t => {
-  const Fake = makeFake([ 'contramap' ])
+test('isExtend predicate function', t => {
+  const Fake = makeFake([ 'map', 'extend' ])
   const fake = Fake()
 
-  t.ok(isFunction(isContravariant))
+  t.ok(isFunction(isExtend), 'is a function')
 
-  t.equal(isContravariant(undefined), false, 'returns false for undefined')
-  t.equal(isContravariant(null), false, 'returns false for null')
-  t.equal(isContravariant(0), false, 'returns false for falsey number')
-  t.equal(isContravariant(1), false, 'returns false for truthy number')
-  t.equal(isContravariant(''), false, 'returns false for falsey string')
-  t.equal(isContravariant('string'), false, 'returns false for truthy string')
-  t.equal(isContravariant(false), false, 'returns false for false')
-  t.equal(isContravariant(true), false, 'returns false for true')
-  t.equal(isContravariant({}), false, 'returns false for an object')
-  t.equal(isContravariant(identity), false, 'returns false for function')
+  t.equal(isExtend(undefined), false, 'returns false for undefined')
+  t.equal(isExtend(null), false, 'returns false for null')
+  t.equal(isExtend(0), false, 'returns false for falsey number')
+  t.equal(isExtend(1), false, 'returns false for truthy number')
+  t.equal(isExtend(''), false, 'returns false for falsey string')
+  t.equal(isExtend('string'), false, 'returns false for truthy string')
+  t.equal(isExtend(false), false, 'returns false for false')
+  t.equal(isExtend(true), false, 'returns false for true')
+  t.equal(isExtend({}), false, 'returns false for an object')
+  t.equal(isExtend([]), false, 'returns false for an array')
+  t.equal(isExtend(identity), false, 'returns false for function')
 
-  t.equal(isContravariant(Fake), true, 'returns true when a Contravariant Functor Constructor is passed')
-  t.equal(isContravariant(fake), true, 'returns true when a Contravariant Functor is passed')
+  t.equal(isExtend(Fake), true, 'returns true when Extend Constructor is passed')
+  t.equal(isExtend(fake), true, 'returns true when Extend is passed')
+
+  t.end()
+})
+
+test('isExtend fantasy-land', t => {
+  const Fake = makeFake([ 'map', 'extend' ], true)
+  const fake = Fake()
+
+  t.equal(isExtend(Fake), false, 'returns false when Extend Constructor is passed')
+  t.equal(isExtend(fake), true, 'returns true when Extend is passed')
 
   t.end()
 })

--- a/src/core/isExtend.spec.js
+++ b/src/core/isExtend.spec.js
@@ -1,16 +1,17 @@
 const test = require('tape')
+const helpers = require('../test/helpers')
 
 const isFunction = require('./isFunction')
+
+const makeFake = helpers.makeFake
 
 const identity = x => x
 
 const isExtend = require('./isExtend')
 
 test('isExtend predicate function', t => {
-  const fake = {
-    map: identity,
-    extend: identity
-  }
+  const Fake = makeFake([ 'map', 'extend' ])
+  const fake = Fake()
 
   t.ok(isFunction(isExtend), 'is a function')
 
@@ -26,7 +27,18 @@ test('isExtend predicate function', t => {
   t.equal(isExtend([]), false, 'returns false for an array')
   t.equal(isExtend(identity), false, 'returns false for function')
 
-  t.equal(isExtend(fake), true, 'returns true when an Extend is passed')
+  t.equal(isExtend(Fake), true, 'returns true when Extend Constructor is passed')
+  t.equal(isExtend(fake), true, 'returns true when Extend is passed')
+
+  t.end()
+})
+
+test('isExtend fantasy-land', t => {
+  const Fake = makeFake([ 'map', 'extend' ], true)
+  const fake = Fake()
+
+  t.equal(isExtend(Fake), false, 'returns false when Extend Constructor is passed')
+  t.equal(isExtend(fake), true, 'returns true when Extend is passed')
 
   t.end()
 })

--- a/src/core/isFoldable.spec.js
+++ b/src/core/isFoldable.spec.js
@@ -27,8 +27,19 @@ test('isFoldable core', t => {
   t.equal(isFoldable(identity), false, 'returns false for function')
 
   t.equal(isFoldable([]), true, 'returns true for an array')
-  t.equal(isFoldable(Fake), true, 'returns true when a Foldable Constructor structure is passed')
-  t.equal(isFoldable(fake), true, 'returns true when a Foldable structure is passed')
+  t.equal(isFoldable(Fake), true, 'returns true when Foldable Constructor structure is passed')
+  t.equal(isFoldable(fake), true, 'returns true when Foldable structure is passed')
 
   t.end()
 })
+
+test('isFoldable fantasy-land', t => {
+  const Fake = makeFake([ 'reduce' ], true)
+  const fake = Fake()
+
+  t.equal(isFoldable(Fake), false, 'returns false when Foldable Constructor structure is passed')
+  t.equal(isFoldable(fake), true, 'returns true when Foldable structure is passed')
+
+  t.end()
+})
+

--- a/src/core/isFunctor.spec.js
+++ b/src/core/isFunctor.spec.js
@@ -13,6 +13,8 @@ test('isFunctor core', t => {
   const Fake = makeFake([ 'map' ])
   const fake = Fake()
 
+  t.ok(isFunction(isFunctor))
+
   t.equal(isFunctor(undefined), false, 'returns false for undefined')
   t.equal(isFunctor(null), false, 'returns false for null')
   t.equal(isFunctor(0), false, 'returns false for falsey number')
@@ -25,10 +27,18 @@ test('isFunctor core', t => {
   t.equal(isFunctor(identity), false, 'returns false for function')
 
   t.equal(isFunctor([]), true, 'returns true for an array')
-  t.equal(isFunctor(Fake), true, 'returns true when a Functor Constructor is passed')
-  t.equal(isFunctor(fake), true, 'returns true when a Functor is passed')
+  t.equal(isFunctor(Fake), true, 'returns true when Functor Constructor is passed')
+  t.equal(isFunctor(fake), true, 'returns true when Functor is passed')
 
-  t.ok(isFunction(isFunctor))
+  t.end()
+})
+
+test('isFunctor fantasy-land', t => {
+  const Fake = makeFake([ 'map' ], true)
+  const fake = Fake()
+
+  t.equal(isFunctor(Fake), false, 'returns false when Functor Constructor is passed')
+  t.equal(isFunctor(fake), true, 'returns true when Functor is passed')
 
   t.end()
 })

--- a/src/core/isMonad.spec.js
+++ b/src/core/isMonad.spec.js
@@ -38,7 +38,7 @@ test('isMonad fantasy-land', t => {
   const fake = Fake()
 
   t.equal(isMonad(Fake), false, 'returns false when Monad Constructor is passed')
-  t.equal(isMonad(fake), true, 'returns true when Monad is passed')
+  t.equal(isMonad(fake), false , 'returns false when Monad is passed')
 
   t.end()
 })

--- a/src/core/isMonad.spec.js
+++ b/src/core/isMonad.spec.js
@@ -27,8 +27,18 @@ test('isMonad predicate function', t => {
   t.equal(isMonad([]), false, 'returns false for an array')
   t.equal(isMonad(identity), false, 'returns false for function')
 
-  t.equal(isMonad(Fake), true, 'returns true when a Monad Constructor is passed')
-  t.equal(isMonad(fake), true, 'returns true when a Monad is passed')
+  t.equal(isMonad(Fake), true, 'returns true when Monad Constructor is passed')
+  t.equal(isMonad(fake), true, 'returns true when Monad is passed')
+
+  t.end()
+})
+
+test('isMonad fantasy-land', t => {
+  const Fake = makeFake([ 'ap', 'chain', 'map', 'of' ], true)
+  const fake = Fake()
+
+  t.equal(isMonad(Fake), false, 'returns false when Monad Constructor is passed')
+  t.equal(isMonad(fake), true, 'returns true when Monad is passed')
 
   t.end()
 })

--- a/src/core/isMonoid.spec.js
+++ b/src/core/isMonoid.spec.js
@@ -27,8 +27,18 @@ test('isMonoid core', t => {
   t.equal(isMonoid([]), false, 'returns false for an array')
   t.equal(isMonoid(identity), false, 'returns false for function')
 
-  t.equal(isMonoid(Fake), true, 'returns true when an Monoid Constructor is passed')
-  t.equal(isMonoid(fake), true, 'returns true when an Monoid is passed')
+  t.equal(isMonoid(Fake), true, 'returns true when Monoid Constructor is passed')
+  t.equal(isMonoid(fake), true, 'returns true when Monoid is passed')
+
+  t.end()
+})
+
+test('isMonoid fantasy-land', t => {
+  const Fake = makeFake([ 'concat', 'empty' ], true)
+  const fake = Fake()
+
+  t.equal(isMonoid(Fake), false, 'returns false when Monoid Constructor is passed')
+  t.equal(isMonoid(fake), true, 'returns true when Monoid is passed')
 
   t.end()
 })

--- a/src/core/isPlus.spec.js
+++ b/src/core/isPlus.spec.js
@@ -27,8 +27,18 @@ test('isPlus predicate function', t => {
   t.equal(isPlus([]), false, 'returns false for an array')
   t.equal(isPlus(identity), false, 'returns false for function')
 
-  t.equal(isPlus(Fake), true, 'returns true when a Plus Constructor is passed')
-  t.equal(isPlus(fake), true, 'returns true when a Plus is passed')
+  t.equal(isPlus(Fake), true, 'returns true when Plus Constructor is passed')
+  t.equal(isPlus(fake), true, 'returns true when Plus is passed')
+
+  t.end()
+})
+
+test('isPlus fantasy-land', t => {
+  const Fake = makeFake([ 'alt', 'map', 'zero' ], true)
+  const fake = Fake()
+
+  t.equal(isPlus(Fake), false, 'returns true when Plus Constructor is passed')
+  t.equal(isPlus(fake), true, 'returns true when Plus is passed')
 
   t.end()
 })

--- a/src/core/isProfunctor.js
+++ b/src/core/isProfunctor.js
@@ -1,0 +1,15 @@
+/** @license ISC License (c) copyright 2017 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const hasAlg = require('./hasAlg')
+const isContravariant = require('./isContravariant')
+const isFunctor = require('./isFunctor')
+
+// isProfunctor :: a -> Boolean
+function isProfunctor(m) {
+  return isContravariant(m)
+    && isFunctor(m)
+    && hasAlg('promap', m)
+}
+
+module.exports = isProfunctor

--- a/src/core/isProfunctor.spec.js
+++ b/src/core/isProfunctor.spec.js
@@ -1,0 +1,44 @@
+const test = require('tape')
+const helpers = require('../test/helpers')
+
+const makeFake = helpers.makeFake
+
+const isFunction = require('./isFunction')
+
+const identity = x => x
+
+const isProfunctor = require('./isProfunctor')
+
+test('isProfunctor core', t => {
+  const Fake = makeFake([ 'map', 'contramap', 'promap' ])
+  const fake = Fake()
+
+  t.ok(isFunction(isProfunctor))
+
+  t.equal(isProfunctor(undefined), false, 'returns false for undefined')
+  t.equal(isProfunctor(null), false, 'returns false for null')
+  t.equal(isProfunctor(0), false, 'returns false for falsey number')
+  t.equal(isProfunctor(1), false, 'returns false for truthy number')
+  t.equal(isProfunctor(''), false, 'returns false for falsey string')
+  t.equal(isProfunctor('string'), false, 'returns false for truthy string')
+  t.equal(isProfunctor(false), false, 'returns false for false')
+  t.equal(isProfunctor(true), false, 'returns false for true')
+  t.equal(isProfunctor({}), false, 'returns false for an object')
+  t.equal(isProfunctor([]), false, 'returns false for an array')
+  t.equal(isProfunctor(identity), false, 'returns false for function')
+
+  t.equal(isProfunctor(Fake), true, 'returns true when Profunctor Constructor is passed')
+  t.equal(isProfunctor(fake), true, 'returns true when Profunctor is passed')
+
+  t.end()
+})
+
+test('isProfunctor fantasy-land', t => {
+  const Fake = makeFake([ 'map', 'contramap', 'promap' ], true)
+  const fake = Fake()
+
+  t.equal(isProfunctor(Fake), false, 'returns false when Profunctor Constructor is passed')
+  t.equal(isProfunctor(fake), true, 'returns true when Profunctor is passed')
+
+  t.end()
+})

--- a/src/core/isSemigroup.spec.js
+++ b/src/core/isSemigroup.spec.js
@@ -28,8 +28,18 @@ test('isSemigroup core', t => {
   t.equal(isSemigroup('string'), true, 'returns true for truthy string')
   t.equal(isSemigroup([]), true, 'returns true for an array')
 
-  t.equal(isSemigroup(Fake), true, 'returns true when a Semigroup Constructor is passed')
-  t.equal(isSemigroup(fake), true, 'returns true when a Semigroup is passed')
+  t.equal(isSemigroup(Fake), true, 'returns true when Semigroup Constructor is passed')
+  t.equal(isSemigroup(fake), true, 'returns true when Semigroup is passed')
+
+  t.end()
+})
+
+test('isSemigroup fantasy-land', t => {
+  const Fake = makeFake([ 'concat' ], true)
+  const fake = Fake()
+
+  t.equal(isSemigroup(Fake), false, 'returns false when Semigroup Constructor is passed')
+  t.equal(isSemigroup(fake), true, 'returns true when Semigroup is passed')
 
   t.end()
 })

--- a/src/core/isSemigroupoid.spec.js
+++ b/src/core/isSemigroupoid.spec.js
@@ -9,7 +9,7 @@ const identity = x => x
 
 const isSemigroupoid = require('./isSemigroupoid')
 
-test('isSemigroupoid predicate function', t => {
+test('isSemigroupoid predicate', t => {
   const Fake = makeFake([ 'compose' ])
   const fake = Fake()
 
@@ -27,8 +27,18 @@ test('isSemigroupoid predicate function', t => {
   t.equal(isSemigroupoid({}), false, 'returns false for an object')
   t.equal(isSemigroupoid(identity), false, 'returns false for function')
 
-  t.equal(isSemigroupoid(Fake), true, 'returns true when a Semigroupoid Constructor is passed')
-  t.equal(isSemigroupoid(fake), true, 'returns true when a Semigroupoid is passed')
+  t.equal(isSemigroupoid(Fake), true, 'returns true when Semigroupoid Constructor is passed')
+  t.equal(isSemigroupoid(fake), true, 'returns true when Semigroupoid is passed')
+
+  t.end()
+})
+
+test('isSemigroupoid fantasy-land', t => {
+  const Fake = makeFake([ 'compose' ], true)
+  const fake = Fake()
+
+  t.equal(isSemigroupoid(Fake), false, 'returns true when Semigroupoid Constructor is passed')
+  t.equal(isSemigroupoid(fake), true, 'returns true when Semigroupoid is passed')
 
   t.end()
 })

--- a/src/predicates/isAlternative.spec.js
+++ b/src/predicates/isAlternative.spec.js
@@ -38,7 +38,7 @@ test('isAlternative fantasy-land', t => {
   const fake = Fake()
 
   t.equal(isAlternative(Fake), false, 'returns true when Alternative Constructor is passed')
-  t.equal(isAlternative(fake), true, 'returns true when Alternative is passed')
+  t.equal(isAlternative(fake), false, 'returns false when Alternative is passed')
 
   t.end()
 })

--- a/src/predicates/isAlternative.spec.js
+++ b/src/predicates/isAlternative.spec.js
@@ -10,7 +10,7 @@ const identity = x => x
 const isAlternative = require('./isAlternative')
 
 test('isAlternative predicate function', t => {
-  const Fake = makeFake([ 'alt', 'ap', 'chain', 'map', 'of', 'zero' ])
+  const Fake = makeFake([ 'alt', 'ap', 'map', 'of', 'zero' ])
   const fake = Fake()
 
   t.ok(isFunction(isAlternative))
@@ -27,8 +27,18 @@ test('isAlternative predicate function', t => {
   t.equal(isAlternative([]), false, 'returns false for an array')
   t.equal(isAlternative(identity), false, 'returns false for function')
 
-  t.equal(isAlternative(Fake), true, 'returns true when an Alternative Constructor is passed')
-  t.equal(isAlternative(fake), true, 'returns true when an Alternative is passed')
+  t.equal(isAlternative(Fake), true, 'returns true when Alternative Constructor is passed')
+  t.equal(isAlternative(fake), true, 'returns true when Alternative is passed')
+
+  t.end()
+})
+
+test('isAlternative fantasy-land', t => {
+  const Fake = makeFake([ 'alt', 'ap', 'map', 'of', 'zero' ], true)
+  const fake = Fake()
+
+  t.equal(isAlternative(Fake), false, 'returns true when Alternative Constructor is passed')
+  t.equal(isAlternative(fake), true, 'returns true when Alternative is passed')
 
   t.end()
 })

--- a/src/predicates/isCategory.spec.js
+++ b/src/predicates/isCategory.spec.js
@@ -32,3 +32,13 @@ test('isCategory predicate function', t => {
 
   t.end()
 })
+
+test('isCategory fantasy-land', t => {
+  const Fake = makeFake([ 'compose', 'id' ], true)
+  const fake = Fake()
+
+  t.equal(isCategory(Fake), false, 'returns false when a Category Constructor is passed')
+  t.equal(isCategory(fake), true, 'returns true when a Category is passed')
+
+  t.end()
+})

--- a/src/predicates/isProfunctor.js
+++ b/src/predicates/isProfunctor.js
@@ -1,15 +1,5 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const hasAlg = require('../core/hasAlg')
-const isContravariant = require('../core/isContravariant')
-const isFunctor = require('../core/isFunctor')
-
-// isProfunctor : a -> Boolean
-function isProfunctor(m) {
-  return isFunctor(m)
-    && isContravariant(m)
-    && hasAlg('promap', m)
-}
-
-module.exports = isProfunctor
+module.exports =
+  require('../core/isProfunctor')

--- a/src/predicates/isProfunctor.spec.js
+++ b/src/predicates/isProfunctor.spec.js
@@ -1,33 +1,10 @@
 const test = require('tape')
-const helpers = require('../test/helpers')
-
-const makeFake = helpers.makeFake
 
 const isFunction = require('../core/isFunction')
-
-const identity = x => x
 
 const isProfunctor = require('./isProfunctor')
 
 test('isProfunctor predicate function', t => {
-  const Fake = makeFake([ 'contramap', 'map', 'promap' ])
-  const fake = Fake()
-
-  t.ok(isFunction(isProfunctor))
-
-  t.equal(isProfunctor(undefined), false, 'returns false for undefined')
-  t.equal(isProfunctor(null), false, 'returns false for null')
-  t.equal(isProfunctor(0), false, 'returns false for falsey number')
-  t.equal(isProfunctor(1), false, 'returns false for truthy number')
-  t.equal(isProfunctor(''), false, 'returns false for falsey string')
-  t.equal(isProfunctor('string'), false, 'returns false for truthy string')
-  t.equal(isProfunctor(false), false, 'returns false for false')
-  t.equal(isProfunctor(true), false, 'returns false for true')
-  t.equal(isProfunctor({}), false, 'returns false for an object')
-  t.equal(isProfunctor(identity), false, 'returns false for function')
-
-  t.equal(isProfunctor(Fake), true, 'returns true when a Contravariant Functor Constructor is passed')
-  t.equal(isProfunctor(fake), true, 'returns true when a Contravariant Functor is passed')
-
+  t.ok(isFunction(isProfunctor), 'is a function')
   t.end()
 })

--- a/src/predicates/isSetoid.spec.js
+++ b/src/predicates/isSetoid.spec.js
@@ -32,3 +32,13 @@ test('isSetoid predicate function', t => {
 
   t.end()
 })
+
+test('isSetoid fantasy-land', t => {
+  const Fake = makeFake([ 'equals' ], true)
+  const fake = Fake()
+
+  t.equal(isSetoid(Fake), false, 'returns false when a Setoid Constructor is passed')
+  t.equal(isSetoid(fake), true, 'returns true when a Setoid is passed')
+
+  t.end()
+})

--- a/src/predicates/isTraversable.spec.js
+++ b/src/predicates/isTraversable.spec.js
@@ -27,8 +27,18 @@ test('isTraversable predicate function', t => {
   t.equal(isTraversable([]), false, 'returns false for an array')
   t.equal(isTraversable(identity), false, 'returns false for function')
 
-  t.equal(isTraversable(Fake), true, 'returns true when a Traversable Constructor is passed')
-  t.equal(isTraversable(fake), true, 'returns true when a Traversable is passed')
+  t.equal(isTraversable(Fake), true, 'returns true when Traversable Constructor is passed')
+  t.equal(isTraversable(fake), true, 'returns true when Traversable is passed')
+
+  t.end()
+})
+
+test('isTraversable fantasy-land', t => {
+  const Fake = makeFake([ 'map', 'traverse' ], true)
+  const fake = Fake()
+
+  t.equal(isTraversable(Fake), false, 'returns false when Traversable Constructor is passed')
+  t.equal(isTraversable(fake), false, 'returns false when Traversable is passed')
 
   t.end()
 })

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -1,8 +1,19 @@
+const fl = require('../core/flNames')
+
 const id =
   x => x
 
 const slice =
   x => Array.prototype.slice.call(x)
+
+const contains = xs => x =>
+  xs.indexOf(x) !== -1
+
+const repFuncs =
+  [ 'id', 'empty', 'of', 'zero' ]
+
+const isRepFunc =
+  contains(repFuncs)
 
 function bindFunc(fn) {
   return function() {
@@ -10,20 +21,33 @@ function bindFunc(fn) {
   }
 }
 
-function makeFake(algs) {
+function makeFake(algs, useFl) {
   const xs = algs.slice()
+  const hasAlg = contains(xs)
 
-  const Fake = function() {
-    return xs.reduce(function(o, alg) {
-      o[alg] = id
-      return o
-    }, {})
+  const inst = xs.reduce((o, alg) => {
+    if(!isRepFunc(alg)) {
+      o[useFl ? fl[alg] : alg] = id
+    }
+
+    return o
+  }, {})
+
+  const Fake =
+    () => inst
+
+  if(!useFl) {
+    Fake['@@implements'] = hasAlg
   }
 
-  Fake['@@implements'] =
-    x => xs.indexOf(x) !== -1
+  inst.constructor = Fake
 
-  return Fake
+  return repFuncs.reduce((c, alg) => {
+    if(hasAlg(alg)) {
+      c[fl[alg]] = id
+    }
+    return c
+  }, Fake)
 }
 
 module.exports = {

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -26,8 +26,9 @@ function makeFake(algs, useFl) {
   const hasAlg = contains(xs)
 
   const inst = xs.reduce((o, alg) => {
-    if(!isRepFunc(alg)) {
-      o[useFl ? fl[alg] : alg] = id
+    const fn = useFl ? fl[alg] : alg
+    if(!isRepFunc(alg) && fn) {
+      o[fn] = id
     }
 
     return o
@@ -43,8 +44,9 @@ function makeFake(algs, useFl) {
   inst.constructor = Fake
 
   return repFuncs.reduce((c, alg) => {
-    if(hasAlg(alg)) {
-      c[fl[alg]] = id
+    const fn = useFl ? fl[alg] : alg
+    if(hasAlg(alg) && fn) {
+      c[fn] = id
     }
     return c
   }, Fake)


### PR DESCRIPTION
## Fantasy All the THINGS!!
![image](https://user-images.githubusercontent.com/3665793/41206294-a3cc7c24-6cb6-11e8-829a-f9504fd882ca.png)

As a first step to [this issue](https://github.com/evilsoft/crocks/issues/202) we need to get the Fantasy Land Methods/Function specific predicates to respect the fantasy-land spec. This PR adds the following to all fantasy-land predicates:
* Check for method on passed object (Constructor/Instance), favoring the fantasy-land prefix over non-decorated.

* Check for method on `constructor` for methods specific to the `TypeRep`. `crocks` provides these functions on the instance as well as the `TypeRep`, but not all libs do that, so we need to check the `TypeRep` of the instance.

* Check for `@@implements` method. There are functions in crocks that can take a `TypeRep` as arguments and need to use that `TypeRep` for typeclass validation. For instance `isFunctor(Identity)` would return true. This is a sole feature of `crocks` and is not part of the fantasy-land spec. As a result only `crocks` or outside types that implement the `@@implements` method will return true when checked against a given `TypeRep`

* Also due to the lack of `ap` and `traverse`, there are a few predicates that will return false for fantasy-land types until those specs are fully implemented:
  * `isAlternative`( must be an `Applicative`)
  * `isApplicative`
  * `isApply`
  * `isChain` (must be an `Apply`)
  * `isMonad` (must be a `Chain`)
  * `isTraversable`