### PR TITLE
Added a test for cloning arrays

### DIFF
--- a/src/core/cloneIterable.js
+++ b/src/core/cloneIterable.js
@@ -1,7 +1,13 @@
 /** @license ISC License (c) copyright 2018 original and current authors */
 /** @author Henrique Limas (HenriqueLimas) */
 
+const isArray = require('../core/isArray')
+
 function cloneIterable(source) {
+  if(isArray(source)) {
+    return source.slice(0)
+  }
+
   let copy = Object.create(Object.getPrototypeOf(source))
   Object.assign(copy, source)
 

--- a/src/core/cloneIterable.spec.js
+++ b/src/core/cloneIterable.spec.js
@@ -23,6 +23,7 @@ test('cloneIterable shapes', t => {
 
   t.deepEqual(cloneIterable(first), first, 'maintains same structure')
   t.notEqual(cloneIterable(first), first, 'returns a clone with the same structure')
+
   t.end()
 })
 
@@ -47,5 +48,16 @@ test('cloneIterable symbols', t => {
   }
 
   t.deepEqual(cloneIterable(first), first, 'clone symbols properties')
+  t.end()
+})
+
+test('cloneIterable Array', t => {
+  const testArray = [ 1, 2, 3 ]
+  const cloned = cloneIterable(testArray)
+  const iterator = cloned[Symbol.iterator]()
+
+  t.deepEqual(cloned, testArray)
+  t.equal(iterator.next().value, 1)
+
   t.end()
 })


### PR DESCRIPTION
@evilsoft I think @HenriqueLimas may have been correct in adding in support directly for Arrays. It appears that they don't clone well. It all looked fined until I went to use it in head and it didn't work. It appears that the context for the iterator is lost and so when calling `next` you just get `{ value: undefined, done: true }`. We can get around this by putting the original code back in for `array` and `string` but i thought it best to re-open this discussion. 

You can remove the array code in cloneIterable to see the failure