### PR TITLE
Add `propSatisfies` and `propPathSatisfies` to the Predicates

### DIFF
--- a/docs/src/pages/docs/functions/predicate-functions.md
+++ b/docs/src/pages/docs/functions/predicate-functions.md
@@ -2,7 +2,7 @@
 description: "Predicate Functions API"
 layout: "notopic"
 title: "Predicate Functions"
-functions: ["hasprop", "hasproppath", "isalt", "isalternative", "isapplicative", "isapply", "isarray", "isbifunctor", "isboolean", "iscategory", "ischain", "iscontravariant", "isdefined", "isempty", "isextend", "isfoldable", "isfunction", "isfunctor", "isinteger", "ismonad", "ismonoid", "isnil", "isnumber", "isobject", "isplus", "isprofunctor", "ispromise", "issame", "issametype", "issemigroup", "issemigroupoid", "issetoid", "isstring", "istraversable", "propeq", "proppatheq"]
+functions: ["hasprop", "hasproppath", "isalt", "isalternative", "isapplicative", "isapply", "isarray", "isbifunctor", "isboolean", "iscategory", "ischain", "iscontravariant", "isdefined", "isempty", "isextend", "isfoldable", "isfunction", "isfunctor", "isinteger", "ismonad", "ismonoid", "isnil", "isnumber", "isobject", "isplus", "isprofunctor", "ispromise", "issame", "issametype", "issemigroup", "issemigroupoid", "issetoid", "isstring", "istraversable", "propeq", "proppatheq", "proppathsatisfies", "propsatisfies"]
 weight: 40
 ---
 
@@ -50,8 +50,10 @@ description of their truth:
 * `isString :: a -> Boolean`: String
 * `isSymbol :: a -> Boolean`: Symbol
 * `isTraversable :: a -> Boolean`: an ADT that provides `map` and `traverse` methods
-* `propEq :: (String | Integer) -> a -> Object -> Boolean`: an `Object` that contains the provided key
-* `propPathEq :: [ String | Integer ] -> a -> Object -> Boolean`: an `Object` that contains the provided key in the provided traversal path
+* `propEq :: (String | Integer) -> a -> Object -> Boolean`: an `Object` that contains the provided key with a value equal to the provided value. (equality by value)
+* `propPathEq :: [ String | Integer ] -> a -> Object -> Boolean`: an `Object` that contains the provided key in the  traversal path, with a value equal to the provided value. (equality by value)
+* `propPathSatisfies :: [ String | Integer ] -> ((a -> Boolean) | Pred) -> Object -> Boolean`: an `Object` that contains the provided key in the traversal path with a value that passes the provided predicate.
+* `propSatisfies :: (String | Integer) -> ((a -> Boolean) | Pred) -> Object -> Boolean`: an `Object` that contains the provided key with a value that passes the provided predicate.
 
 [pred]: ../crocks/Pred.html
 [ifelse]: logic-functions.html#ifelse

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -180,6 +180,7 @@ const isTraversable = require('./predicates/isTraversable')
 const propEq = require('./predicates/propEq')
 const propPathEq = require('./predicates/propPathEq')
 const propSatisfies = require('./predicates/propSatisfies')
+const propPathSatisfies = require('./predicates/propPathSatisfies')
 
 // transforms
 const arrayToList = require('./List/arrayToList')
