### PR TITLE
Change Foldable to Filterable on List.filter for FL Compliance

### DIFF
--- a/src/core/List.js
+++ b/src/core/List.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const VERSION = 3
+const VERSION = 4
 
 const _equals = require('./equals')
 const _implements = require('./implements')
@@ -212,17 +212,19 @@ function List(x) {
       }, head) : head
   }
 
-  function filter(pred) {
-    if(!isPredOrFunc(pred)) {
-      throw new TypeError('List.filter: Pred or predicate function required')
-    }
+  function filter(method) {
+    return function(pred) {
+      if(!isPredOrFunc(pred)) {
+        throw new TypeError(`List.${method}: Pred or predicate function required`)
+      }
 
-    return List(
-      xs.reduce(
-        (x, y) => predOrFunc(pred, y) ? x.concat([ y ]) : x,
-        []
+      return List(
+        xs.reduce(
+          (x, y) => predOrFunc(pred, y) ? x.concat([ y ]) : x,
+          []
+        )
       )
-    )
+    }
   }
 
   function reject(pred) {
@@ -319,12 +321,13 @@ function List(x) {
   return {
     inspect, toString: inspect, valueOf, toArray,
     head, tail, cons, type, equals, empty,
-    reduceRight, fold, foldMap, filter, reject,
+    reduceRight, fold, foldMap, reject,
     ap, of, sequence, traverse,
     concat: concat('concat'),
     map: map('map'),
     chain: chain('chain'),
     reduce: reduce('reduce'),
+    filter: filter('filter'),
     [fl.of]: of,
     [fl.equals]: equals,
     [fl.concat]: concat(fl.concat),
@@ -332,6 +335,7 @@ function List(x) {
     [fl.map]: map(fl.map),
     [fl.chain]: chain(fl.chain),
     [fl.reduce]: reduce(fl.reduce),
+    [fl.filter]: filter(fl.filter),
     ['@@type']: _type,
     constructor: List
   }

--- a/src/core/List.spec.js
+++ b/src/core/List.spec.js
@@ -537,6 +537,23 @@ test('List filter functionality', t => {
   t.end()
 })
 
+test('List filter properties (Filterable)', t => {
+  const m = List([ 2, 6, 10, 25, 9, 28 ])
+  const n = List([ 'string', 'party' ])
+
+  const isEven = x => x % 2 === 0
+  const isBig = x => x >= 10
+
+  const left = m.filter(x => isBig(x) && isEven(x)).valueOf()
+  const right = m.filter(isBig).filter(isEven).valueOf()
+
+  t.same(left, right , 'distributivity')
+  t.same(m.filter(() => true).valueOf(), m.valueOf(), 'identity')
+  t.same(m.filter(() => false).valueOf(), n.filter(() => false).valueOf(), 'annihilation')
+
+  t.end()
+})
+
 test('List reject errors', t => {
   const reject = bindFunc(List([ 0 ]).reject)
 

--- a/src/core/List.spec.js
+++ b/src/core/List.spec.js
@@ -69,6 +69,7 @@ test('List fantasy-land api', t => {
   t.ok(isFunction(m[fl.map]), 'provides map method on instance')
   t.ok(isFunction(m[fl.chain]), 'provides chain method on instance')
   t.ok(isFunction(m[fl.reduce]), 'provides reduce method on instance')
+  t.ok(isFunction(m[fl.filter]), 'provides filter method on instance')
 
   t.end()
 })
@@ -136,7 +137,7 @@ test('List @@type', t => {
   const m = List([])
 
   t.equal(m['@@type'], List['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'], 'crocks/List@3', 'returns crocks/List@3')
+  t.equal(m['@@type'], 'crocks/List@4', 'returns crocks/List@4')
 
   t.end()
 })
@@ -477,6 +478,25 @@ test('List foldMap functionality', t => {
 
   t.same(fold([ 1, 2 ]), '12', 'combines and extracts semigroups')
   t.same(fold([ 3 ]), '3', 'extracts a single semigroup')
+
+  t.end()
+})
+
+test('List filter fantasy-land errors', t => {
+  const filter = bindFunc(List([ 0 ])[fl.filter])
+
+  const err = /List.fantasy-land\/filter: Pred or predicate function required/
+
+  t.throws(filter(undefined), err, 'throws with undefined')
+  t.throws(filter(null), err, 'throws with null')
+  t.throws(filter(0), err, 'throws with falsey number')
+  t.throws(filter(1), err, 'throws with truthy number')
+  t.throws(filter(''), err, 'throws with falsey string')
+  t.throws(filter('string'), err, 'throws with truthy string')
+  t.throws(filter(false), err, 'throws with false')
+  t.throws(filter(true), err, 'throws with true')
+  t.throws(filter([]), err, 'throws with an array')
+  t.throws(filter({}), err, 'throws with an object')
 
   t.end()
 })

--- a/src/core/flNames.js
+++ b/src/core/flNames.js
@@ -11,6 +11,7 @@ module.exports = {
   empty: 'fantasy-land/empty',
   equals: 'fantasy-land/equals',
   extend: 'fantasy-land/extend',
+  filter: 'fantasy-land/filter',
   id: 'fantasy-land/id',
   map: 'fantasy-land/map',
   of: 'fantasy-land/of',

--- a/src/pointfree/filter.js
+++ b/src/pointfree/filter.js
@@ -9,7 +9,7 @@ const isObject = require('../core/isObject')
 const object = require('../core/object')
 const predOrFunc = require('../core/predOrFunc')
 
-// filter : Foldable f => (a -> Boolean) -> f a -> f a
+// filter : Filterable f => (a -> Boolean) -> f a -> f a
 function filter(pred, m) {
   if(!isPredOrFunc(pred)) {
     throw new TypeError('filter: Pred or predicate function required for first argument')
@@ -26,7 +26,7 @@ function filter(pred, m) {
     return object.filter(fn, m)
   }
 
-  throw new TypeError('filter: Foldable or Object required for second argument')
+  throw new TypeError('filter: Filterable or Object required for second argument')
 }
 
 module.exports = curry(filter)

--- a/src/pointfree/filter.spec.js
+++ b/src/pointfree/filter.spec.js
@@ -31,7 +31,7 @@ test('filter pointfree', t => {
   t.throws(m([], f), noFunc, 'throws if first arg is an array')
   t.throws(m({}, f), noFunc, 'throws if first arg is an object')
 
-  const noData = /filter: Foldable or Object required for second argument/
+  const noData = /filter: Filterable or Object required for second argument/
   t.throws(m(unit, undefined), noData, 'throws if second arg is undefined')
   t.throws(m(unit, null), noData, 'throws if second arg is null')
   t.throws(m(unit, 0), noData, 'throws if second arg is a falsey number')
@@ -41,23 +41,23 @@ test('filter pointfree', t => {
   t.throws(m(unit, false), noData, 'throws if second arg is false')
   t.throws(m(unit, true), noData, 'throws if second arg is true')
 
-  t.doesNotThrow(m(unit, f), 'allows a function and Foldable container')
-  t.doesNotThrow(m(unit, []), 'allows a function and an array (also Foldable)')
+  t.doesNotThrow(m(unit, f), 'allows a function and Filterable container')
+  t.doesNotThrow(m(unit, []), 'allows a function and an array (also Filterable)')
   t.doesNotThrow(m(unit, {}), 'allows a function and an object')
 
-  t.doesNotThrow(m(Pred(unit), f), 'allows a Pred and Foldable container')
-  t.doesNotThrow(m(Pred(unit), []), 'allows a Pred and an array (also Foldable)')
+  t.doesNotThrow(m(Pred(unit), f), 'allows a Pred and Filterable container')
+  t.doesNotThrow(m(Pred(unit), []), 'allows a Pred and an array (also Filterable)')
   t.doesNotThrow(m(Pred(unit), {}), 'allows a Pred and an object')
 
   t.end()
 })
 
-test('filter Foldable', t => {
+test('filter Filterable', t => {
   const m = { filter: constant('called') }
 
   const result = filter(identity, m)
 
-  t.equals(result, 'called', 'calls filter on Foldable, passing the function')
+  t.equals(result, 'called', 'calls filter on Filterable, passing the function')
 
   t.end()
 })


### PR DESCRIPTION
This PR addresses #237 

I'm not sure if we need to change this in the pointfree docs - I see that most functions don't represent a typeclass. Thoughts?