### PR TITLE
Add `unsetPath` helper function

### DIFF
--- a/docs/src/pages/docs/functions/helpers.md
+++ b/docs/src/pages/docs/functions/helpers.md
@@ -2,7 +2,7 @@
 title: "Helpers"
 description: "Helper functions"
 layout: "notopic"
-functions: ["assign", "assoc", "binary", "compose", "composek", "composep", "composes", "curry", "defaultprops", "defaultto", "dissoc", "fanout", "frompairs", "lifta2", "lifta3", "liftn", "mapprops", "mapreduce", "mconcat", "mconcatmap", "mreduce", "mreducemap", "nary", "objof", "omit", "once", "partial", "pick", "pipe", "pipek", "pipep", "pipes", "propor", "proppathor", "tap", "unary", "unit"]
+functions: ["assign", "assoc", "binary", "compose", "composek", "composep", "composes", "curry", "defaultprops", "defaultto", "dissoc", "fanout", "frompairs", "lifta2", "lifta3", "liftn", "mapprops", "mapreduce", "mconcat", "mconcatmap", "mreduce", "mreducemap", "nary", "objof", "omit", "once", "partial", "pick", "pipe", "pipek", "pipep", "pipes", "propor", "proppathor", "tap", "unary", "unit", "unsetPath"]
 weight: 20
 ---
 
@@ -983,11 +983,50 @@ applies (2) arguments to a given function.
 ```haskell
 unit :: () -> undefined
 ```
+
 While it seems like just a simple function, `unit` can be used for a number of
 things. A common use for it is as a default `noop` as it is a function that does
 nothing and returns `undefined`. You can also use it in a pointed fashion to
 represent some special value for a given type. This pointed use is the heart and
-soul of the infamous `Maybe` type.
+soul of the infamous [`Maybe`][maybe] type.
 
+#### unsetPath
+
+`crocks/helpers/unsetPath`
+
+```haskell
+unsetPath :: [ String | Integer ] -> (Object | Array) -> (Object | Array)
+```
+
+Used to remove a property or index on a deeply nested `Object`/`Array`.
+`unsetPath` is will return a new instance with the property or index removed.
+
+The provided path can be a mixture of either `Integer`s or `String`s to allow
+for traversing through both `Array`s and `Object`s. When an `Integer` is provided
+it will treat that portion as an `Array` while `String`s are used to reference
+through `Object`s.
+
+```javascript
+import unsetPath from 'crocks/helpers/unsetPath'
+
+unsetPath([ 'people', 0, 'remove' ], {
+  people: [
+    { name: 'Tonya', remove: true },
+    { name: 'Bobby' },
+  ]
+})
+//=> { people: [ { name: 'Tonya' }, { name: 'Bobby' } ] }
+
+unsetPath([ 'a', 'c', 'd' ], { a: null })
+//=> { a: null }
+
+unsetPath([ 'a', 'b' ], { a: { b: false } })
+//=> { a: {} }
+
+unsetPath([ 'a', 'b' ], { a: { c: false } })
+//=> { a: { c: false } }
+```
+
+[maybe]: ../crocks/Maybe.html
 [safe]: ../crocks/Maybe.html#safe
 [topairs]: ../crocks/Pair.html#topairs

--- a/docs/src/pages/docs/functions/index.md
+++ b/docs/src/pages/docs/functions/index.md
@@ -100,6 +100,7 @@ need to account for for the rest of your flow.
 | [`tryCatch`][trycatch] | `(a -> b) -> a -> Result e b` | `crocks/Result/tryCatch` |
 | [`unary`][unary] | `((*) -> b) -> a -> b` | `crocks/helpers/unary` |
 | [`unit`][unit] | `() -> undefined` | `crocks/helpers/unit` |
