### PR TITLE
Add Fantasy Land Compliance for Pointfree Functions

### DIFF
--- a/src/core/equals.js
+++ b/src/core/equals.js
@@ -53,7 +53,7 @@ function equals(a, b) {
   }
 
   if(hasAlg('equals', a)) {
-    return (b[fl.equals] || b.equals).bind(b)(a)
+    return (b[fl.equals] || b.equals).call(b, a)
   }
 
   return (strats[type(a)] || comp)(a, b)

--- a/src/core/equals.js
+++ b/src/core/equals.js
@@ -5,6 +5,7 @@ const isSameType = require('./isSameType')
 const isSame = require('./isSame')
 const hasAlg = require('./hasAlg')
 const type = require('./type')
+const fl = require('./flNames')
 
 const comp = (a, b) =>
   a.valueOf() === b.valueOf()
@@ -52,8 +53,9 @@ function equals(a, b) {
   }
 
   if(hasAlg('equals', a)) {
-    return a.equals(b)
+    return (b[fl.equals] || b.equals).bind(b)(a)
   }
+
   return (strats[type(a)] || comp)(a, b)
 }
 

--- a/src/core/hasAlg.js
+++ b/src/core/hasAlg.js
@@ -7,12 +7,10 @@ const fl = require('./flNames')
 const check = (alg, m) =>
   isFunction(m[fl[alg]]) || isFunction(m[alg])
 
-const checkRep = (alg, m) =>
-  !!m.constructor && isFunction(m.constructor[fl[alg]])
-    || isFunction(m.constructor[alg])
+const checkImpl = (alg, m) =>
+  isFunction(m['@@implements']) && !!m['@@implements'](alg)
 
 const hasAlg = (alg, m) =>
-  !!m && (check(alg, m) || checkRep(alg, m))
-    || isFunction(m['@@implements']) && !!m['@@implements'](alg)
+  !!m && (check(alg, m) || checkImpl(alg, m))
 
 module.exports = hasAlg

--- a/src/core/isApplicative.js
+++ b/src/core/isApplicative.js
@@ -7,7 +7,7 @@ const isApply = require('./isApply')
 // isApplicative : a -> Boolean
 function isApplicative(m) {
   return isApply(m)
-    && hasAlg('of', m)
+    && (hasAlg('of', m) || hasAlg('of', m.constructor))
 }
 
 module.exports = isApplicative

--- a/src/core/isMonoid.js
+++ b/src/core/isMonoid.js
@@ -7,7 +7,7 @@ const isSemigroup = require('./isSemigroup')
 // isMonoid :: a -> Boolean
 function isMonoid(m) {
   return isSemigroup(m)
-    && hasAlg('empty', m)
+    && (hasAlg('empty', m) || hasAlg('empty', m.constructor))
 }
 
 module.exports = isMonoid

--- a/src/core/isPlus.js
+++ b/src/core/isPlus.js
@@ -7,7 +7,7 @@ const isAlt = require('./isAlt')
 // isPlus : a -> Boolean
 function isPlus(m) {
   return isAlt(m)
-    && hasAlg('zero', m)
+    && (hasAlg('zero', m) || hasAlg('zero', m.constructor))
 }
 
 module.exports = isPlus

--- a/src/pointfree/alt.js
+++ b/src/pointfree/alt.js
@@ -2,6 +2,7 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const curry = require('../core/curry')
+const fl = require('../core/flNames')
 const isAlt = require('../core/isAlt')
 const isSameType = require('../core/isSameType')
 
@@ -13,7 +14,7 @@ function alt(m, x) {
     )
   }
 
-  return x.alt(m)
+  return (x[fl.alt] || x.alt).bind(x)(m)
 }
 
 module.exports = curry(alt)

--- a/src/pointfree/alt.js
+++ b/src/pointfree/alt.js
@@ -14,7 +14,7 @@ function alt(m, x) {
     )
   }
 
-  return (x[fl.alt] || x.alt).bind(x)(m)
+  return (x[fl.alt] || x.alt).call(x, m)
 }
 
 module.exports = curry(alt)

