### PR TITLE
More changes to setPath and unsetPath

### DIFF
--- a/docs/src/pages/docs/functions/helpers.md
+++ b/docs/src/pages/docs/functions/helpers.md
@@ -898,7 +898,7 @@ def([ 'arr', 'length' ], data)
 `crocks/helpers/setPath`
 
 ```haskell
-setPath :: [ String | Integer ] -> a -> (Object | Array) -> (Object | Array)
+setPath :: [ (String | Integer) ] -> a -> (Object | Array) -> (Object | Array)
 ```
 
 Used to set a value on a deeply nested `Object`, `setPath` will traverse down
@@ -1050,16 +1050,16 @@ soul of the infamous [`Maybe`][maybe] type.
 `crocks/helpers/unsetPath`
 
 ```haskell
-unsetPath :: [ String | Integer ] -> (Object | Array) -> (Object | Array)
+unsetPath :: [ (String | Integer) ] -> a -> a
 ```
 
 Used to remove a property or index on a deeply nested `Object`/`Array`.
 `unsetPath` is will return a new instance with the property or index removed.
 
-The provided path can be a mixture of either `Integer`s or `String`s to allow
-for traversing through both `Array`s and `Object`s. When an `Integer` is provided
-it will treat that portion as an `Array` while `String`s are used to reference
-through `Object`s.
+The provided path can be a mixture of either Positive `Integer`s or `String`s to
+allow for traversing through both `Array`s and `Object`s. When an `Integer` is
+provided it will treat that portion as an `Array` while `String`s are used to
+reference through `Object`s.
 
 ```javascript
 import unsetPath from 'crocks/helpers/unsetPath'

--- a/docs/src/pages/docs/functions/index.md
+++ b/docs/src/pages/docs/functions/index.md
@@ -56,7 +56,7 @@ need to account for for the rest of your flow.
 | Function | Signature | Location |
 |:---|:---|:---|
 | [`assign`][assign] | `Object -> Object -> Object` | `crocks/helpers/assign` |
-| [`assoc`][setprop]<br /><i>(deprecated)</i> | `String -> a -> Object -> Object` | `crocks/helpers/assoc` |
+| [`assoc`][setprop]<br /><i>(deprecated)</i> | <code>(String &#124; Integer) -> a -> (Object &#124; Array) -> (Object &#124; Array)</code> | `crocks/helpers/assoc` |
 | [`binary`][binary] | `((*) -> c) -> a -> b -> c` | `crocks/helpers/binary` |
 | [`branch`][branch] | `a -> Pair a a` | `crocks/Pair/branch` |
 | [`compose`][compose] | `((y -> z), ..., (a -> b)) -> a -> z` | `crocks/helpers/compose` |
@@ -96,14 +96,14 @@ need to account for for the rest of your flow.
 | [`safe`][safe] | <code>((a -> Boolean) &#124; Pred) -> a -> Maybe a</code> | `crocks/Maybe/safe` |
 | [`safeAfter`][safeafter] | <code>safeAfter :: ((b -> Boolean) &#124; Pred) -> (a -> b) -> a -> Maybe b</code> | `crocks/Maybe/safeAfter` |
 | [`safeLift`][safelift] | <code>((a -> Boolean) &#124; Pred) -> (a -> b) -> a -> Maybe b</code> | `crocks/Maybe/safeLift` |
-| [`setPath`][setpath] | <code>[ String &#124; Integer ] -> a -> (Object &#124; Array) -> (Object &#124; Array)</code> | `crocks/helpers/setPath` |
+| [`setPath`][setpath] | <code>[ (String &#124; Integer) ] -> a -> (Object &#124; Array) -> (Object &#124; Array)</code> | `crocks/helpers/setPath` |
 | [`setProp`][setprop] | <code>(String &#124; Integer) -> a -> (Object &#124; Array) -> (Object &#124; Array)</code> | `crocks/helpers/setProp` |
 | [`tap`][tap] | `(a -> b) -> a -> a` | `crocks/helpers/tap` |
 | [`toPairs`][topairs] | `Object -> List (Pair String a)` | `crocks/Pair/toPairs` |
 | [`tryCatch`][trycatch] | `((*) -> b) -> (*) -> Result e b` | `crocks/Result/tryCatch` |
 | [`unary`][unary] | `((*) -> b) -> a -> b` | `crocks/helpers/unary` |
 | [`unit`][unit] | `() -> undefined` | `crocks/helpers/unit` |
-| [`unsetPath`][unsetpath] |  <code>[ String &#124; Integer ] -> (Object &#124; Array) -> (Object &#124; Array)</code>  | `crocks/helpers/unsetPath` |
+| [`unsetPath`][unsetpath] |  <code>[ (String &#124; Integer) ] -> a -> a</code>  | `crocks/helpers/unsetPath` |
 
 ## Logic
 

--- a/src/core/array.js
+++ b/src/core/array.js
@@ -130,6 +130,14 @@ function set(indx, val, m) {
   return arr
 }
 
+function unset(indx, m) {
+  return m.slice(0, indx)
+    .concat(m.slice(indx + 1))
+}
+
 module.exports = {
-  ap, chain, fold, foldMap, map, sequence, set, traverse
+  ap, chain, fold,
+  foldMap, map,
+  sequence, set,
+  traverse, unset
 }

--- a/src/core/array.spec.js
+++ b/src/core/array.spec.js
@@ -16,6 +16,7 @@ const chain = array.chain
 const sequence = array.sequence
 const set = array.set
 const traverse = array.traverse
+const unset = array.unset
 
 const constant = x => () => x
 const identity = x => x
@@ -297,6 +298,17 @@ test('array foldMap functionality', t => {
 
   t.same(fold([ 1, 2 ]), '12', 'combines and extracts semigroups')
   t.same(fold([ 3 ]), '3', 'extracts a single semigroup')
+
+  t.end()
+})
+
+test('array unset functionality', t => {
+  const data = [ 'a', 'b', 'c' ]
+
+  t.same(unset(0, data), [ 'b', 'c' ], 'removes the head element with an index of 0')
+  t.same(unset(1, data), [ 'a', 'c' ], 'removes elements in the middle of array')
+  t.same(unset(2, data), [ 'a', 'b' ], 'removes last element with last index specified')
+  t.same(unset(12, data), data, 'provides a new instance of array, with the same elements when index does not exist')
 
   t.end()
 })

--- a/src/core/object.js
+++ b/src/core/object.js
@@ -37,9 +37,17 @@ function set(key, val, m) {
   return assign({ [key]: val }, m)
 }
 
+function unset(key, m) {
+  return Object.keys(m).reduce((acc, k) => {
+    if(m[k] !== undefined && k !== key) {
+      acc[k] = m[k]
+    }
+
+    return acc
+  }, {})
+}
+
 module.exports = {
-  assign,
-  filter,
-  map,
-  set
+  assign, filter,
+  map, set, unset
 }

--- a/src/core/object.spec.js
+++ b/src/core/object.spec.js
@@ -8,6 +8,7 @@ const assign = object.assign
 const filter = object.filter
 const map = object.map
 const set = object.set
+const unset = object.unset
 
 const identity = x => x
 
@@ -79,6 +80,15 @@ test('object set functionality', t => {
 
   t.same(set('c', 10, data), { a: 'string', b: false, c: 10 }, 'adds a new key when it does not exist')
   t.same(set('b', 10, data), { a: 'string', b: 10 }, 'overrides an existing key when it exists')
+
+  t.end()
+})
+
+test('object unset functionality', t => {
+  const data = { a: 'string', b: false }
+
+  t.same(unset('a', data), { b: false }, 'removes specified key')
+  t.same(unset('c', data), data, 'returns a new object with nothing removed')
 
   t.end()
 })

--- a/src/helpers/setPath.js
+++ b/src/helpers/setPath.js
@@ -13,12 +13,13 @@ const object = require('../core/object')
 const isValid = x =>
   isObject(x) || isArray(x)
 
+const pathErr =
+  'setPath: Non-empty Array of non-empty Strings and/or Positive Integers required for first argument'
+
 // setPath :: [ String | Integer ] -> a -> (Object | Array) -> (Object | Array)
 function setPath(path, val, obj) {
   if(!isArray(path) || isEmpty(path)) {
-    throw new TypeError(
-      'setPath: Non-empty Array of non-empty Strings and/or Positive Integers required for first argument'
-    )
+    throw new TypeError(pathErr)
   }
 
   if(!isValid(obj)) {
@@ -30,6 +31,10 @@ function setPath(path, val, obj) {
   const key = path[0]
   let newVal = val
 
+  if(!(isString(key) && !isEmpty(key) || isInteger(key) && key >= 0)) {
+    throw new TypeError(pathErr)
+  }
+
   if(path.length > 1) {
     const next = !isValid(obj[key])
       ? isInteger(path[1]) ? [] : {}
@@ -39,7 +44,7 @@ function setPath(path, val, obj) {
   }
 
   if(isObject(obj)) {
-    if(isString(key) && !isEmpty(key)) {
+    if(isString(key)) {
       return object.set(key, newVal, obj)
     }
 
@@ -48,7 +53,7 @@ function setPath(path, val, obj) {
     )
   }
 
-  if(isInteger(key) && key >= 0) {
+  if(isInteger(key)) {
     return array.set(key, newVal, obj)
   }
 

--- a/src/helpers/setPath.spec.js
+++ b/src/helpers/setPath.spec.js
@@ -26,6 +26,18 @@ test('setPath helper function', t => {
   t.throws(f([], {}), badKeys, 'throws when first arg is an empty array')
   t.throws(f({}, {}), badKeys, 'throws when first arg is an object')
 
+  t.throws(f([ undefined ], {}), badKeys, 'throws when first arg contains undefined')
+  t.throws(f([ null ], {}), badKeys, 'throws when first arg contains null')
+  t.throws(f([ NaN ], {}), badKeys, 'throws when first arg contains NaN')
+  t.throws(f([ '' ], {}), badKeys, 'throws with an empty string in path')
+  t.throws(f([ 1.23 ], {}), badKeys, 'throws with float number in path')
+  t.throws(f([ -1 ], {}), badKeys, 'throws with negative integer number in path')
+  t.throws(f([ false ], {}), badKeys, 'throws when first arg contains false')
+  t.throws(f([ true ], {}), badKeys, 'throws when first arg contains true')
+  t.throws(f([ unit ], {}), badKeys, 'throws when first arg contains a function')
+  t.throws(f([ [] ], {}), badKeys, 'throws when first arg contains an array')
+  t.throws(f([ {} ], {}), badKeys, 'throws when first arg contains an object')
+
   const noObj = /setPath: Object or Array required for third argument/
   t.throws(f([ 'key' ], undefined), noObj, 'throws when third arg is undefined')
   t.throws(f([ 'key' ], null), noObj, 'throws when third arg is null')
@@ -45,17 +57,8 @@ test('setPath errors with objects', t => {
   const f = bindFunc(path => fn(path, {}))
 
   const err = /setPath: Non-empty String required in path when referencing an Object/
-  t.throws(f([ undefined ]), err, 'throws with undefined in path')
-  t.throws(f([ null ]), err, 'throws with null in path')
-  t.throws(f([ NaN ]), err, 'throws with NaN in path')
-  t.throws(f([ '' ]), err, 'throws with an empty string in path')
   t.throws(f([ 0 ]), err, 'throws with falsey number in path')
   t.throws(f([ 1 ]), err, 'throws with truthy number in path')
-  t.throws(f([ false ]), err, 'throws with false in path')
-  t.throws(f([ true ]), err, 'throws with true in path')
-  t.throws(f([ unit ]), err, 'throws with a function in path')
-  t.throws(f([ {} ]), err, 'throws with an object in path')
-  t.throws(f([ [] ]), err, 'throws with an object in path')
 
   t.end()
 })
@@ -76,18 +79,7 @@ test('setPath errors with array', t => {
   const f = bindFunc(path => fn(path, []))
 
   const err = /setPath: Positive Integers required in path when referencing an Array/
-  t.throws(f([ undefined ]), err, 'throws with undefined in path')
-  t.throws(f([ null ]), err, 'throws with null in path')
-  t.throws(f([ NaN ]), err, 'throws with NaN in path')
-  t.throws(f([ '' ]), err, 'throws with an empty string in path')
   t.throws(f([ 'string' ]), err, 'throws with a non-empty string in path')
-  t.throws(f([ 1.23 ]), err, 'throws with float number in path')
-  t.throws(f([ -1 ]), err, 'throws with negative integer number in path')
-  t.throws(f([ false ]), err, 'throws with false in path')
-  t.throws(f([ true ]), err, 'throws with true in path')
-  t.throws(f([ unit ]), err, 'throws with a function in path')
-  t.throws(f([ {} ]), err, 'throws with an object in path')
-  t.throws(f([ [] ]), err, 'throws with an object in path')
 
   t.end()
 })

--- a/src/helpers/setProp.js
+++ b/src/helpers/setProp.js
@@ -40,7 +40,7 @@ function fn(name) {
   return curry(setProp)
 }
 
-// setProp :: String -> a -> Object -> Object
+// setProp :: (String | Integer) -> a -> (Object | Array) -> (Object | Array)
 const setProp =
   fn('setProp')
 

--- a/src/helpers/unsetPath.js
+++ b/src/helpers/unsetPath.js
@@ -14,6 +14,7 @@ const object = require('../core/object')
 const pathError =
   'unsetPath: Non-empty Array of non-empty Strings and/or Positive Integers required for first argument'
 
+// unsetPath :: [ String | Integer ] -> a -> a
 function unsetPath(path, obj) {
   if(!isArray(path) || isEmpty(path)) {
     throw new TypeError(pathError)

--- a/src/helpers/unsetPath.spec.js
+++ b/src/helpers/unsetPath.spec.js
@@ -6,11 +6,10 @@ const unit = require('../core/_unit')
 
 const unsetPath = require('./unsetPath')
 
-test('unsetPath errors', t => {
+test('unsetPath helper function', t => {
   const fn = bindFunc(unsetPath)
 
-  const pathErr = /unsetPath: Non-empty Array of non-empty Strings and\/or Integers required for first argument/
-
+  const pathErr = /unsetPath: Non-empty Array of non-empty Strings and\/or Positive Integers required for first argument/
   t.throws(fn(undefined, {}), pathErr, 'throws when first arg is undefined')
   t.throws(fn(null, {}), pathErr, 'throws when first arg is null')
   t.throws(fn(NaN, {}), pathErr, 'throws when first arg is NaN')
@@ -24,26 +23,17 @@ test('unsetPath errors', t => {
   t.throws(fn({}, {}), pathErr, 'throws when first arg is an object')
   t.throws(fn([], {}), pathErr, 'throws when first arg is an empty array')
 
-  t.throws(fn([ undefined ], {}), pathErr, 'throws with undefined in path')
-  t.throws(fn([ null ], {}), pathErr, 'throws with null in path')
-  t.throws(fn([ NaN ], {}), pathErr, 'throws with NaN in path')
-  t.throws(fn([ false ], {}), pathErr, 'throws with false in path')
-  t.throws(fn([ true ], {}), pathErr, 'throws with true in path')
-  t.throws(fn([ unit ], {}), pathErr, 'throws with function in path')
-  t.throws(fn([ {} ], {}), pathErr, 'throws with object in path')
-  t.throws(fn([ [] ], {}), pathErr, 'throws with array in path')
-
-  const noObj = /unsetPath: Object or Array required for second argument/
-  t.throws(fn([ 'key' ], undefined), noObj, 'throws when second arg is undefined')
-  t.throws(fn([ 'key' ], null), noObj, 'throws when second arg is null')
-  t.throws(fn([ 'key' ], NaN), noObj, 'throws when second arg is NaN')
-  t.throws(fn([ 'key' ], 0), noObj, 'throws when second arg is falsey number')
-  t.throws(fn([ 'key' ], 1), noObj, 'throws when second arg is truthy number')
-  t.throws(fn([ 'key' ], ''), noObj, 'throws when second arg is falsey string')
-  t.throws(fn([ 'key' ], 'string'), noObj, 'throws when second arg is truthy string')
-  t.throws(fn([ 'key' ], false), noObj, 'throws when second arg is false')
-  t.throws(fn([ 'key' ], true), noObj, 'throws when second arg is true')
-  t.throws(fn([ 'key' ], unit), noObj, 'throws when second arg is a function')
+  t.throws(fn([ undefined ], {}), pathErr, 'throws when path contains undefined')
+  t.throws(fn([ null ], {}), pathErr, 'throws when path contains null')
+  t.throws(fn([ NaN ], {}), pathErr, 'throws when path contains NaN')
+  t.throws(fn([ '' ], {}), pathErr, 'throws when path contains empty string')
+  t.throws(fn([ 0.32 ], {}), pathErr, 'throws when path contains float')
+  t.throws(fn([ -1 ], {}), pathErr, 'throws when path contains negative integer')
+  t.throws(fn([ false ], {}), pathErr, 'throws when path contains false')
+  t.throws(fn([ true ], {}), pathErr, 'throws when path contains true')
+  t.throws(fn([ unit ], {}), pathErr, 'throws when path contains a function')
+  t.throws(fn([ {} ], {}), pathErr, 'throws when path contains an object')
+  t.throws(fn([ [] ], {}), pathErr, 'throws when path contains an array')
 
   t.end()
 })
@@ -52,7 +42,7 @@ test('unsetPath with objects', t => {
   t.same(
     unsetPath([ 'a', 'b' ], { a: { b: 1, c: true } }),
     { a: { c: true } },
-    'removes tail of path when it exists'
+    'removes end of path when it exists'
   )
 
   t.same(
@@ -70,8 +60,29 @@ test('unsetPath with objects', t => {
   t.same(
     unsetPath([ 'a', 'b' ], { a: 'string' }),
     { a: 'string' },
-    'does not modify when path tail does not exist'
+    'does not modify when path end does not exist'
   )
+
+  t.same(
+    unsetPath([ 'a', 0 ], { a: { b: false } }),
+    { a: { b: false } },
+    'does not modify when path end is an object, but referenced with integer'
+  )
+
+  const f = a => unsetPath([ 'a', 'b' ], { a })
+
+  const testNaN = x =>
+    Object.keys(x).length === 1 && isNaN(x['a'])
+
+  t.same(f(undefined), { a: undefined }, 'returns { a: undefined } with undefined in target path')
+  t.same(f(null), { a: null }, 'returns { a: null } with null in target path')
+  t.ok(testNaN(f(NaN)), 'returns { a: NaN } with NaN in tartget path')
+  t.same(f(0), { a: 0 }, 'returns { a: 0 } with falsey number in target path')
+  t.same(f(1), { a: 1 }, 'returns { a: 1  }with truthy number in target path')
+  t.same(f(''), { a: '' }, 'returns { a: \'\' } with falsey string in target path')
+  t.same(f('string'), { a: 'string' }, 'returns { a: \'string\' } with truthy string in target path')
+  t.same(f(false), { a: false }, 'returns { a: false } with false in target path')
+  t.same(f(true), { a: true }, 'returns { a: true } with true in target path')
 
   t.end()
 })
@@ -100,5 +111,43 @@ test('unsetPath with arrays', t => {
     [ [ 1, 2 ], 3 ],
     'does not modify when path tail does not exist'
   )
+
+  t.same(
+    unsetPath([ 0, '1' ], [ [ 1, 2 ], 3 ]),
+    [ [ 1, 2 ], 3 ],
+    'does not modify when path end is an array, but referenced with string'
+  )
+
+  const f = x => unsetPath([ 0, 'a' ], [ x ])
+
+  const testNaN = x =>
+    x.length === 1 && isNaN(x[0])
+
+  t.same(f(undefined), [ undefined ], 'returns [ undefined ] with undefined in target path')
+  t.same(f(null), [ null ], 'returns [ null ] with null in target path')
+  t.ok(testNaN(f(NaN)), 'returns [ NaN ] with NaN in target path')
+  t.same(f(0), [ 0 ], 'returns [ 0 ] with falsey number in target path')
+  t.same(f(1), [ 1 ], 'returns [ 1 ] with truthy number in target path')
+  t.same(f(''), [ '' ], 'returns [ \'\' ] with falsey string in target path')
+  t.same(f('string'), [ 'string' ], 'returns [ \'string\' ] with truthy string in target path')
+  t.same(f(false), [ false ], 'returns [ false ] with false in target path')
+  t.same(f(true), [ true ], 'returns [ true ] with true in target path')
+
+  t.end()
+})
+
+test('unsetPath without arrays or objects at head', t => {
+  const f = x => unsetPath([ 1, 0 ], x)
+
+  t.equal(f(undefined), undefined, 'returns undefined with undefined')
+  t.equal(f(null), null, 'returns null with null')
+  t.ok(isNaN(f(NaN)), 'returns NaN with NaN')
+  t.equal(f(0), 0, 'returns falsey number with falsey number')
+  t.equal(f(1), 1, 'returns truthy number with truthy number')
+  t.equal(f(''), '', 'returns falsey string with string')
+  t.equal(f('string'), 'string', 'returns truthy string with string')
+  t.equal(f(false), false, 'returns false with false')
+  t.equal(f(true), true, 'returns true with true')
+
   t.end()
 })


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3665793/51295215-6d0af180-19cb-11e9-99b7-f1ee4867018c.png)
As part of this [this issue](https://github.com/evilsoft/crocks/issues/329), there are some opportunities to clean some bits up around the Path functions. This PR implements those changes by doing the following:
* Add `unset` function to `core/array`
* Add `unset function to `core/object`
* Remove a couple needless checks on keys in `setPath`
* Report key based errors in `setPath` outside of next being an Array or Object.
* update `unsetPath` to use new `unset` functions in `array` and `object`
* update `unsetPath` to report errors more like `setPath`