### PR TITLE
Fixup some Links in the Docs

### DIFF
--- a/docs/src/pages/docs/functions/index.md
+++ b/docs/src/pages/docs/functions/index.md
@@ -68,7 +68,7 @@ need to account for for the rest of your flow.
 | [`defaultTo`][defaultto] | `a -> b -> a` | `crocks/helpers/defaultTo` |
 | [`dissoc`][dissoc] | `String -> Object -> Object` | `crocks/helpers/dissoc` |
 | [`fanout`][fanout] | `(a -> b) -> (a -> c) -> (a -> Pair b c)` | `crocks/helpers/fanout` |
-| [`find`][find] | <code>Foldable f => ((a -> Boolean) &#124; Pred) -> f a -> Maybe a</code> | `crocks/helpers/find` |
+| [`find`][find] | <code>Foldable f => ((a -> Boolean) &#124; Pred) -> f a -> Maybe a</code> | `crocks/Maybe/find` |
 | [`fromPairs`][frompairs] | `Foldable f => f (Pair String a) -> Object` | `crocks/helpers/fromPairs` |
 | [`liftA2`][lifta2] | `Applicative m => (a -> b -> c) -> m a -> m b -> m c` | `crocks/helpers/liftA2` |
 | [`liftA3`][lifta3] | `Applicative m => (a -> b -> c -> d) -> m a -> m b -> m c -> m d` | `crocks/helpers/liftA3` |

--- a/docs/src/pages/docs/functions/index.md
+++ b/docs/src/pages/docs/functions/index.md
@@ -129,6 +129,7 @@ type: `Pred a` and vice-versa
 [applyto]: combinators.html#applyto
 [composeb]: combinators.html#composeb
 [constant]: combinators.html#constant
+[converge]: combinators.html#converge
 [flip]: combinators.html#flip
 [identity]: combinators.html#identity
 [substitution]: combinators.html#substitution

--- a/docs/src/pages/index.soy
+++ b/docs/src/pages/index.soy
@@ -72,7 +72,7 @@ description: "A collection of well known Algebraic Data Types for your utter enj
   <div class="features">
     <div class="container">
       <div class="row">
-        <a href="/docs/crocks/">
+        <a href="docs/crocks/">
           <section class="feature col-md-4 col-md-offset-2">
             <div class="feature-graphic">
               <span class="icon-16-code-file"></span>
@@ -81,7 +81,7 @@ description: "A collection of well known Algebraic Data Types for your utter enj
             <p class="feature-description">The `crocks` are the heart and soul of this library. This is where you will find all your favorite ADT's you have grown to love.</p>
           </section>
         </a>
-        <a href="/docs/monoids/">
+        <a href="docs/monoids/">
           <section class="feature col-md-4">
             <div class="feature-graphic">
               <span class="icon-16-code-file"></span>
@@ -90,7 +90,7 @@ description: "A collection of well known Algebraic Data Types for your utter enj
             <p class="feature-description">Each Monoid provides a means to represent a binary operation and is usually locked down to a specific type. These are great when you need to combine a list of values down to one value.</p>
           </section>
         </a>
-        <a href="/docs/functions/">
+        <a href="docs/functions/">
           <section class="feature col-md-4">
             <div class="feature-graphic">
               <span class="icon-16-code-file"></span>


### PR DESCRIPTION
## Links are hard
![image](https://user-images.githubusercontent.com/3665793/48307880-5ba8f300-e50b-11e8-859a-2ad2836cd19d.png)

This PR does the following:
* Adds the `converge` link on the Functions Landing Page
* Updates the Features Links to work with `gh-pages`