--- a/src/pointfree/bimap.js
+++ b/src/pointfree/bimap.js
@@ -19,7 +19,7 @@ function bimap(f, g, m) {
     )
   }
 
-  return (m[fl.bimap] || m.bimap).bind(m)(f, g)
+  return (m[fl.bimap] || m.bimap).call(m, f, g)
 }
 
 module.exports = curry(bimap)

--- a/src/pointfree/bimap.js
+++ b/src/pointfree/bimap.js
@@ -4,6 +4,7 @@
 const curry = require('../core/curry')
 const isBifunctor = require('../core/isBifunctor')
 const isFunction = require('../core/isFunction')
+const fl = require('../core/flNames')
 
 function bimap(f, g, m) {
   if(!(isFunction(f) &&  isFunction(g))) {
@@ -18,7 +19,7 @@ function bimap(f, g, m) {
     )
   }
 
-  return m.bimap(f, g)
+  return (m[fl.bimap] || m.bimap).bind(m)(f, g)
 }
 
 module.exports = curry(bimap)

--- a/src/pointfree/bimap.spec.js
+++ b/src/pointfree/bimap.spec.js
@@ -4,10 +4,17 @@ const helpers = require('../test/helpers')
 
 const bindFunc = helpers.bindFunc
 
+const fl = require('../core/flNames')
 const isFunction = require('../core/isFunction')
 const unit = require('../core/_unit')
 
+const constant = x => () => x
 const identity = x => x
+
+const mock = x => Object.assign({}, {
+  map: unit,
+  bimap: sinon.spy()
+}, x)
 
 const bimap = require('./bimap')
 
@@ -54,15 +61,35 @@ test('bimap pointfree', t => {
   t.end()
 })
 
-test('bimap bifunctor', t => {
-  const m = {
-    map: unit,
-    bimap: sinon.spy(unit)
-  }
+test('bimap with Bifunctor', t => {
+  const x = 'result'
+  const m = mock({ bimap: sinon.spy(constant(x)) })
 
-  bimap(identity)(identity, m)
+  const f = x => identity(x)
+  const g = x => identity(x)
 
-  t.ok(m.bimap.calledWith(identity, identity), 'calls bimap on bifunctor, passing the function')
+  const result = bimap(f)(g, m)
+
+  t.ok(m.bimap.calledWith(f, g), 'calls bimap on third argument, passing the (2) functions')
+  t.ok(m.bimap.calledOn(m), 'binds bimap to third argument')
+  t.equal(result, x, 'returns the result of bimap on third argument')
+
+  t.end()
+})
+
+test('bimap with Bifunctor (fantasy-land)', t => {
+  const x = 'result'
+  const m = mock({ [fl.bimap]: sinon.spy(constant(x)) })
+
+  const f = x => identity(x)
+  const g = x => identity(x)
+
+  const result = bimap(f, g, m)
+
+  t.ok(m[fl.bimap].calledWith(f, g), 'calls fantasy-land/bimap on third argument, passing the (2) functions')
+  t.ok(m[fl.bimap].calledOn(m), 'binds fantasy-land/bimap to third argument')
+  t.equal(result, x, 'returns the result of fantasy-land/bimap on third argument')
+  t.notOk(m.bimap.called, 'does not call bimap on third argument')
 
   t.end()
 })

--- a/src/pointfree/chain.js
+++ b/src/pointfree/chain.js
@@ -22,7 +22,7 @@ function chain(fn, m) {
     return _chain(fn, m)
   }
 
-  return (m[fl.chain] || m.chain).bind(m)(fn)
+  return (m[fl.chain] || m.chain).call(m, fn)
 }
 
 module.exports = curry(chain)

--- a/src/pointfree/chain.js
+++ b/src/pointfree/chain.js
@@ -6,6 +6,7 @@ const curry = require('../core/curry')
 const isArray = require('../core/isArray')
 const isChain = require('../core/isChain')
 const isFunction = require('../core/isFunction')
+const fl = require('../core/flNames')
 
 // chain : Chain m => (a -> m b) -> m a -> m b
 function chain(fn, m) {
@@ -21,7 +22,7 @@ function chain(fn, m) {
     return _chain(fn, m)
   }
 
-  return m.chain(fn)
+  return (m[fl.chain] || m.chain).bind(m)(fn)
 }
 
 module.exports = curry(chain)

--- a/src/pointfree/concat.js
+++ b/src/pointfree/concat.js
@@ -13,7 +13,7 @@ function concat(x, m) {
     )
   }
 
