### PR TITLE
Avoid Async resolving/rejecting multiple times in a single fork.

### DIFF
--- a/src/Async/Async.spec.js
+++ b/src/Async/Async.spec.js
@@ -439,6 +439,32 @@ test('Async fork', t => {
   t.end()
 })
 
+test('Async fork settle', t => {
+
+  const res = sinon.spy(identity)
+  const rej = sinon.spy(identity)
+
+  Async(rej => { rej(10); rej(10) }).fork(rej, res)
+  t.ok(rej.calledOnce, 'calls reject once when called twice in an Async')
+
+  rej.reset()
+  Async((_, res) => { res(10); res(10) }).fork(rej, res)
+  t.ok(res.calledOnce, 'calls resolve once when called twice in an Async')
+
+  res.reset()
+  Async((rej, res) => { rej(10); res(10) }).fork(rej, res)
+  t.ok(rej.calledOnce, 'calls reject when called before a resolve in an Async')
+  t.ok(res.notCalled, 'does not call resolve after reject in an Async')
+
+  rej.reset()
+  res.reset()
+  Async((rej, res) => { res(10); rej(10) }).fork(rej, res)
+  t.ok(res.calledOnce, 'calls resolve when called before a reject in an Async')
+  t.ok(rej.notCalled, 'does not call reject after resolve in an Async')
+
+  t.end()
+})
+
 test('Async cancel chain cleanup functions', t => {
   const resCleanUp = sinon.spy()
   const rejCleanUp = sinon.spy()

--- a/src/Async/index.js
+++ b/src/Async/index.js
@@ -128,15 +128,29 @@ function Async(fn) {
     }
 
     let cancelled = false
+    let settled = false
 
-    const cancel = () => { cancelled = true }
+    const cancel =
+      () => { cancelled = true }
 
     const forkCancel =
       isFunction(cleanup) ? cleanup : unit
 
+    const settle = (f, x) => {
+      if(!settled) {
+        settled = true
+
+        if(cancelled) {
+          return unit()
+        }
+
+        return f(x)
+      }
+    }
+
     const internal = fn(
-      x => cancelled ? unit() : reject(x),
-      x => cancelled ? unit() : resolve(x)
+      settle.bind(null, reject),
+      settle.bind(null, resolve)
     )
 
     const internalFn = isFunction(internal) ? internal : unit


### PR DESCRIPTION
## Whoa!! Settle Down Now

![image](https://user-images.githubusercontent.com/3665793/43876259-1cb71b92-9b49-11e8-827d-841fda923092.png)

This PR addresses [this reported bug](https://github.com/evilsoft/crocks/issues/293) and provides some settled state in the `fork` function on an `Async` instance. Now when if you have something like:

```javascript
const m = Async((rej, res) => {
  res(33)
  res(200)
  rej('silly')
})
```

All other `rej`/`res` calls after the first will be sunk and will not report back. Used bind to remove another closure inside of the closure in fork in an effort to keep the stack slim.