### PR TITLE
Add Tuple documentation

### DIFF
--- a/docs/src/pages/docs/crocks/Pair.md
+++ b/docs/src/pages/docs/crocks/Pair.md
@@ -2,7 +2,7 @@
 title: "Pair"
 description: "Canonical Product Type"
 layout: "guide"
-functions: ["branch", "fst", "merge", "snd", "topairs", "writertopair"]
+functions: ["branch", "fst", "snd", "topairs", "writertopair"]
 weight: 100
 ---
 
@@ -29,7 +29,7 @@ of the concatenation in the first position of the resulting `Pair`.
 
 A helpful benefit of the `Bifunctor` aspects `Pair` allows for defining parallel
 computations. There are many functions that ship with `crocks` that allow for
-parallelization such as [`branch`](#branch), [`merge`](#merge-pointfree) and
+parallelization such as [`branch`](#branch), `merge` and
 `fanout`. Using those helpers in conjunction with the ability to
 [`bimap`](#bimap) functions over a given `Pair`s values.
 
@@ -40,7 +40,7 @@ import bimap from 'crocks/pointfree/bimap'
 import branch from 'crocks/Pair/branch'
 import compose from 'crocks/helpers/compose'
 import mreduce from 'crocks/helpers/mreduce'
-import merge from 'crocks/Pair/merge'
+import merge from 'crocks/pointfree/merge'
 
 // negate :: a -> Boolean
 const negate =
@@ -114,7 +114,7 @@ Pair(34, Pair(true, 'string'))
 
 ## Instance Methods
 
-#### twoals
+#### equals
 
 ```haskell
 Pair a b ~> c -> Boolean
@@ -230,7 +230,7 @@ import Pair from 'crocks/Pair'
 
 import compose from 'crocks/helpers/compose'
 import map from 'crocks/pointfree/map'
-import merge from 'crocks/Pair/merge'
+import merge from 'crocks/pointfree/merge'
 import objOf from 'crocks/helpers/objOf'
 
 // length :: String -> Number
@@ -280,7 +280,7 @@ import compose from 'crocks/helpers/compose'
 import bimap from 'crocks/pointfree/bimap'
 import branch from 'crocks/Pair/branch'
 import identity from 'crocks/combinators/identity'
-import merge from 'crocks/Pair/merge'
+import merge from 'crocks/pointfree/merge'
 import mreduce from 'crocks/helpers/mreduce'
 
 // add10 :: Number -> Number
@@ -551,7 +551,7 @@ second position, while leaving the value in the first position untouched.
 import Pair from 'crocks/Pair'
 
 import extend from 'crocks/pointfree/extend'
-import merge from 'crocks/Pair/merge'
+import merge from 'crocks/pointfree/merge'
 import objOf from 'crocks/helpers/objOf'
 
 // name :: Pair String String
@@ -708,7 +708,7 @@ import Sum from 'crocks/Sum'
 
 import compose from 'crocks/helpers/compose'
 import fanout from 'crocks/helpers/fanout'
-import merge from 'crocks/Pair/merge'
+import merge from 'crocks/pointfree/merge'
 import mreduce from 'crocks/helpers/mreduce'
 
 // length :: [ a ] -> Integer
@@ -763,7 +763,7 @@ import branch from 'crocks/Pair/branch'
 import compose from 'crocks/helpers/compose'
 import curry from 'crocks/helpers/curry'
 import objOf from 'crocks/helpers/objOf'
-import merge from 'crocks/Pair/merge'
+import merge from 'crocks/pointfree/merge'
 
 // add10 :: Number -> Number
 const add10 =
@@ -810,7 +810,7 @@ to this function named [`fromPairs`][frompairs].
 ```javascript
 import compose from 'crocks/helpers/compose'
 import map from 'crocks/pointfree/map'
-import merge from 'crocks/Pair/merge'
+import merge from 'crocks/pointfree/merge'
 import toPairs from 'crocks/Pair/toPairs'
 
 // record :: Object
@@ -865,7 +865,7 @@ import Pair from 'crocks/Pair'
 import flip from 'crocks/combinators/flip'
 import fst from 'crocks/Pair/fst'
 import ifElse from 'crocks/logic/ifElse'
-import merge from 'crocks/Pair/merge'
+import merge from 'crocks/pointfree/merge'
 import snd from 'crocks/Pair/snd'
 
 // lte :: (Number, Number) -> Boolean
@@ -887,53 +887,6 @@ min(Pair(45, 22))
 
 min(Pair(100, 100))
 //=> 100
-```
-
-#### merge (pointfree)
-
-`crocks/Pair/merge`
-
-```haskell
-merge :: ((a, b) -> c) -> Pair a b -> c
-```
-
-The pointfree `merge` function allows the ability to fold out a new value, using
-a binary function to combine the two values into one. This function takes two
-arguments, with the first being a binary function used to combine a `Pair`s
-values and the second is the instance of `Pair` for the function to be applied.
-Like the method on `Pair`, this function will return the result of the provided
-binary function.
-
-```javascript
-import Pair from 'crocks/Pair'
-
-import assoc from 'crocks/helpers/assoc'
-import compose from 'crocks/helpers/compose'
-import curry from 'crocks/helpers/curry'
-import map from 'crocks/pointfree/map'
-import merge from 'crocks/Pair/merge'
-
-// mergeObj :: Pair String a -> Object -> Object
-const mergeObj =
-  merge(assoc)
-
-// inc :: Number -> Number
-const inc =
-  x => x + 1
-
-// incAssign :: Pair String Number -> Object -> Object
-const incAssign = curry(
-  compose(mergeObj, map(inc))
-)
-
-incAssign(Pair('apples', 5), {})
-// { apples: 6 }
-
-incAssign(
-  Pair('num', 57),
-  { string: 'a string' }
-)
-// { string: 'a string', num: 58 }
 ```
 
 #### snd (pointfree)

--- a/docs/src/pages/docs/crocks/Tuple.md
+++ b/docs/src/pages/docs/crocks/Tuple.md
@@ -212,14 +212,11 @@ Semigroup s1, s2 => 2-Tuple s1 s2 ~> 2-Tuple s1 s2 -> 2-Tuple s1 s2
 ...
 ```
 
-When a given `n-Tuple` contains `Semigroup` instances in all defined `n`
-positions. It can be concatenated with another `n-Tuple` instance containing
-instances of the same `Semigroup`s in the same positions as the `n-Tuple`
-instance it is being concatenated with.
-
-`concat` will be called on each contained `Semigroup` instance with the instance
-corresponding to the other `n-Tuple` instance. The result of each concatenation
-will be provided in a new `n-Tuple` instance of the same `Semigroup`s.
+Two instances of the same `n-Tuple` can be combined using concatenation, as
+long as both have instances of the same `Semigroup`s in the same
+position. `concat` will be called on each contained `Semigroup` instance with
+the instance corresponding to the other `n-Tuple` instance. The result of each
+concatenation will be provided in a new `n-Tuple` instance.
 
 ```javascript
 import Tuple from 'crocks/Tuple'
@@ -255,9 +252,8 @@ value. `map` takes a function `(a -> b)` and will return a
 new `n-Tuple` instance with the result of mapping the rightmost value from its
 original `a` type to the resulting `b`.
 
-This method will only apply to the rightmost value, if the need to map one or
-many of the values in the various other positions, [`mapAll`](#mapall) can be
-used.
+This method will only apply to the rightmost value. [`mapAll`](#mapall) can be
+used to map over all values in a given `n-Tuple`.
 
 ```javascript
 import Tuple from 'crocks/Tuple'

--- a/docs/src/pages/docs/crocks/Tuple.md
+++ b/docs/src/pages/docs/crocks/Tuple.md
@@ -1,0 +1,480 @@
+---
+title: "Tuple"
+description: "Tuple Crock"
+layout: "guide"
+functions: ["nmap"]
+weight: 150
+---
+
+```haskell
+Tuple(n) = n-Tuple *...n
+```
+
+`Tuple` provides a means to construct a Product Type of an arbitrary size.
+This allows types to be defined with as many independent values as needed for
+a given flow.
+
+```javascript
+import Tuple from 'crocks/Tuple'
+
+import First from 'crocks/First'
+import Sum from 'crocks/Sum'
+
+import compose from 'crocks/helpers/compose'
+import concat from 'crocks/pointfree/concat'
+import constant from 'crocks/combinators/constant'
+import flip from 'crocks/combinators/flip'
+import ifElse from 'crocks/logic/ifElse'
+import mapReduce from 'crocks/helpers/mapReduce'
+import merge from 'crocks/pointfree/merge'
+import nmap from 'crocks/Tuple/nmap'
+import option from 'crocks/pointfree/option'
+import propEq from 'crocks/predicates/propEq'
+import valueOf from 'crocks/pointfree/valueOf'
+
+// Triple :: 3-Tuple
+const Triple = Tuple(3)
+
+// EventRecord :: { event: String, payload: a }
+// ReportTriple :: Triple Sum Sum (First Boolean)
+
+// data :: [ EventRecord ]
+const data = [
+  { event: 'start', payload: '' },
+  { event: 'answer', payload: { id: 4, correct: true } },
+  { event: 'answer', payload: { id: 2, correct: false } },
+  { event: 'answer', payload: { id: 5, correct: false } },
+  { event: 'stop', payload: '' },
+  { event: 'start', payload: '' },
+  { event: 'answer', payload: { id: 1, correct: true } },
+  { event: 'answer', payload: { id: 3, correct: true } },
+  { event: 'complete', payload: { passed: true } },
+  { event: 'stop', payload: '' }
+]
+
+// trimap :: (a -> d) -> (b -> e) -> (c -> f) -> Triple a b c -> Triple d e f
+const trimap =
+  nmap(3)
+
+// reportEmpty :: () -> ReportTriple
+const reportEmpty = () =>
+  Triple(Sum.empty(), Sum.empty(), First.empty())
+
+// encodeCorrect :: EventRecord -> Sum
+const encodeCorrect = ifElse(
+  propEq('correct', true),
+  constant(Sum(1)),
+  Sum.empty
+)
+
+// encode :: EventRecord -> ReportTriple
+const encode = ({ event, payload }) => {
+  switch (event) {
+  case 'stop':
+    return Triple(
+      Sum(1), Sum.empty(), First.empty()
+    )
+
+  case 'answer':
+    return Triple(
+      Sum.empty(), encodeCorrect(payload), First.empty()
+    )
+
+  case 'complete':
+    return Triple(
+      Sum.empty(), Sum.empty(), First(true)
+    )
+  }
+
+  return reportEmpty()
+}
+
+// extract :: ReportTriple -> Triple Number Number Boolean
+const extract =
+  trimap(valueOf, valueOf, option(false))
+
+// decode :: (Number, Number, Boolean) -> Object
+const decode = (attempts, correct, complete) =>
+  ({ attempts, correct, complete })
+
+// foldReport :: [ EventRecord ] -> ReportTriple
+const foldReport = mapReduce(
+  encode,
+  flip(concat),
+  reportEmpty()
+)
+
+// calculate :: [ EventRecord ] -> Object
+const calculate = compose(
+  merge(decode),
+  extract,
+  foldReport
+)
+
+calculate(data)
+//=> { attempts: 2, correct: 3, complete: true }
+```
+
+<article id="topic-implements">
+
+## Implements
+
+`Setoid`, `Semigroup`, `Functor`
+
+</article>
+
+<article id="topic-construction">
+
+## Construction
+
+```haskell
+Tuple :: Number -> n-Tuple *...n
+```
+
+`Tuple` is a type constructor that takes a non-zero, positive `Integer` as its
+argument. Instead of an instance, it will return a constructor that is used
+to construct an `n` sized `Tuple`, where `n` is the number of independent values
+that can be represented.
+
+The resulting `n-Tuple` constructor is parameterized as an `n-Functor`, where
+each parameter can vary from instance to instance.
+
+```javascript
+import Tuple from 'crocks/Tuple'
+
+// Triple :: 3-Tuple
+const Triple =
+  Tuple(3)
+
+// Quad :: 4-Tuple
+const Quad =
+  Tuple(4)
+
+Triple(false, true, 45)
+//=> 3-Tuple (false, true, 45)
+
+Quad({ a: true }, [ 1, 2, 3 ], 60, 'string')
+//=> 4-Tuple ({ a: true }, [ 1, 2, 3 ], 60, "string")
+```
+
+</article>
+
+<article id="topic-instance">
+
+## Instance Methods
+
+#### equals
+
+```haskell
+n-Tuple *...n ~> a -> Boolean
+```
+
+Used to compare the values of two `n-Tuple` instances by value.`equals` takes
+any given argument and will return a `true` if passed an `n-Tuple` of the same
+size with match values in the same positions as the `n-Tuple` `equals` was
+run on. If the provided argument is not an `n-Tuple` of the same type or the
+underlying values are not equal, then `equals` will return `false`.
+
+
+```javascript
+import Tuple from 'crocks/Tuple'
+
+// Pair :: 2-Tuple
+const Pair =
+  Tuple(2)
+
+// Triple :: 3-Tuple
+const Triple =
+  Tuple(3)
+
+Pair(1, false)
+  .equals(Pair(1, false))
+//=> true
+
+Triple(1, false, [ 1, 2 ])
+  .equals(Triple(1, false, [ 1, 2 ]))
+//=> true
+
+Triple(1, false, [ 1, 2 ])
+  .equals(Triple(1, true, [ 3, 4 ]))
+//=> false
+
+Pair(1, false)
+  .equals(Triple(1, false, [ 1, 2 ]))
+//=> false
+```
+
+#### concat
+
+```haskell
+Semigroup s1 => 1-Tuple s1 ~> 1-Tuple s1 -> 1-Tuple s1
+Semigroup s1, s2 => 2-Tuple s1 s2 ~> 2-Tuple s1 s2 -> 2-Tuple s1 s2
+...
+```
+
+When a given `n-Tuple` contains `Semigroup` instances in all defined `n`
+positions. It can be concatenated with another `n-Tuple` instance containing
+instances of the same `Semigroup`s in the same positions as the `n-Tuple`
+instance it is being concatenated with.
+
+`concat` will be called on each contained `Semigroup` instance with the instance
+corresponding to the other `n-Tuple` instance. The result of each concatenation
+will be provided in a new `n-Tuple` instance of the same `Semigroup`s.
+
+```javascript
+import Tuple from 'crocks/Tuple'
+import Sum from 'crocks/Sum'
+
+// Triple :: 3-Tuple
+const Triple =
+  Tuple(3)
+
+// Unary :: 1-Tuple
+const Unary =
+  Tuple(1)
+
+Triple([ 1, 3 ], Sum(10), Sum(1))
+  .concat(Triple([ 4 ], Sum.empty(), Sum(9)))
+//=> 3-Tuple( [ 1, 3, 4 ], Sum 10, Sum, 10 )
+
+Unary([ 10 ])
+  .concat(Unary([ 10 ]))
+//=> 1-Tuple( [ 10, 10 ] )
+```
+
+#### map
+
+```haskell
+1-Tuple a ~> (a -> b) -> 1-Tuple b
+2-Tuple a b ~> (b -> c) -> 2-Tuple a c
+...
+```
+
+Used to lift a single function into a given `n-Tuple` to map the rightmost
+value. `map` takes a function `(a -> b)` and will return a
+new `n-Tuple` instance with the result of mapping the rightmost value from its
+original `a` type to the resulting `b`.
+
+This method will only apply to the rightmost value, if the need to map one or
+many of the values in the various other positions, [`mapAll`](#mapall) can be
+used.
+
+```javascript
+import Tuple from 'crocks/Tuple'
+
+import Maybe from 'crocks/Maybe'
+import chain from 'crocks/pointfree/chain'
+import prop from 'crocks/Maybe/prop'
+
+const { Just } = Maybe
+
+// Pair :: 2-Tuple
+const Pair =
+  Tuple(2)
+
+Pair(false, Just({ a: 'this is a' }))
+  .map(chain(prop('a')))
+//=> 2-Tuple( false, Just "this is a" )
+```
+
+#### mapAll
+
+```haskell
+1-Tuple a ~> (a -> b) -> 1-Tuple b
+2-Tuple a b ~> (a -> c) -> (b -> d) -> 2-Tuple c d
+...
+```
+
+While [`map`](#map) allows for the rightmost portion of a given `n-Tuple` to be
+mapped, `mapAll` provides a means to map all values at once, independently of
+each other. A `Tuple` of `n` size requires `n` number of functions in the same
+left to right order as their respective values. `mapAll` returns a
+new `n-Tuple` of the same size containing the results of the provided mapping
+functions.
+
+```javascript
+import Tuple from 'crocks/Tuple'
+import objOf from 'crocks/helpers/objOf'
+
+// Triple :: 3-Tuple
+const Triple =
+  Tuple(3)
+
+// toUpper :: String -> String
+const toUpper =
+  x => x.toUpperCase()
+
+// negate :: a -> Boolean
+const negate =
+  x => !x
+
+Triple('little', false, 94)
+  .mapAll(toUpper, negate, objOf('a'))
+//=> 3-Tuple( "LITTLE", true, { a: 94 } )
+```
+
+#### project
+
+```haskell
+1-Tuple a ~> Integer -> a
+2-Tuple a b ~> Integer -> (a | b)
+3-tuple a b c ~> Integer -> (a | b | c)
+...
+```
+
+Used to extract a specific value from a given `n-Tuple`. `project` takes a
+positive, non-zero `Integer` as its input and will return the extracted value
+residing in the provided 1 based index.
+
+```javascript
+import Tuple from 'crocks/Tuple'
+
+// Pair :: 2-Tuple
+const Pair =
+  Tuple(2)
+
+// Triple :: 3-Tuple
+const Triple =
+  Tuple(3)
+
+Triple('one', 'two', 'three')
+  .project(1)
+//=> "one"
+
+Pair('one', 'two')
+  .project(2)
+//=> "two"
+```
+
+#### merge
+
+```haskell
+1-Tuple a ~> (a -> b) -> b
+2-Tuple a b ~> ((a, b) -> c) -> c
+3-Tuple a b c ~> ((a, b, c) -> d) -> d
+...
+```
+
+Used to fold a given `n-Tuple` into a single value, `merge` accepts a function
+of any arity and will apply each value in the `n-Tuple`, in order, to the
+provided function. `merge` returns the result of the application.
+
+When using an `n-Tuple` to manage parallel processing, `merge` is used to
+combine the separate branches into a single result.
+
+```javascript
+import Tuple from 'crocks/Tuple'
+import curry from 'crocks/helpers/curry'
+
+// Triple :: 3-Tuple
+const Triple =
+  Tuple(3)
+
+// buildObj :: (a, b, c) -> Object
+const buildObj = curry(
+  (first, second, third) =>
+    ({ first, second, third })
+)
+
+Triple(99, 'name', [ 1, 5, 7 ])
+  .merge(buildObj)
+//=> { first: 99, second: "name", third: [ 1, 5, 7 ] }
+```
+
+#### toArray
+
+```haskell
+1-Tuple a ~> () -> [ a ]
+2-Tuple a b ~> () -> [ a + b ]
+3-Tuple a b c ~> () -> [ a + b + c ]
+...
+```
+
+`toArray` is a Natural Transformation from a given `n-Tuple` to a
+JavaScript `Array`. Any arguments applied to `toArray` will be ignored and will
+return an Array of `n` size, where `n` corresponds to the size of
+the `n-Tuple`. Each value will be in the same left to right position as the
+order defined by the `n-Tuple`
+
+```javascript
+import Tuple from 'crocks/Tuple'
+
+// Pair :: 2-Tuple
+const Pair =
+  Tuple(2)
+
+// Quad :: 4-Tuple
+const Quad =
+  Tuple(4)
+
+Pair(false, { a: false })
+  .toArray()
+//=> [ false, { a: false } ]
+
+Quad([ 1, 3 ], [ 2, 4 ], 'name', 'Joe')
+  .toArray()
+//=> [ [ 1, 3 ], [ 2, 4 ], "name", "Joe" ]
+```
+
+</article>
+
+<article id="topic-pointfree">
+
+## Pointfree Functions
+
+#### nmap
+
+`crocks/Tuple/nmap`
+
+```haskell
+nmap :: Integer -> ...(* -> *) -> m ...* -> m ...*
+```
+
+`nmap` takes a non-zero, positive `Integer` as its argument and will return
+another function that takes the same number of unary functions as
+the provided `Integer`. After all functions are provided, the last argument
+needs to be an `n-Tuple` of the same size as the provided `Integer`.
+
+```javascript
+import Tuple from 'crocks/Tuple'
+import nmap from 'crocks/Tuple/nmap'
+
+// toUpper :: String -> String
+const toUpper =
+  x => x.toUpperCase()
+
+// add :: Number -> Number -> Number
+const add =
+  x => y => x + y
+
+// Pair :: 2-Tuple a b
+const Pair =
+  Tuple(2)
+
+// Triple :: 3-Tuple a b c
+const Triple =
+  Tuple(3)
+
+// bimap :: (a -> c) -> (b -> d) -> Pair a b -> Pair c d
+const bimap =
+  nmap(2)
+
+// trimap :: (a -> d) -> (b -> e) -> (c -> f) -> Triple a b c -> Triple d e f
+const trimap =
+  nmap(3)
+
+// pair :: Pair String Number
+const pair =
+  Pair('jordan', 13)
+
+bimap(toUpper, add(10), pair)
+//=> 2-Tuple( "JORDAN", 23 )
+
+const triple =
+  Triple(32, 'string', 0)
+
+trimap(add(10), toUpper, add(10), triple)
+//=> 3-Tuple( 42, "STRING", 10 )
+```
+
+</article>

--- a/docs/src/pages/docs/crocks/index.md
+++ b/docs/src/pages/docs/crocks/index.md
@@ -33,6 +33,7 @@ but what they do from type to type may vary.
 | `Result` | `Err`, `Ok`, `of`| `alt`, `ap`, `bimap`, `chain`, `coalesce`, `concat`, `either`, `equals`, `map`, `of`, `sequence`, `swap`, `traverse` |
 | `Star` | `id` | `both`, `compose`, `contramap`, `map`, `promap`, `runWith` |
 | [`State`][state] | [`get`][state-get], [`modify`][state-modify], [`of`][state-of], [`put`][state-put] | [`ap`][state-ap], [`chain`][state-chain], [`evalWith`][state-eval], [`execWith`][state-exec], [`map`][state-map], [`runWith`][state-run] |
+| [`Tuple`][tuple] | --- | [`concat`][tuple-concat], [`equals`][tuple-equals], [`map`][tuple-map], [`mapAll`][tuple-mapall], [`merge`][tuple-merge], [`project`][tuple-project], [`toArray`][tuple-toarray] |
 | `Unit` | `empty`, `of` | `ap`, `chain`, `concat`, `empty`, `equals`, `map`, `of`, `valueOf` |
 | `Writer`| `of` | `ap`, `chain`, `equals`, `log`, `map`, `of`, `read`, `valueOf` |
 
@@ -155,3 +156,12 @@ but what they do from type to type may vary.
 [state-run]: State.html#runwith
 [state-eval]: State.html#evalwith
 [state-exec]: State.html#execwith
+
+[tuple]: Tuple.html
+[tuple-concat]: Tuple.html#concat
+[tuple-equals]: Tuple.html#equals
+[tuple-map]: Tuple.html#map
+[tuple-mapall]: Tuple.html#mapall
+[tuple-merge]: Tuple.html#merge
+[tuple-project]: Tuple.html#project
+[tuple-toarray]: Tuple.html#toarray

--- a/docs/src/pages/docs/functions/pointfree-functions.md
+++ b/docs/src/pages/docs/functions/pointfree-functions.md
@@ -2,13 +2,13 @@
 title: "Point-free Functions"
 description: "Point-free Functions API"
 layout: "notopic"
-functions: ["alt", "ap", "bimap", "both", "chain", "coalesce", "comparewith", "concat", "cons", "contramap", "either", "empty", "equals", "extend", "filter", "first", "fold", "head", "map", "option", "promap", "reduce", "reduceright", "run", "runwith", "second", "sequence", "swap", "tail", "traverse", "valueof"]
+functions: ["alt", "ap", "bimap", "both", "chain", "coalesce", "comparewith", "concat", "cons", "contramap", "either", "empty", "equals", "extend", "filter", "first", "fold", "head", "map", "merge", "option", "promap", "race", "reduce", "reduceright", "run", "runwith", "second", "sequence", "swap", "tail", "traverse", "valueof"]
 weight: 50
 ---
 
 While it can seem natural to work with all these containers in a fluent fashion,
 it can get cumbersome and hard to get a lot of reuse out of. A way to really get
-the most out of reusability in Javascript is to take what is called a point-free
+the most out of re-usability in JavaScript is to take what is called a point-free
 approach. Below is a small code same to contrast the difference between the two
 calling styles:
 
@@ -72,7 +72,8 @@ accepted Datatype):
 | `head` | `m a -> Maybe a` | `crocks/pointfree` |
 | `log` | `m a b -> a` | `crocks/Writer` |
 | `map` | `(a -> b) -> m a -> m b` | `crocks/pointfree` |
-| [`merge`][merge] | `(a -> b -> c) -> m a b -> c` | `crocks/Pair` |
+| `merge` | `(a -> b -> c) -> m a b -> c` | `crocks/pointfree` |
+| [`nmap`][nmap] | `Integer -> ...(* -> *) m ...* -> m ...*` | `crocks/Tuple` |
 | `option` | `a -> m a -> a` | `crocks/pointfree` |
 | `promap` | `(c -> a) -> (b -> d) -> m a b -> m c d` | `crocks/pointfree` |
 | [`race`][race] | `m e a -> m e a -> m e a` | `crocks/Async` |
@@ -100,12 +101,12 @@ accepted Datatype):
 | `chain` | `Array`, [`Async`][async-chain], [`Const`][const-chain], `Either`, `Identity`, `IO`, `List`, [`Maybe`][maybe-chain], [`Pair`][pair-chain], [`Reader`][reader-chain], `Result`, [`State`][state-chain], `Unit`, `Writer` |
 | `coalesce` | [`Async`][async-coalesce], `Either`, [`Maybe`][maybe-coalesce], `Result` |
 | `compareWith` | [`Equiv`][equiv-compare] |
-| `concat` | [`All`][all-concat], [`Any`][any-concat], `Array`, [`Assign`][assign-concat], [`Const`][const-concat], `Either`, [`Endo`][endo-concat], [`Equiv`][equiv-concat], [`First`][first-concat], `Identity`, [`Last`][last-concat], `List`, [`Max`][max-concat], [`Maybe`][maybe-concat], [`Min`][min-concat], [`Pair`][pair-concat], [`Pred`][pred-concat], [`Prod`][prod-concat], `Result`, `String`, [`Sum`][sum-concat], `Unit` |
+| `concat` | [`All`][all-concat], [`Any`][any-concat], `Array`, [`Assign`][assign-concat], [`Const`][const-concat], `Either`, [`Endo`][endo-concat], [`Equiv`][equiv-concat], [`First`][first-concat], `Identity`, [`Last`][last-concat], `List`, [`Max`][max-concat], [`Maybe`][maybe-concat], [`Min`][min-concat], [`Pair`][pair-concat], [`Pred`][pred-concat], [`Prod`][prod-concat], `Result`, `String`, [`Sum`][sum-concat], [`Tuple`][tuple-concat], `Unit` |
 | `cons` | `Array`, `List` |
 | `contramap` | [`Arrow`][arrow-contra], [`Equiv`][equiv-contra], [`Pred`][pred-contra], `Star` |
 | `either` | `Either`, [`Maybe`][maybe-either], `Result` |
 | `empty` | [`All`][all-empty], [`Any`][any-empty], `Array`, [`Assign`][assign-empty], [`Endo`][endo-empty], [`Equiv`][equiv-empty], [`First`][first-empty], [`Last`][last-empty], `List`, [`Max`][max-empty], [`Min`][min-empty], `Object`, [`Pred`][pred-empty], [`Prod`][prod-empty], `String`, [`Sum`][sum-empty], `Unit` |
-| `equals` | [`All`][all-equals], [`Any`][any-equals], `Array`, [`Assign`][assign-equals], `Boolean`, [`Const`][const-equals], `Either`, [`First`][first-equals], [`Last`][last-equals], `List`, [`Max`][max-equals], [`Maybe`][maybe-equals], [`Min`][min-equals], `Number`, `Object`, [`Pair`][pair-equals], [`Prod`][prod-equals], `Result`, `String`, [`Sum`][sum-equals], `Unit`, `Writer` |
+| `equals` | [`All`][all-equals], [`Any`][any-equals], `Array`, [`Assign`][assign-equals], `Boolean`, [`Const`][const-equals], `Either`, [`First`][first-equals], [`Last`][last-equals], `List`, [`Max`][max-equals], [`Maybe`][maybe-equals], [`Min`][min-equals], `Number`, `Object`, [`Pair`][pair-equals], [`Prod`][prod-equals], `Result`, `String`, [`Sum`][sum-equals], [`Tuple`][tuple-equals], `Unit`, `Writer` |
 | [`evalWith`][eval] | [`State`][state-eval] |
 | [`execWith`][exec] | [`State`][state-exec] |
 | `extend` | [`Pair`][pair-extend] |
@@ -115,8 +116,8 @@ accepted Datatype):
 | [`fst`][fst] | [`Pair`][pair-fst] |
 | `head` | `Array`, `List`, `String` |
 | `log` | `Writer` |
-| `map` | [`Async`][async-map], `Array`, [`Arrow`][arrow-map], [`Const`][const-map], `Either`, `Function`, `Identity`, `IO`, `List`, [`Maybe`][maybe-map], `Object`, [`Pair`][pair-map], [`Reader`][reader-map], `Result`, `Star`, [`State`][state-map], `Unit`, `Writer` |
-| [`merge`][merge] | [`Pair`][pair-merge] |
+| `map` | [`Async`][async-map], `Array`, [`Arrow`][arrow-map], [`Const`][const-map], `Either`, `Function`, `Identity`, `IO`, `List`, [`Maybe`][maybe-map], `Object`, [`Pair`][pair-map], [`Reader`][reader-map], `Result`, `Star`, [`State`][state-map], [`Tuple`][tuple-map], `Unit`, `Writer` |
+| `merge` | [`Pair`][pair-merge], [`Tuple`][tuple-merge] |
 | `option` | [`First`][first-option], [`Last`][last-option], [`Maybe`][maybe-option] |
 | `promap` | [`Arrow`][arrow-pro], `Star` |
 | [`race`][race] | [`Async`][async-race] |
@@ -260,11 +261,16 @@ accepted Datatype):
 [state-map]: ../crocks/State.html#map
 [state-run]: ../crocks/State.html#runwith
 
+[tuple-concat]: ../crocks/Tuple.html#concat
+[tuple-equals]: ../crocks/Tuple.html#equals
+[tuple-map]: ../crocks/Tuple.html#map
+[tuple-merge]: ../crocks/Tuple.html#merge
+
 [exec]: ../crocks/State.html#execwith-pointfree
 [eval]: ../crocks/State.html#evalwith-pointfree
 
 [fst]: ../crocks/Pair.html#fst-pointfree
-[merge]: ../crocks/Pair.html#merge-pointfree
+[nmap]: ../crocks/Tuple.html#nmap
 [snd]: ../crocks/Pair.html#snd-pointfree
 
 [race]: ../crocks/Async.html#race-pointfree

--- a/src/Tuple/index.js
+++ b/src/Tuple/index.js
@@ -21,10 +21,12 @@ function _Tuple(n) {
   if (!(isInteger(n) && n >= 1)) {
     throw new TypeError('Tuple: First argument must be an integer')
   }
+
   const type =
     constant(_type(n))
 
-  const typeString = typeFn('Tuple', VERSION, n)
+  const typeString =
+    typeFn('Tuple', VERSION, n)
 
   const withProps = fn => {
     fn.type = type
@@ -63,8 +65,8 @@ function _Tuple(n) {
       )
     }
 
-    const inspect =
-      () => `${n}-Tuple(${parts.map(_inspect).join(',')} )`
+    const inspect = () =>
+      `${n}-Tuple(${parts.map(_inspect).join(',')} )`
 
     function map(method) {
       return function(fn) {

--- a/templates/ADT_doc.md
+++ b/templates/ADT_doc.md
@@ -97,7 +97,7 @@ weight: 10
 ```haskell
 ```
 
-[POINTFREE FUNCTION NAME]
+[POINTFREE FUNCTION DESC]
 
 ```javascript
 ```


### PR DESCRIPTION
## The Product of Types

![image](https://user-images.githubusercontent.com/3665793/43052140-881795d0-8dd7-11e8-868d-84baeb7180f0.png)


This PR is the final outstanding portion for the upcoming anticipated release and has all the Documentation changes/additions from the addition of the new `Tuple type`. For the most part, this PR does the following:
* Remove `merge` from the `Pair` portion of the docs as it is now used for both `Pair` and `Tuple`
* Update code references to `crocks/Pair/merge` in all the code examples in the docs.
* Fix a search/replace mistake from a previous PR. `(twoals -> equals)`.
* Add `Tuple` documentation.
* Add `Tuple` links to the `crocks` index page to the main article and functions.
* Add `merge` and `nmap` to the search list for the pointfree page.
* Update the path for `merge` to read the general `crocks/pointfree` on the pointfree index page
* Add links to `Tuple` pointfree targets on the pointfree index page
* Remove old links to `merge` on the pointfree index page
* Add entry and link for `nmap` in the `Tuple` folder on the pointfree index page.