@@ -395,6 +396,7 @@ test('entry', t => {
   t.equal(crocks.propEq, propEq, 'provides the propEq predicate')
   t.equal(crocks.propPathEq, propPathEq, 'provides the propEq predicate')
   t.equal(crocks.propSatisfies, propSatisfies, 'provides the propSatisfies predicate')
+  t.equal(crocks.propPathSatisfies, propPathSatisfies, 'provides the propPathSatisfies predicate')
 
   // transforms
   t.equal(crocks.arrayToList, arrayToList, 'provides the arrayToList transform')

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -179,6 +179,7 @@ const isSymbol = require('./predicates/isSymbol')
 const isTraversable = require('./predicates/isTraversable')
 const propEq = require('./predicates/propEq')
 const propPathEq = require('./predicates/propPathEq')
+const propSatisfies = require('./predicates/propSatisfies')
 
 // transforms
 const arrayToList = require('./List/arrayToList')
@@ -393,6 +394,7 @@ test('entry', t => {
   t.equal(crocks.isTraversable, isTraversable, 'provides the isTraversable predicate')
   t.equal(crocks.propEq, propEq, 'provides the propEq predicate')
   t.equal(crocks.propPathEq, propPathEq, 'provides the propEq predicate')
+  t.equal(crocks.propSatisfies, propSatisfies, 'provides the propSatisfies predicate')
 
   // transforms
   t.equal(crocks.arrayToList, arrayToList, 'provides the arrayToList transform')

--- a/src/predicates/index.js
+++ b/src/predicates/index.js
@@ -35,5 +35,6 @@ module.exports = {
   isSymbol: require('./isSymbol'),
   isTraversable: require('./isTraversable'),
   propEq: require('./propEq'),
-  propPathEq: require('./propPathEq')
+  propPathEq: require('./propPathEq'),
+  propSatisfies: require('./propSatisfies')
 }

--- a/src/predicates/index.js
+++ b/src/predicates/index.js
@@ -36,5 +36,6 @@ module.exports = {
   isTraversable: require('./isTraversable'),
   propEq: require('./propEq'),
   propPathEq: require('./propPathEq'),
-  propSatisfies: require('./propSatisfies')
+  propSatisfies: require('./propSatisfies'),
+  propPathSatisfies: require('./propPathSatisfies')
 }

--- a/src/predicates/index.spec.js
+++ b/src/predicates/index.spec.js
@@ -39,6 +39,7 @@ const isTraversable = require('./isTraversable')
 const propEq = require('./propEq')
 const propPathEq = require('./propPathEq')
 const propSatisfies = require('./propSatisfies')
+const propPathSatisfies = require('./propPathSatisfies')
 
 test('predicates entry', t => {
   t.equal(index.hasProp, hasProp, 'provides the hasProp predicate')
@@ -78,6 +79,7 @@ test('predicates entry', t => {
   t.equal(index.propEq, propEq, 'provides the propEq predicate')
   t.equal(index.propPathEq, propPathEq, 'provides the propEq predicate')
   t.equal(index.propSatisfies, propSatisfies, 'provides the propSatisfies predicate')
+  t.equal(index.propPathSatisfies, propPathSatisfies, 'provides the propPathSatisfies predicate')
 
   t.end()
 })

--- a/src/predicates/index.spec.js
+++ b/src/predicates/index.spec.js
@@ -38,6 +38,7 @@ const isString = require('./isString')
 const isTraversable = require('./isTraversable')
 const propEq = require('./propEq')
 const propPathEq = require('./propPathEq')
+const propSatisfies = require('./propSatisfies')
 
 test('predicates entry', t => {
   t.equal(index.hasProp, hasProp, 'provides the hasProp predicate')
@@ -76,6 +77,7 @@ test('predicates entry', t => {
   t.equal(index.isTraversable, isTraversable, 'provides the isTraversable predicate')
   t.equal(index.propEq, propEq, 'provides the propEq predicate')
   t.equal(index.propPathEq, propPathEq, 'provides the propEq predicate')
+  t.equal(index.propSatisfies, propSatisfies, 'provides the propSatisfies predicate')
 
   t.end()
 })

--- a/src/predicates/propPathSatisfies.js
+++ b/src/predicates/propPathSatisfies.js
@@ -3,7 +3,6 @@
 
 const curry = require('../core/curry')
 const isArray = require('../core/isArray')
-const isDefined = require('../core/isDefined')
 const isEmpty  = require('../core/isEmpty')
 const isInteger = require('../core/isInteger')
 const isNil = require('../core/isNil')
@@ -45,10 +44,6 @@ function propPathSatisfies(keys, pred, x) {
     }
 
     target = target[key]
-
-    if(!isDefined(target)) {
-      return false
-    }
   }
 
   return !!predOrFunc(pred, target)

--- a/src/predicates/propPathSatisfies.js
+++ b/src/predicates/propPathSatisfies.js
@@ -1,0 +1,57 @@
+/** @license ISC License (c) copyright 2018 original and current authors */
+/** @author Ian Hofmann-Hicks (evilsoft) */
+
+const curry = require('../core/curry')
+const isArray = require('../core/isArray')
+const isDefined = require('../core/isDefined')
+const isEmpty  = require('../core/isEmpty')
+const isInteger = require('../core/isInteger')
+const isNil = require('../core/isNil')
+const isPredOrFunc = require('../core/isPredOrFunc')
+const isString = require('../core/isString')
+const predOrFunc = require('../core/predOrFunc')
+
+// propPathSatisfies: [ (String | Integer) ] -> (a -> Boolean) -> b -> Boolean
+// propPathSatisfies: [ (String | Integer) ] -> Pred a -> b -> Boolean
+function propPathSatisfies(keys, pred, x) {
+  if(!isArray(keys)) {
+    throw new TypeError(
+      'propPathSatisfies: Array of Non-empty Strings or Integers required for first argument'
+    )
+  }
+
+  if(!isPredOrFunc(pred)) {
+    throw new TypeError(
+      'propPathSatisfies: Pred or predicate function required for second argument'
+    )
+  }
+
+  if(isNil(x)) {
+    return false
+  }
+
+  let target = x
+  for(let i = 0; i < keys.length; i++) {
+    const key = keys[i]
+
+    if(!(isString(key) && !isEmpty(key) || isInteger(key))) {
+      throw new TypeError(
+        'propPathSatisfies: Array of Non-empty Strings or Integers required for first argument'
+      )
+    }
+
+    if(isNil(target)) {
+      return false
+    }
+
+    target = target[key]
+
+    if(!isDefined(target)) {
+      return false
+    }
+  }
+
+  return !!predOrFunc(pred, target)
+}
+
+module.exports = curry(propPathSatisfies)

--- a/src/predicates/propPathSatisfies.spec.js
+++ b/src/predicates/propPathSatisfies.spec.js
@@ -1,0 +1,121 @@
+const test = require('tape')
+const { bindFunc } = require('../test/helpers')
+
+const Pred = require('../Pred')
+const isFunction = require('../core/isFunction')
+const isNumber = require('../core/isNumber')
+const unit = require('../core/_unit')
+
+const propPathSatisfies = require('./propPathSatisfies')
+
+const T =
+  () => true
+
+test('propPathSatisfies function', t => {
+  const fn = propPathSatisfies([ 'a' ], T)
+
+  t.ok(isFunction(propPathSatisfies), 'is a function')
+
+  t.equals(fn(null), false, 'returns false when target is null')
+  t.equals(fn(NaN), false, 'returns false when target is NaN')
+  t.equals(fn(undefined), false, 'returns false when target is undefined')
+
+  t.end()
+})
+
+test('propPathSatisfies errors', t => {
+  const firstArg = bindFunc(
+    x => propPathSatisfies(x, T, 'target')
+  )
+
+  const err = /propPathSatisfies: Array of Non-empty Strings or Integers required for first argument/
+  t.throws(firstArg(undefined), err, 'throws with undefined as first argument')
+  t.throws(firstArg(null), err, 'throws with null as first argument')
+  t.throws(firstArg(NaN), err, 'throws with NaN as first argument')
+  t.throws(firstArg(false), err, 'throws with false as first argument')
+  t.throws(firstArg(true), err, 'throws with true as first argument')
+  t.throws(firstArg(''), err, 'throws with falsey string as first argument')
+  t.throws(firstArg('string'), err, 'throws with truthy string as first argument')
+  t.throws(firstArg(0), err, 'throws with falsey Number as first argument')
+  t.throws(firstArg(1), err, 'throws with truthy Number as first argument')
+  t.throws(firstArg({}), err, 'throws with Object as first argument')
+  t.throws(firstArg(unit), err, 'throws with Function as first argument')
+
+  t.throws(firstArg([ undefined ]), err, 'throws with undefined in first argument array')
+  t.throws(firstArg([ null ]), err, 'throws with null in first argument array')
+  t.throws(firstArg([ NaN ]), err, 'throws with NaN in first argument array')
+  t.throws(firstArg([ '' ]), err, 'throws with empty String in first argument array')
+  t.throws(firstArg([ 1.93 ]), err, 'throws with Float in first argument array')
+  t.throws(firstArg([ false ]), err, 'throws with false in first argument array')
+  t.throws(firstArg([ true ]), err, 'throws with true in first argument array')
+  t.throws(firstArg([ [] ]), err, 'throws with Array in first argument array')
+  t.throws(firstArg([ {} ]), err, 'throws with Object in first argument array')
+  t.throws(firstArg([ unit ]), err, 'throws with Function in first argument array')
+
+  const secondArg = bindFunc(
+    x => propPathSatisfies([ 'a' ], x, 'target')
+  )
+
+  const predErr = /propPathSatisfies: Pred or predicate function required for second argument/
+  t.throws(secondArg(undefined), predErr, 'throws with undefined as second argument')
+  t.throws(secondArg(null), predErr, 'throws with null as second argument')
+  t.throws(secondArg(NaN), predErr, 'throws with NaN as second argument')
+  t.throws(secondArg(false), predErr, 'throws with false as second argument')
+  t.throws(secondArg(true), predErr, 'throws with true as second argument')
+  t.throws(secondArg(''), predErr, 'throws with falsey string as second argument')
+  t.throws(secondArg('string'), predErr, 'throws with truthy string as second argument')
+  t.throws(secondArg(0), predErr, 'throws with falsey number as second argument')
+  t.throws(secondArg(1), predErr, 'throws with truthy number as second argument')
+  t.throws(secondArg({}), predErr, 'throws with object as second argument')
+  t.throws(secondArg([]), predErr, 'throws with Array as second argument')
+
+  t.end()
+})
+
+test('propPathSatisfies object traversal', t => {
+  const fn = propPathSatisfies([ 'a', 'b' ], isNumber)
+
+  t.equals(fn({ a: { b: 23 } }), true, 'returns true when function predicate matches')
+  t.equals(fn({ a: { b: '33' } }), false, 'returns false when function predicate does not match')
+  t.equals(fn({ a: null }), false, 'returns false when null encountered with predicate function')
+  t.equals(fn({ a: NaN }), false, 'returns false when NaN encountered with predicate function')
+  t.equals(fn({ a: undefined }), false, 'returns false when undefined encountered with predicate function')
+  t.equals(fn({ a: { c: 'not' } }), false, 'returns false when key does not exist with predicate function')
+  t.equals(fn({ b: 23 }), false, 'returns false on shallow path with predicate function')
+
+  const pred = propPathSatisfies([ 'a', 'b' ], Pred(isNumber))
+
+  t.equals(pred({ a: { b: 23 } }), true, 'returns true when Pred matches')
+  t.equals(pred({ a: { b: '33' } }), false, 'returns false when Pred does not match')
+  t.equals(pred({ a: null }), false, 'returns false when null encountered with Pred')
+  t.equals(pred({ a: NaN }), false, 'returns false when NaN encountered with Pred')
+  t.equals(pred({ a: undefined }), false, 'returns false when undefined encountered with Pred')
+  t.equals(pred({ a: { c: 'not' } }), false, 'returns false when key does not exist with Pred')
+  t.equals(pred({ b: 23 }), false, 'returns false on shallow path with Pred')
+
+  t.end()
+})
+
+test('propPathSatisfies array traversal', t => {
+  const fn = propPathSatisfies([ 1, 1 ], isNumber)
+
+  t.equals(fn([ 34, [ 99, 44 ] ]), true, 'returns true when function predicate matches')
+  t.equals(fn([ 'three', [ 'one', 'two' ] ]), false, 'returns false when function predicate does not match')
+  t.equals(fn([ 75, [ 33 ] ]), false, 'returns false when index does not exist with predicate function')
+  t.equals(fn([ 75, null ]), false, 'returns false when null encountered with predicate function')
+  t.equals(fn([ 75, NaN ]), false, 'returns false when NaN encountered with predicate function')
+  t.equals(fn([ 75, undefined ]), false, 'returns false when undefined encountered with predicate function')
+  t.equals(fn([ 75 ]), false, 'returns false on shallow path with predicate function')
+
+  const pred = propPathSatisfies([ 1, 1 ], Pred(isNumber))
+
+  t.equals(pred([ 34, [ 99, 44 ] ]), true, 'returns true when Pred matches')
+  t.equals(pred([ 'three', [ 'one', 'two' ] ]), false, 'returns false when Pred does not match')
+  t.equals(pred([ 75, [ 33 ] ]), false, 'returns false when index does not exist with Pred')
+  t.equals(pred([ 75, null ]), false, 'returns false when null encountered with Pred')
+  t.equals(pred([ 75, NaN ]), false, 'returns false when NaN encountered with Pred')
+  t.equals(pred([ 75, undefined ]), false, 'returns false when undefined encountered with Pred')
+  t.equals(pred([ 75 ]), false, 'returns false on shallow path with Pred')
+
+  t.end()
+})

--- a/src/predicates/propSatisfies.js
+++ b/src/predicates/propSatisfies.js
@@ -1,0 +1,30 @@
+/** @license ISC License (c) copyright 2018 original and current authors */
+/** @author Ian Hofmann-Hicks (evilsoft) */
+
+const curry = require('../core/curry')
+const isEmpty = require('../core/isEmpty')
+const isInteger = require('../core/isInteger')
+const isNil = require('../core/isNil')
+const isPredOrFunc = require('../core/isPredOrFunc')
+const isString = require('../core/isString')
+const predOrFunc = require('../core/predOrFunc')
+
+// propSatisfies: (String | Integer) -> (a -> Boolean) -> b -> Boolean
+// propSatisfies: (String | Integer) -> Pred a -> b -> Boolean
+function propSatisfies(key, pred, x) {
+  if(!(isString(key) && !isEmpty(key) || isInteger(key))) {
+    throw new TypeError(
+      'propSatisfies: Non-empty String or Integer required for first argument'
+    )
+  }
+
+  if(!isPredOrFunc(pred)) {
+    throw new TypeError(
+      'propSatisfies: Pred or predicate function required for second argument'
+    )
+  }
+
+  return isNil(x) ? false : !!predOrFunc(pred, x[key])
+}
+
+module.exports = curry(propSatisfies)

--- a/src/predicates/propSatisfies.spec.js
+++ b/src/predicates/propSatisfies.spec.js
@@ -1,0 +1,93 @@
+const test = require('tape')
+const { bindFunc } = require('../test/helpers')
+
+const Pred = require('../Pred')
+const isFunction = require('../core/isFunction')
+const isNumber = require('../core/isNumber')
+const unit = require('../core/_unit')
+
+const propSatisfies = require('./propSatisfies')
+
+const T =
+  () => true
+
+test('propSatisfies function', t => {
+  const fn = propSatisfies('a', T)
+
+  t.ok(isFunction(propSatisfies), 'is a function')
+
+  t.equals(fn(null), false, 'returns false when target is null')
+  t.equals(fn(NaN), false, 'returns false when target is NaN')
+  t.equals(fn(undefined), false, 'returns false when target is undefined')
+
+  t.end()
+})
+
+test('propSatisfies errors', t => {
+  const firstArg = bindFunc(
+    x => propSatisfies(x, T, 'target')
+  )
+
+  const err = /propSatisfies: Non-empty String or Integer required for first argument/
+  t.throws(firstArg(undefined), err, 'throws with undefined as first argument')
+  t.throws(firstArg(null), err, 'throws with null as first argument')
+  t.throws(firstArg(NaN), err, 'throws with NaN as first argument')
+  t.throws(firstArg(false), err, 'throws with false as first argument')
+  t.throws(firstArg(true), err, 'throws with true as first argument')
+  t.throws(firstArg(''), err, 'throws with empty string as first argument')
+  t.throws(firstArg(1.234), err, 'throws with float as first argument')
+  t.throws(firstArg({}), err, 'throws with object as first argument')
+  t.throws(firstArg([]), err, 'throws with Array as first argument')
+  t.throws(firstArg(unit), err, 'throws with Function as first argument')
+
+  const secondArg = bindFunc(
+    x => propSatisfies('a', x, 'target')
+  )
+
+  const predErr = /propSatisfies: Pred or predicate function required for second argument/
+  t.throws(secondArg(undefined), predErr, 'throws with undefined as second argument')
+  t.throws(secondArg(null), predErr, 'throws with null as second argument')
+  t.throws(secondArg(NaN), predErr, 'throws with NaN as second argument')
+  t.throws(secondArg(false), predErr, 'throws with false as second argument')
+  t.throws(secondArg(true), predErr, 'throws with true as second argument')
+  t.throws(secondArg(''), predErr, 'throws with falsey string as second argument')
+  t.throws(secondArg('string'), predErr, 'throws with truthy string as second argument')
+  t.throws(secondArg(0), predErr, 'throws with falsey number as second argument')
+  t.throws(secondArg(1), predErr, 'throws with truthy number as second argument')
+  t.throws(secondArg({}), predErr, 'throws with object as second argument')
+  t.throws(secondArg([]), predErr, 'throws with Array as second argument')
+
+  t.end()
+})
+
+test('propSatisfies object traversal', t => {
+  const fn = propSatisfies('a', isNumber)
+
+  t.equals(fn({ a: 33 }), true, 'returns true when function predicate matches')
+  t.equals(fn({ a: '33' }), false, 'returns false when function predicate does not match')
+  t.equals(fn({ b: 33 }), false, 'returns false when key does not exist with predicate function')
+
+  const pred = propSatisfies('a', Pred(isNumber))
+
+  t.equals(pred({ a: 33 }), true, 'returns true when Pred matches')
+  t.equals(pred({ a: '33' }), false, 'returns false when Pred does not match')
+  t.equals(pred({ b: 33 }), false, 'returns false when key does not exist with Pred')
+
+  t.end()
+})
+
+test('propSatisfies array traversal', t => {
+  const fn = propSatisfies(1, isNumber)
+
+  t.equals(fn([ 34, 99 ]), true, 'returns true when function predicate matches')
+  t.equals(fn([ 'one', 'two' ]), false, 'returns false when function predicate does not match')
+  t.equals(fn([ 75 ]), false, 'returns false when index does not exist with predicate function')
+
+  const pred = propSatisfies(1, Pred(isNumber))
+
+  t.equals(pred([ 34, 99 ]), true, 'returns true when function predicate matches')
+  t.equals(pred([ 'one', 'two' ]), false, 'returns false when function predicate does not match')
+  t.equals(pred([ 75 ]), false, 'returns false when index does not exist with predicate function')
+
+  t.end()
+})


### PR DESCRIPTION
## Packed with peanuts
![image](https://user-images.githubusercontent.com/3665793/43698527-3503bd78-98ff-11e8-9d81-861a6d609fcf.png)

Addressing the last (2) items on [this issue](https://github.com/evilsoft/crocks/issues/302), this PR add the predicate functions: `propSatisfies` and `propPathSatisfies` that allows one to check a value on an object to see if it passes a provided predicate (function or Pred Type).