+| [`unsetPath`][unsetpath] |  <code>[ String &#124; Integer] -> (Object &#124; Array) -> (Object &#124; Array)</code>  | `crocks/helpers/unsetPath` |
 
 ## Logic
 
@@ -175,6 +176,7 @@ type: `Pred a` and vice-versa
 [trycatch]: helpers.html#trycatch
 [unary]: helpers.html#unary
 [unit]: helpers.html#unit
+[unsetpath]: helpers.html#unsetpath
 
 [and]: logic-functions.html#and
 [ifelse]: logic-functions.html#ifelse

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -44,5 +44,6 @@ module.exports = {
   toPairs: require('../Pair/toPairs'),
   tryCatch: require('../Result/tryCatch'),
   unary: require('./unary'),
-  unit: require('./unit')
+  unit: require('./unit'),
+  unsetPath: require('./unsetPath')
 }

--- a/src/helpers/index.spec.js
+++ b/src/helpers/index.spec.js
@@ -48,6 +48,7 @@ const toPairs = require('../Pair/toPairs')
 const tryCatch = require('../Result/tryCatch')
 const unary = require('./unary')
 const unit = require('./unit')
+const unsetPath = require('./unsetPath')
 
 test('helpers entry', t => {
   t.equal(index.assign, assign, 'provides the assign helper')
@@ -96,6 +97,7 @@ test('helpers entry', t => {
   t.equal(index.tryCatch, tryCatch, 'provides the tryCatch helper')
   t.equal(index.unary, unary, 'provides the unary helper')
   t.equal(index.unit, unit, 'provides the unit helper')
+  t.equal(index.unsetPath, unsetPath, 'provides the unsetPath helper')
 
   t.end()
 })

--- a/src/helpers/unsetPath.js
+++ b/src/helpers/unsetPath.js
@@ -1,0 +1,60 @@
+/** @license ISC License (c) copyright 2018 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const curry = require('../core/curry')
+const isArray = require('../core/isArray')
+const isEmpty = require('../core/isEmpty')
+const isInteger  = require('../core/isInteger')
+const isObject  = require('../core/isObject')
+const isString = require('../core/isString')
+const object = require('../core/object')
+
+const pathError =
+  'unsetPath: Non-empty Array of non-empty Strings and/or Integers required for first argument'
+
+function unset(key, obj) {
+  return function(acc, k) {
+    if(obj[k] !== undefined && k !== key) {
+      acc[k] = obj[k]
+    }
+
+    return acc
+  }
+}
+
+function unsetPath(path, obj) {
+  if(!isArray(path) || isEmpty(path)) {
+    throw new TypeError(pathError)
+  }
+
+  if(!(isObject(obj) || isArray(obj))) {
+    throw new TypeError('unsetPath: Object or Array required for second argument')
+  }
+
+  const key = path[0]
+
+  if(path.length === 1) {
+    if(!(isString(key) || isInteger(key))) {
+      throw new TypeError(pathError)
+    }
+
+    return isInteger(key) && isArray(obj)
+      ? obj.slice(0, key).concat(obj.slice(key + 1))
+      : Object.keys(obj).reduce(unset(key, obj), {})
+  }
+
+  const next =
+    obj[key]
+
+  if(!(isObject(next) || isArray(next))) {
+    return obj
+  }
+
+  return isInteger(key) && isArray(obj)
+    ? obj.slice(0, key)
+      .concat([ unsetPath(path.slice(1), next) ])
+      .concat(obj.slice(key + 1))
+    : object.assign({ [key]: unsetPath(path.slice(1), next) }, obj)
+}
+
+module.exports = curry(unsetPath)

--- a/src/helpers/unsetPath.spec.js
+++ b/src/helpers/unsetPath.spec.js
@@ -1,0 +1,104 @@
+const test = require('tape')
+const helpers = require('../test/helpers')
+
+const bindFunc = helpers.bindFunc
+const unit = require('../core/_unit')
+
+const unsetPath = require('./unsetPath')
+
+test('unsetPath errors', t => {
+  const fn = bindFunc(unsetPath)
+
+  const pathErr = /unsetPath: Non-empty Array of non-empty Strings and\/or Integers required for first argument/
+
+  t.throws(fn(undefined, {}), pathErr, 'throws when first arg is undefined')
+  t.throws(fn(null, {}), pathErr, 'throws when first arg is null')
+  t.throws(fn(NaN, {}), pathErr, 'throws when first arg is NaN')
+  t.throws(fn(0, {}), pathErr, 'throws when first arg is falsey number')
+  t.throws(fn(1, {}), pathErr, 'throws when first arg is truthy number')
+  t.throws(fn('', {}), pathErr, 'throws when first arg is falsey string')
+  t.throws(fn('string', {}), pathErr, 'throws when first arg is truthy string')
+  t.throws(fn(false, {}), pathErr, 'throws when first arg is false')
+  t.throws(fn(true, {}), pathErr, 'throws when first arg is true')
+  t.throws(fn(unit, {}), pathErr, 'throws when first arg is a function')
+  t.throws(fn({}, {}), pathErr, 'throws when first arg is an object')
+  t.throws(fn([], {}), pathErr, 'throws when first arg is an empty array')
+
+  t.throws(fn([ undefined ], {}), pathErr, 'throws with undefined in path')
+  t.throws(fn([ null ], {}), pathErr, 'throws with null in path')
+  t.throws(fn([ NaN ], {}), pathErr, 'throws with NaN in path')
+  t.throws(fn([ false ], {}), pathErr, 'throws with false in path')
+  t.throws(fn([ true ], {}), pathErr, 'throws with true in path')
+  t.throws(fn([ unit ], {}), pathErr, 'throws with function in path')
+  t.throws(fn([ {} ], {}), pathErr, 'throws with object in path')
+  t.throws(fn([ [] ], {}), pathErr, 'throws with array in path')
+
+  const noObj = /unsetPath: Object or Array required for second argument/
+  t.throws(fn([ 'key' ], undefined), noObj, 'throws when second arg is undefined')
+  t.throws(fn([ 'key' ], null), noObj, 'throws when second arg is null')
+  t.throws(fn([ 'key' ], NaN), noObj, 'throws when second arg is NaN')
+  t.throws(fn([ 'key' ], 0), noObj, 'throws when second arg is falsey number')
+  t.throws(fn([ 'key' ], 1), noObj, 'throws when second arg is truthy number')
+  t.throws(fn([ 'key' ], ''), noObj, 'throws when second arg is falsey string')
+  t.throws(fn([ 'key' ], 'string'), noObj, 'throws when second arg is truthy string')
+  t.throws(fn([ 'key' ], false), noObj, 'throws when second arg is false')
+  t.throws(fn([ 'key' ], true), noObj, 'throws when second arg is true')
+  t.throws(fn([ 'key' ], unit), noObj, 'throws when second arg is a function')
+
+  t.end()
+})
+
+test('unsetPath with objects', t => {
+  t.same(
+    unsetPath([ 'a', 'b' ], { a: { b: 1, c: true } }),
+    { a: { c: true } },
+    'removes tail of path when it exists'
+  )
+
+  t.same(
+    unsetPath([ 'a', 'b' ], { a: { b: 1 } }),
+    { a: {} },
+    'keeps an empty object when last prop is unset'
+  )
+
+  t.same(
+    unsetPath([ 'b', 'a' ], { a: false }),
+    { a: false },
+    'does not modify when path head does not exist'
+  )
+
+  t.same(
+    unsetPath([ 'a', 'b' ], { a: 'string' }),
+    { a: 'string' },
+    'does not modify when path tail does not exist'
+  )
+
+  t.end()
+})
+
+test('unsetPath with arrays', t => {
+  t.same(
+    unsetPath([ 1, 0 ], [ [ 1 ], [ 2, 3 ] ]),
+    [ [ 1 ], [ 3 ] ],
+    'removes tail of path when it exists'
+  )
+
+  t.same(
+    unsetPath([ 0, 0 ], [ [ 1 ] ]),
+    [ [] ],
+    'keeps an empty array when last index is unset'
+  )
+
+  t.same(
+    unsetPath([ 1, 0 ], [ 1 ]),
+    [ 1 ],
+    'does not modify when head index does not exist'
+  )
+
+  t.same(
+    unsetPath([ 0, 2 ], [ [ 1, 2 ], 3 ]),
+    [ [ 1, 2 ], 3 ],
+    'does not modify when path tail does not exist'
+  )
+  t.end()
+})

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -75,6 +75,7 @@ const toPairs = require('./Pair/toPairs')
 const tryCatch = require('./Result/tryCatch')
 const unary = require('./helpers/unary')
 const unit = require('./helpers/unit')
+const unsetPath = require('./helpers/unsetPath')
 
 // logic
 const and = require('./logic/and')
@@ -292,6 +293,7 @@ test('entry', t => {
   t.equal(crocks.tryCatch, tryCatch, 'provides the tryCatch helper')
   t.equal(crocks.unary, unary, 'provides the unary helper')
   t.equal(crocks.unit, unit, 'provides the unit helper')
+  t.equal(crocks.unsetPath, unsetPath, 'provides the unsetPath helper')
 
   // logic
   t.equal(crocks.and, and, 'provides the and logic')


### PR DESCRIPTION
## A path a little less traveled

![image](https://user-images.githubusercontent.com/3665793/46579191-65e24980-c9c1-11e8-940f-b8739428e0d5.png)

This PR adds a function that provides the functionality from the `dissocPath` function provided by `ramda`. This was motivated by the documentation on the [meiosis project](https://github.com/foxdonut/meiosis) from @foxdonut.

This PR signals a change to some of the existing functions to match this new naming convention for dealing with functions like: `prop` and `propPath`. The following functions will be addressed in the next breaking change release, although they will be deprecated and their original names will still be available until we hit `1.0.0`:
* `Maybe/propPath` -> `Maybe/getPath`
* `Maybe/prop` -> `Maybe/getProp`
* `helpers/assoc` -> `helpers/setProp` (will work with `Array` as well)
* `helpers/dissoc` -> `helpers/unsetProp` (will work with `Array` as well)
* `helpers/propOr` -> `helpers/getPropOr`
* `helpers/propPathOr` -> `helpers/getPathOr`