-  return (m[fl.concat] || m.concat).bind(m)(x)
+  return (m[fl.concat] || m.concat).call(m, x)
 }
 
 module.exports = curry(concat)

--- a/src/pointfree/concat.js
+++ b/src/pointfree/concat.js
@@ -4,20 +4,16 @@
 const curry = require('../core/curry')
 const isSameType = require('../core/isSameType')
 const isSemigroup = require('../core/isSemigroup')
-const isString = require('../core/isString')
+const fl = require('../core/flNames')
 
 function concat(x, m) {
   if(!(isSemigroup(m) && isSameType(x, m))) {
     throw new TypeError(
-      'concat: Semigroups of the same type required both arguments'
+      'concat: Semigroups of the same type required for both arguments'
     )
   }
 
-  if(isString(m)) {
-    return m + x
-  }
-
-  return m.concat(x)
+  return (m[fl.concat] || m.concat).bind(m)(x)
 }
 
 module.exports = curry(concat)

--- a/src/pointfree/contramap.js
+++ b/src/pointfree/contramap.js
@@ -4,6 +4,8 @@
 const compose = require('../core/compose')
 const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
+const isContravariant = require('../core/isContravariant')
+const fl = require('../core/flNames')
 
 // contramap : Functor f => (b -> a) -> f b -> f a
 function contramap(fn, m) {
@@ -17,9 +19,10 @@ function contramap(fn, m) {
     return compose(m, fn)
   }
 
-  if(m && isFunction(m.contramap)) {
-    return m.contramap(fn)
+  if(isContravariant(m)) {
+    return (m[fl.contramap] || m.contramap).bind(m)(fn)
   }
+
   throw new TypeError(
     'contramap: Function or Contavariant Functor of the same type required for second argument'
   )

--- a/src/pointfree/contramap.js
+++ b/src/pointfree/contramap.js
@@ -20,7 +20,7 @@ function contramap(fn, m) {
   }
 
   if(isContravariant(m)) {
-    return (m[fl.contramap] || m.contramap).bind(m)(fn)
+    return (m[fl.contramap] || m.contramap).call(m, fn)
   }
 
   throw new TypeError(

--- a/src/pointfree/contramap.spec.js
+++ b/src/pointfree/contramap.spec.js
@@ -6,10 +6,16 @@ const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
 const unit = require('../core/_unit')
+const fl = require('../core/flNames')
 
+const constant = x => () => x
 const identity = x => x
 
 const contramap = require('./contramap')
+
+const mock = x => Object.assign({}, {
+  contramap: sinon.spy()
+}, x)
 
 test('contramap pointfree', t => {
   const m = bindFunc(contramap)
@@ -47,12 +53,36 @@ test('contramap pointfree', t => {
   t.end()
 })
 
-test('contramap contra functor', t => {
-  const m = { contramap: sinon.spy(unit) }
+test('contramap with Contravariant', t => {
+  const x = 'result'
 
-  contramap(identity, m)
+  const m = mock({
+    contramap: sinon.spy(constant(x))
+  })
 
-  t.ok(m.contramap.calledWith(identity), 'calls contramap on functor, passing the function')
+  const result = contramap(identity, m)
+
+  t.ok(m.contramap.calledWith(identity), 'calls contramap on second argument, passing the function')
+  t.ok(m.contramap.calledOn(m), 'binds contramap to second argument')
+  t.equal(result, x, 'returns the result of contramap on second argument')
+
+  t.end()
+})
+
+test('contramap with Contravariant (fantasy-land)', t => {
+  const x = 'result'
+
+  const m = mock({
+    [fl.contramap]: sinon.spy(constant(x))
+  })
+
+  const result = contramap(identity, m)
+
+  t.ok(m[fl.contramap].calledWith(identity), 'calls fantasy-land/contramap on second argument, passing function')
+  t.ok(m[fl.contramap].calledOn(m), 'binds fantasy-land/contramap to second argument')
+  t.equal(result, x, 'returns the result of fantasy-land/contramap on second argument')
+  t.notOk(m.contramap.called, 'does not call contramap on second argument')
+
   t.end()
 })
 

--- a/src/pointfree/empty.js
+++ b/src/pointfree/empty.js
@@ -7,11 +7,11 @@ const fl = require('../core/flNames')
 
 function empty(m) {
   if(m && hasAlg('empty', m)) {
-    return (m[fl.empty]
-      || m.empty
-      || m.constructor[fl.empty]
-      || m.constructor.empty
-    ).bind(m)()
+    return (m[fl.empty] || m.empty).bind(m)()
+  }
+
+  if(m && hasAlg('empty', m.constructor)) {
+    return (m.constructor[fl.empty] || m.constructor.empty).bind(m)()
   }
 
   if(isSameType([], m)) {

--- a/src/pointfree/empty.js
+++ b/src/pointfree/empty.js
@@ -7,11 +7,11 @@ const fl = require('../core/flNames')
 
 function empty(m) {
   if(m && hasAlg('empty', m)) {
-    return (m[fl.empty] || m.empty).bind(m)()
+    return (m[fl.empty] || m.empty).call(m)
   }
 
   if(m && hasAlg('empty', m.constructor)) {
-    return (m.constructor[fl.empty] || m.constructor.empty).bind(m)()
+    return (m.constructor[fl.empty] || m.constructor.empty).call(m)
   }
 
   if(isSameType([], m)) {

--- a/src/pointfree/empty.js
+++ b/src/pointfree/empty.js
@@ -1,12 +1,17 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const isFunction = require('../core/isFunction')
+const hasAlg = require('../core/hasAlg')
 const isSameType = require('../core/isSameType')
+const fl = require('../core/flNames')
 
 function empty(m) {
-  if(m && isFunction(m.empty)) {
-    return m.empty()
+  if(m && hasAlg('empty', m)) {
+    return (m[fl.empty]
+      || m.empty
+      || m.constructor[fl.empty]
+      || m.constructor.empty
+    ).bind(m)()
   }
 
   if(isSameType([], m)) {

--- a/src/pointfree/empty.spec.js
+++ b/src/pointfree/empty.spec.js
@@ -4,15 +4,22 @@ const helpers = require('../test/helpers')
 
 const bindFunc = helpers.bindFunc
 
+const isFunction = require('../core/isFunction')
+const fl = require('../core/flNames')
 const unit = require('../core/_unit')
 
 const constant = x => () => x
+
+const mock = (x, value) => Object.assign({}, {
+  constructor: { empty: sinon.spy(constant(value)) }
+}, x)
 
 const empty = require('./empty')
 
 test('empty pointfree', t => {
   const fn = bindFunc(empty)
-  const mock = { empty: sinon.spy(constant('result')) }
+
+  t.ok(isFunction(empty), 'empty is a function')
 
   const err = /empty: Monoid, Array, String or Object required/
   t.throws(fn(undefined), err, 'throws with undefined')
@@ -23,17 +30,92 @@ test('empty pointfree', t => {
   t.throws(fn(true), err, 'throws with a true')
   t.throws(fn(unit), err, 'throws with a function')
 
+  t.end()
+})
+
+test('empty with String', t => {
   t.equal(empty(''), '', 'returns an empty string for a string value')
   t.equal(empty(String), '', 'returns an empty string for a string constructor')
+
+  t.end()
+})
+
+test('empty with Array', t => {
   t.same(empty([]), [], 'returns an empty array for an array value')
   t.same(empty(Array), [], 'returns an empty array for an array constructor')
+
+  t.end()
+})
+
+test('empty with Object', t => {
   t.same(empty({}), {}, 'returns an empty object for an object value')
   t.same(empty(Object), {}, 'returns an empty object for an object constructor')
 
-  const result = empty(mock)
+  t.end()
+})
 
-  t.ok(mock.empty.called, 'calls empty on object with it defined')
-  t.equal(result, 'result', 'resturns the result of empty call')
+test('empty with Monoid same level', t => {
+  const x = 'result'
+
+  const m = mock({
+    empty: sinon.spy(constant(x))
+  }, x)
+
+  const result = empty(m)
+
+  t.ok(m.empty.called, 'calls empty on object')
+  t.ok(m.empty.calledOn(m), 'binds empty to provided object')
+  t.equal(result, x, 'returns the result of empty call')
+
+  t.end()
+})
+
+test('empty with Monoid on constructor of instance', t => {
+  const x = 'result'
+  const m = mock({}, x)
+
+  const result = empty(m)
+
+  t.ok(m.constructor.empty.called, 'calls empty on object constructor')
+  t.ok(m.constructor.empty.calledOn(m), 'binds constructor empty to provided instance')
+  t.equal(result, x, 'returns the result of empty call')
+
+  t.end()
+})
+
+test('empty with Monoid same level (fantasy-land)', t => {
+  const x = 'result'
+
+  const m = mock({
+    empty: sinon.spy(),
+    [fl.empty]: sinon.spy(constant(x))
+  }, x)
+
+  const result = empty(m)
+
+  t.ok(m[fl.empty].called, 'calls fantasy-land/empty on object')
+  t.ok(m[fl.empty].calledOn(m), 'binds fantasy-land/empty to provided object')
+  t.equal(result, x, 'returns the result of empty call')
+  t.notOk(m.empty.called, 'does not call empty')
+
+  t.end()
+})
+
+test('empty with Monoid on constructor of instance (fantasy-land)', t => {
+  const x = 'result'
+  const m = {
+    constructor: {
+      empty: sinon.spy(),
+      [fl.empty]: sinon.spy(constant(x))
+    }
+  }
+
+  const result = empty(m)
+
+  t.ok(m.constructor[fl.empty].called, 'calls fantasy-land/empty on object constructor')
+  t.ok(m.constructor[fl.empty].calledOn(m), 'binds constructor fantasy-land/empty to provided instance')
+  t.equal(result, x, 'returns the result of empty call')
+  t.notOk(m.constructor.empty.called, 'does not call constructor empty')
 
   t.end()
 })

--- a/src/pointfree/extend.js
+++ b/src/pointfree/extend.js
@@ -15,7 +15,7 @@ function extend(fn, m) {
     throw new TypeError('extend: Extend required for second argument')
   }
 
-  return (m[fl.extend] || m.extend).bind(m)(fn)
+  return (m[fl.extend] || m.extend).call(m, fn)
 }
 
 module.exports = curry(extend)

--- a/src/pointfree/extend.js
+++ b/src/pointfree/extend.js
@@ -2,6 +2,7 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const curry = require('../core/curry')
+const fl = require('../core/flNames')
 const isExtend = require('../core/isExtend')
 const isFunction = require('../core/isFunction')
 
@@ -14,7 +15,7 @@ function extend(fn, m) {
     throw new TypeError('extend: Extend required for second argument')
   }
 
-  return m.extend(fn)
+  return (m[fl.extend] || m.extend).bind(m)(fn)
 }
 
 module.exports = curry(extend)

--- a/src/pointfree/map.js
+++ b/src/pointfree/map.js
@@ -1,13 +1,15 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const array = require('../core/array')
 const compose = require('../core/compose')
 const curry = require('../core/curry')
 const isArray = require('../core/isArray')
 const isObject = require('../core/isObject')
 const isFunction = require('../core/isFunction')
+
+const array = require('../core/array')
 const object = require('../core/object')
+const fl = require('../core/flNames')
 
 // map : Functor f => (a -> b) -> f a -> f b
 function map(fn, m) {
@@ -21,6 +23,10 @@ function map(fn, m) {
 
   if(isArray(m)) {
     return array.map(fn, m)
+  }
+
+  if(m && isFunction(m[fl.map])) {
+    return m[fl.map](fn)
   }
 
   if(m && isFunction(m.map)) {

--- a/src/pointfree/map.js
+++ b/src/pointfree/map.js
@@ -6,6 +6,7 @@ const curry = require('../core/curry')
 const isArray = require('../core/isArray')
 const isObject = require('../core/isObject')
 const isFunction = require('../core/isFunction')
+const isFunctor= require('../core/isFunctor')
 
 const array = require('../core/array')
 const object = require('../core/object')
@@ -25,12 +26,8 @@ function map(fn, m) {
     return array.map(fn, m)
   }
 
-  if(m && isFunction(m[fl.map])) {
-    return m[fl.map](fn)
-  }
-
-  if(m && isFunction(m.map)) {
-    return m.map(fn)
+  if(m && isFunctor(m)) {
+    return (m[fl.map] || m.map).call(m, fn)
   }
 
   if(isObject(m)) {

--- a/src/pointfree/map.spec.js
+++ b/src/pointfree/map.spec.js
@@ -6,8 +6,14 @@ const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
 const unit = require('../core/_unit')
+const fl = require('../core/flNames')
 
+const constant = x => () => x
 const identity = x => x
+
+const mock = x => Object.assign({}, {
+  map: sinon.spy()
+}, x)
 
 const map = require('./map')
 
@@ -42,12 +48,36 @@ test('map pointfree', t => {
   t.end()
 })
 
-test('map functor', t => {
-  const m = { map: sinon.spy(unit) }
+test('map with Functor', t => {
+  const x = 'result'
 
-  map(identity)(m)
+  const m = mock({
+    map: sinon.spy(constant(x))
+  })
+
+  const result = map(identity)(m)
 
   t.ok(m.map.calledWith(identity), 'calls map on functor, passing the function')
+  t.ok(m.map.calledOn(m), 'binds map to second argument')
+  t.equal(result, x, 'returns the result of map on second argument')
+
+  t.end()
+})
+
+test('map with Functor (fantasy-land)', t => {
+  const x = 'result'
+
+  const m = mock({
+    [fl.map]: sinon.spy(constant(x))
+  })
+
+  const result = map(identity)(m)
+
+  t.ok(m[fl.map].calledWith(identity), 'calls fantasy-land/map on functor')
+  t.ok(m[fl.map].calledOn(m), 'binds fantasy-land/map to second argument')
+  t.equal(result, x, 'returns the result of fantasy-land/map on second argument')
+  t.notOk(m.map.called, 'does not call map on functor, when fantasy-land/map present')
+
   t.end()
 })
 

--- a/src/pointfree/promap.js
+++ b/src/pointfree/promap.js
@@ -3,7 +3,9 @@
 
 const compose = require('../core/compose')
 const curry = require('../core/curry')
+const fl = require('../core/flNames')
 const isFunction = require('../core/isFunction')
+const isProfunctor = require('../core/isProfunctor')
 
 function promap(l, r, m) {
   if(!(isFunction(l) && isFunction(r))) {
@@ -16,8 +18,8 @@ function promap(l, r, m) {
     return compose(compose(r, m), l)
   }
 
-  if(m && isFunction(m.promap)) {
-    return m.promap(l, r)
+  if(isProfunctor(m)) {
+    return (m[fl.promap] || m.promap).bind(m)(l, r)
   }
 
   throw new TypeError(

--- a/src/pointfree/promap.js
+++ b/src/pointfree/promap.js
@@ -19,7 +19,7 @@ function promap(l, r, m) {
   }
 
   if(isProfunctor(m)) {
-    return (m[fl.promap] || m.promap).bind(m)(l, r)
+    return (m[fl.promap] || m.promap).call(m, l, r)
   }
 
   throw new TypeError(

--- a/src/pointfree/promap.spec.js
+++ b/src/pointfree/promap.spec.js
@@ -5,9 +5,17 @@ const helpers = require('../test/helpers')
 const bindFunc = helpers.bindFunc
 
 const isFunction = require('../core/isFunction')
+const fl = require('../core/flNames')
 const unit = require('../core/_unit')
 
+const constant = x => () => x
 const identity = x => x
+
+const mock = x => Object.assign({}, {
+  contramap: unit,
+  map: unit,
+  promap: sinon.spy()
+}, x)
 
 const promap = require('./promap')
 
@@ -55,12 +63,41 @@ test('promap pointfree', t => {
   t.end()
 })
 
-test('promap profunctor', t => {
-  const m = { promap: sinon.spy(unit) }
+test('promap Profunctor', t => {
+  const x = 'result'
 
-  promap(identity)(identity, m)
+  const m = mock({
+    promap: sinon.spy(constant(x))
+  })
 
-  t.ok(m.promap.calledWith(identity, identity), 'calls promap on profunctor, passing the function')
+  const f = constant('left')
+  const g = constant('right')
+
+  const result = promap(f)(g, m)
+
+  t.ok(m.promap.calledWith(f, g), 'calls promap on third, passing functions')
+  t.ok(m.promap.calledOn(m), 'binds promap to third argument')
+  t.equal(result, x, 'returns the result of promap on third argument')
+
+  t.end()
+})
+
+test('promap Profunctor (fantasy-land)', t => {
+  const x = 'result'
+
+  const m = mock({
+    [fl.promap]: sinon.spy(constant(x))
+  })
+
+  const f = constant('left')
+  const g = constant('right')
+
+  const result = promap(f)(g, m)
+
+  t.ok(m[fl.promap].calledWith(f, g), 'calls fantasy-land/promap on third, passing functions')
+  t.ok(m[fl.promap].calledOn(m), 'binds fanstay-land/promap to third argument')
+  t.equal(result, x, 'returns the result of fantasy-land/promap on third argument')
+  t.notOk(m.promap.called, 'does not call promap on third argument')
 
   t.end()
 })

--- a/src/pointfree/reduce.js
+++ b/src/pointfree/reduce.js
@@ -4,6 +4,7 @@
 const curry = require('../core/curry')
 const isFoldable = require('../core/isFoldable')
 const isFunction = require('../core/isFunction')
+const fl = require('../core/flNames')
 
 function reduce(fn, init, m) {
   if(!isFunction(fn)) {
@@ -18,7 +19,7 @@ function reduce(fn, init, m) {
     )
   }
 
-  return m.reduce(fn, init)
+  return (m[fl.reduce] || m.reduce).bind(m)(fn, init)
 }
 
 module.exports = curry(reduce)

--- a/src/pointfree/reduce.js
+++ b/src/pointfree/reduce.js
@@ -19,7 +19,7 @@ function reduce(fn, init, m) {
     )
   }
 
-  return (m[fl.reduce] || m.reduce).bind(m)(fn, init)
+  return (m[fl.reduce] || m.reduce).call(m, fn, init)
 }
 
 module.exports = curry(reduce)

--- a/src/predicates/isCategory.js
+++ b/src/predicates/isCategory.js
@@ -7,7 +7,7 @@ const isSemigroupoid = require('../core/isSemigroupoid')
 // isCategory : a -> Boolean
 function isCategory(m) {
   return isSemigroupoid(m)
-    && hasAlg('id', m)
+    && (hasAlg('id', m) || hasAlg('id', m.constructor))
 }
 
 module.exports = isCategory


### PR DESCRIPTION
## The Latest in Point Free Energy
![image](https://user-images.githubusercontent.com/3665793/41392650-cf48afc4-6f56-11e8-95a0-51118026052e.png)

This PR finishes off [this issue](https://github.com/evilsoft/crocks/issues/202) by adding a preference to fantasy-land methods/functions over non-decorated methods/functions.

Like with the predicates, this covers all of the methods/functions that are implemented at this time. When we add the `ap` and `traverse` implementations, we will go back and add both the assosiated predicates and pointfree functions.

Tested these against `folktale`, `Fluture`, `creed` and `most`
