### PR TITLE
Add `unsetProp` and deprecate `dissoc` in favor of the new function

### DIFF
--- a/docs/src/pages/docs/functions/helpers.md
+++ b/docs/src/pages/docs/functions/helpers.md
@@ -2,7 +2,7 @@
 title: "Helpers"
 description: "Helper functions"
 layout: "notopic"
-functions: ["assign", "assoc", "binary", "compose", "composek", "composep", "composes", "curry", "defaultprops", "defaultto", "dissoc", "frompairs", "lifta2", "lifta3", "liftn", "mapprops", "mapreduce", "mconcat", "mconcatmap", "mreduce", "mreducemap", "nary", "objof", "omit", "once", "partial", "pick", "pipe", "pipek", "pipep", "pipes", "propor", "proppathor", "setpath", "setprop", "tap", "unary", "unit", "unsetpath"]
+functions: ["assign", "assoc", "binary", "compose", "composek", "composep", "composes", "curry", "defaultprops", "defaultto", "dissoc", "frompairs", "lifta2", "lifta3", "liftn", "mapprops", "mapreduce", "mconcat", "mconcatmap", "mreduce", "mreducemap", "nary", "objof", "omit", "once", "partial", "pick", "pipe", "pipek", "pipep", "pipes", "propor", "proppathor", "setpath", "setprop", "tap", "unary", "unit", "unsetpath", "unsetprop"]
 weight: 20
 ---
 
@@ -260,20 +260,6 @@ back either the default or the passed value, depending on if the passed value is
 `null`, `undefined` or `NaN`. While this *is* JavaScript and you can return
 anything, it is suggested to stick to the signature and only let `a`s through.
 As a `b` can be an `a` as well.
-
-#### dissoc
-
-`crocks/helpers/dissoc`
-
-```haskell
-dissoc :: String -> Object -> Object
-```
-
-While [`assoc`](#assoc) can be used to associate a given key-value pair to a
-given `Object`, `dissoc` does the opposite. Just pass `dissoc` a `String` key
-and the `Object` you wish to dissociate that key from and you will get back a
-new, shallow copy of the `Object` sans your key. As with all the `Object`
-functions, `dissoc` will remove any `undefined` values from the result.
 
 #### fromPairs
 
@@ -1080,6 +1066,44 @@ unsetPath([ 'a', 'b' ], { a: { b: false } })
 
 unsetPath([ 'a', 'b' ], { a: { c: false } })
 //=> { a: { c: false } }
+```
+
+#### unsetProp
+
+`crocks/helpers/unsetProp`
+
+```haskell
+unsetProp :: (String | Integer) -> a -> a
+```
+
+`unsetProp` is a binary function that takes either a property name or an index
+as its first argument. Which specifies what should be removed, or "unset", from
+the `Object` or `Array` provided as the second argument. If the value provided
+for the second argument is not an `Object` or `Array`, then the value provided
+is echoed back as the result.
+
+The first argument must be either a non-empty `String` or
+positive `Integer`. A `String` should be provided when working with
+an `Object`, while `Array`s require an `Integer`. `unsetProp` will return a new
+instance of either the `Object` or `Array`, sans the key or index.
+
+```javascript
+import unsetProp from '/crocks/helpers/unsetProp'
+
+unsetProp('temp', { name: 'Joey', temp: 33 })
+//=> { name: 'Joey' }
+
+unsetProp(1, [ 33, 22, 99 ])
+//=> [ 33, 99 ]
+
+unsetProp('d', { a: 'A', b: 'B' })
+//=> { a: 'A', b: 'B' }
+
+unsetProp(10, [ 'a', 'b', 'c' ])
+//=> [ 'a', 'b', 'c' ]
+
+unsetProp('silly', null)
+//=> null
 ```
 
 [maybe]: ../crocks/Maybe.html

--- a/docs/src/pages/docs/functions/index.md
+++ b/docs/src/pages/docs/functions/index.md
@@ -66,7 +66,7 @@ need to account for for the rest of your flow.
 | [`curry`][curry] | `((a, b, ...) -> z) -> a -> b -> ... -> z` | `crocks/helpers/curry` |
 | [`defaultProps`][defaultprops] | `Object -> Object -> Object` | `crocks/helpers/defaultProps` |
 | [`defaultTo`][defaultto] | `a -> b -> a` | `crocks/helpers/defaultTo` |
-| [`dissoc`][dissoc] | `String -> Object -> Object` | `crocks/helpers/dissoc` |
+| [`dissoc`][unsetprop]<br /><i>(deprecated)</i> | <code>(String &#124; Integer) -> a -> a</code> | `crocks/helpers/dissoc` |
 | [`fanout`][fanout] | `(a -> b) -> (a -> c) -> (a -> Pair b c)` | `crocks/Pair/fanout` |
 | [`find`][find] | <code>Foldable f => ((a -> Boolean) &#124; Pred) -> f a -> Maybe a</code> | `crocks/Maybe/find` |
 | [`fromPairs`][frompairs] | `Foldable f => f (Pair String a) -> Object` | `crocks/helpers/fromPairs` |
@@ -103,7 +103,8 @@ need to account for for the rest of your flow.
 | [`tryCatch`][trycatch] | `((*) -> b) -> (*) -> Result e b` | `crocks/Result/tryCatch` |
 | [`unary`][unary] | `((*) -> b) -> a -> b` | `crocks/helpers/unary` |
 | [`unit`][unit] | `() -> undefined` | `crocks/helpers/unit` |
-| [`unsetPath`][unsetpath] |  <code>[ (String &#124; Integer) ] -> a -> a</code>  | `crocks/helpers/unsetPath` |
+| [`unsetPath`][unsetpath] | <code>[ (String &#124; Integer) ] -> a -> a</code>  | `crocks/helpers/unsetPath` |
+| [`unsetProp`][unsetprop] | <code>(String &#124; Integer) -> a -> a</code> | `crocks/helpers/unsetProp` |
 
 ## Logic
 
@@ -182,6 +183,7 @@ type: `Pred a` and vice-versa
 [unary]: helpers.html#unary
 [unit]: helpers.html#unit
 [unsetpath]: helpers.html#unsetpath
+[unsetprop]: helpers.html#unsetprop
 
 [and]: logic-functions.html#and
 [ifelse]: logic-functions.html#ifelse

--- a/src/helpers/dissoc.js
+++ b/src/helpers/dissoc.js
@@ -1,30 +1,7 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const curry = require('../core/curry')
-const isString = require('../core/isString')
-const isObject  = require('../core/isObject')
+const unsetProp = require('./unsetProp')
 
-function applyDissoc(key, obj) {
-  return function(acc, k) {
-    if(obj[k] !== undefined && k !== key) {
-      acc[k] = obj[k]
-    }
-    return acc
-  }
-}
-
-// dissoc : String -> Object -> Object
-function dissoc(key, obj) {
-  if(!isString(key)) {
-    throw new TypeError('dissoc: String required for first argument')
-  }
-
-  if(!isObject(obj)) {
-    throw new TypeError('dissoc: Object required for second argument')
-  }
-
-  return Object.keys(obj).reduce(applyDissoc(key, obj), {})
-}
-
-module.exports = curry(dissoc)
+module.exports =
+  unsetProp.origFn('dissoc')

--- a/src/helpers/dissoc.spec.js
+++ b/src/helpers/dissoc.spec.js
@@ -2,41 +2,91 @@ const test = require('tape')
 const helpers = require('../test/helpers')
 
 const bindFunc = helpers.bindFunc
-const unit = require('../core/_unit')
+
+const isFunction = require('../core/isFunction')
+const unit =  Function.prototype
 
 const dissoc = require('./dissoc')
 
-test('dissoc', t => {
+const err =
+  /dissoc: Non-empty String required or Positive Integer required for first argument/
+
+test('dissoc helper function', t => {
+  t.ok(isFunction(dissoc), 'is a function')
+
+  const fn = bindFunc(x => dissoc(x, {}))
+
+  t.throws(fn(undefined), err, 'throws when first arg is undefined')
+  t.throws(fn(null), err, 'throws when first arg is null')
+  t.throws(fn(false, {}), err, 'throws when first arg is false')
+  t.throws(fn(true, {}), err, 'throws when first arg is true')
+  t.throws(fn(unit, {}), err, 'throws when first arg is a function')
+  t.throws(fn({}, {}), err, 'throws when first arg is an object')
+  t.throws(fn([], {}), err, 'throws when first arg is an array')
+
+  t.end()
+})
+
+test('dissoc with Object', t => {
   const fn = bindFunc(dissoc)
 
-  const noString = /dissoc: String required for first argument/
-  t.throws(fn(undefined, {}), noString, 'throws when first arg is undefined')
-  t.throws(fn(null, {}), noString, 'throws when first arg is null')
-  t.throws(fn(0, {}), noString, 'throws when first arg is falsey number')
-  t.throws(fn(1, {}), noString, 'throws when first arg is truthy number')
-  t.throws(fn(false, {}), noString, 'throws when first arg is false')
-  t.throws(fn(true, {}), noString, 'throws when first arg is true')
-  t.throws(fn(unit, {}), noString, 'throws when first arg is a function')
-  t.throws(fn({}, {}), noString, 'throws when first arg is an object')
-  t.throws(fn([], {}), noString, 'throws when first arg is an array')
+  t.throws(fn('', {}), err, 'throws when first arg is empty string')
 
-  const noObj = /dissoc: Object required for second argument/
-  t.throws(fn('', undefined), noObj, 'throws when second arg is undefined')
-  t.throws(fn('', null), noObj, 'throws when second arg is null')
-  t.throws(fn('', 0), noObj, 'throws when second arg is falsey number')
-  t.throws(fn('', 1), noObj, 'throws when second arg is truthy number')
-  t.throws(fn('', ''), noObj, 'throws when second arg is falsey string')
-  t.throws(fn('', 'string'), noObj, 'throws when second arg is truthy string')
-  t.throws(fn('', false), noObj, 'throws when second arg is false')
-  t.throws(fn('', true), noObj, 'throws when second arg is true')
+  const data =
+    { a: true }
+
+  const noString =
+    x => dissoc(x, data)
+
+  t.equals(noString(0), data, 'does nothing with falsy number as first argument')
+  t.equals(noString(1), data, 'does nothing with truthy number as first argument')
 
   const undefs = { a: undefined, b: undefined }
-  t.same(dissoc('', undefs), {}, 'removes undefined values')
+  t.same(dissoc('key', undefs), {}, 'removes undefined values')
 
   const defs = { a: 1, b: 2 }
-  t.same(dissoc('', defs), defs, 'empty string returns with nothing removed')
-  t.notEqual(dissoc('', defs), defs, 'returns a new object')
+  t.notEqual(dissoc('key', defs), defs, 'returns a new object')
   t.same(dissoc('a', defs), { b: 2 }, 'returns a new object with specified key removed')
+
+  t.end()
+})
+
+test('dissoc with Array', t => {
+  const fn = bindFunc(dissoc)
+
+  t.throws(fn(3.1416, []), err, 'throws when first arg is float')
+  t.throws(fn(-6, []), err, 'throws when first arg is negative')
+
+  const data =
+    [ 1, 2, 3 ]
+
+  const noInteger =
+    x => dissoc(x, data)
+
+  t.equals(noInteger('string'), data, 'does nothing with truthy string as first argument')
+
+  const undefs = [ undefined, undefined ]
+  t.same(dissoc(0, undefs), [ undefined ], 'does not remove undefined values')
+
+  const defs = [ 34, 99, 'string' ]
+  t.same(dissoc(3, defs), defs, 'keeps items when index does not exist')
+  t.notEqual(dissoc(3, defs), defs, 'returns a new object')
+
+  t.same(dissoc(1, defs), [ 34, 'string' ], 'removes item at index without holes')
+
+  t.end()
+})
+
+test('dissoc without Object or Array', t => {
+  t.equals(dissoc('a', undefined), undefined, 'returns undefined with undefined')
+  t.equals(dissoc('a', null), null, 'returns null with when null')
+  t.ok(Number.isNaN(dissoc('a', NaN)), 'returns NaN with NaN')
+  t.equals(dissoc('a', 0), 0, 'returns falsy number with falsy number')
+  t.equals(dissoc('a', 1), 1, 'returns truthy number with truthy number')
+  t.equals(dissoc('a', ''), '', 'returns falsy string with falsy string')
+  t.equals(dissoc('a', 'string'), 'string', 'returns truthy string with truthy string')
+  t.equals(dissoc('a', false), false, 'returns false with false')
+  t.equals(dissoc('a', true), true, 'returns true with true')
 
   t.end()
 })

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -37,5 +37,6 @@ module.exports = {
   tap: require('./tap'),
   unary: require('./unary'),
   unit: require('./unit'),
-  unsetPath: require('./unsetPath')
+  unsetPath: require('./unsetPath'),
+  unsetProp: require('./unsetProp')
 }

--- a/src/helpers/unsetProp.js
+++ b/src/helpers/unsetProp.js
@@ -1,0 +1,51 @@
+/** @license ISC License (c) copyright 2019 original and current authors */
+/** @author Ian Hofmann-Hicks (evil) */
+
+const curry = require('../core/curry')
+const isArray = require('../core/isArray')
+const isEmpty = require('../core/isEmpty')
+const isInteger  = require('../core/isInteger')
+const isObject  = require('../core/isObject')
+const isString = require('../core/isString')
+
+const array = require('../core/array')
+const object = require('../core/object')
+
+function fn(name) {
+  function unsetProp(key, obj) {
+    if(!(isObject(obj) || isArray(obj))) {
+      return obj
+    }
+
+    if(!(isString(key) && !isEmpty(key) || isInteger(key) && key >= 0)) {
+      throw new TypeError(
+        `${name}: Non-empty String required or Positive Integer required for first argument`
+      )
+    }
+
+    if(isObject(obj)) {
+      if(isString(key) && !isEmpty(key)) {
+        return object.unset(key, obj)
+      }
+    }
+
+    if(isArray(obj)) {
+      if(isInteger(key) && key >= 0) {
+        return array.unset(key, obj)
+      }
+    }
+
+    return obj
+  }
+
+  return curry(unsetProp)
+}
+
+const unsetProp =
+  fn('unsetProp')
+
+unsetProp.origFn =
+  fn
+
+module.exports =
+  unsetProp

--- a/src/helpers/unsetProp.spec.js
+++ b/src/helpers/unsetProp.spec.js
@@ -1,0 +1,92 @@
+const test = require('tape')
+const helpers = require('../test/helpers')
+
+const bindFunc = helpers.bindFunc
+
+const isFunction = require('../core/isFunction')
+const unit =  Function.prototype
+
+const unsetProp = require('./unsetProp')
+
+const err =
+  /unsetProp: Non-empty String required or Positive Integer required for first argument/
+
+test('unsetProp helper function', t => {
+  t.ok(isFunction(unsetProp), 'is a function')
+  const fn = bindFunc(x => unsetProp(x, {}))
+
+  t.throws(fn(undefined), err, 'throws when first arg is undefined')
+  t.throws(fn(null), err, 'throws when first arg is null')
+  t.throws(fn(NaN), err, 'throws when first arg is NaN')
+  t.throws(fn(false, {}), err, 'throws when first arg is false')
+  t.throws(fn(true, {}), err, 'throws when first arg is true')
+  t.throws(fn(unit, {}), err, 'throws when first arg is a function')
+  t.throws(fn({}, {}), err, 'throws when first arg is an object')
+  t.throws(fn([], {}), err, 'throws when first arg is an array')
+
+  t.end()
+})
+
+test('unsetProp with Object', t => {
+  const fn = bindFunc(unsetProp)
+
+  t.throws(fn('', {}), err, 'throws when first arg is empty string')
+
+  const data =
+    { a: true }
+
+  const noString =
+    x => unsetProp(x, data)
+
+  t.equals(noString(0), data, 'does nothing with falsy number as first argument')
+  t.equals(noString(1), data, 'does nothing with truthy number as first argument')
+
+  const undefs = { a: undefined, b: undefined }
+  t.same(unsetProp('key', undefs), {}, 'removes undefined values')
+
+  const defs = { a: 1, b: 2 }
+  t.notEqual(unsetProp('key', defs), defs, 'returns a new object')
+  t.same(unsetProp('a', defs), { b: 2 }, 'returns a new object with specified key removed')
+
+  t.end()
+})
+
+test('unsetProp with Array', t => {
+  const fn = bindFunc(unsetProp)
+
+  t.throws(fn(1.34, []), err, 'throws when first arg is float')
+  t.throws(fn(-1, []), err, 'throws when first arg is negative')
+
+  const data =
+    [ 1, 2, 3 ]
+
+  const noInteger =
+    x => unsetProp(x, data)
+
+  t.equals(noInteger('string'), data, 'does nothing with truthy string as first argument')
+
+  const undefs = [ undefined, undefined ]
+  t.same(unsetProp(0, undefs), [ undefined ], 'does not remove undefined values')
+
+  const defs = [ 34, 99, 'string' ]
+  t.same(unsetProp(3, defs), defs, 'keeps items when index does not exist')
+  t.notEqual(unsetProp(3, defs), defs, 'returns a new object')
+
+  t.same(unsetProp(1, defs), [ 34, 'string' ], 'removes item at index without holes')
+
+  t.end()
+})
+
+test('unsetProp without Object or Array', t => {
+  t.equals(unsetProp('a', undefined), undefined, 'returns undefined with undefined')
+  t.equals(unsetProp('a', null), null, 'returns null with when null')
+  t.ok(Number.isNaN(unsetProp('a', NaN)), 'returns NaN with NaN')
+  t.equals(unsetProp('a', 0), 0, 'returns falsy number with falsy number')
+  t.equals(unsetProp('a', 1), 1, 'returns truthy number with truthy number')
+  t.equals(unsetProp('a', ''), '', 'returns falsy string with falsy string')
+  t.equals(unsetProp('a', 'string'), 'string', 'returns truthy string with truthy string')
+  t.equals(unsetProp('a', false), false, 'returns false with false')
+  t.equals(unsetProp('a', true), true, 'returns true with true')
+
+  t.end()
+})

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -78,6 +78,7 @@ const tryCatch = require('./Result/tryCatch')
 const unary = require('./helpers/unary')
 const unit = require('./helpers/unit')
 const unsetPath = require('./helpers/unsetPath')
+const unsetProp = require('./helpers/unsetProp')
 
 // logic
 const and = require('./logic/and')
@@ -306,6 +307,7 @@ test('entry', t => {
   t.equal(crocks.unary, unary, 'provides the unary helper')
   t.equal(crocks.unit, unit, 'provides the unit helper')
   t.equal(crocks.unsetPath, unsetPath, 'provides the unsetPath helper')
+  t.equal(crocks.unsetProp, unsetProp, 'provides the unsetProp helper')
 
   // logic
   t.equal(crocks.and, and, 'provides the and logic')


### PR DESCRIPTION
## Get rid of the crusties
![image](https://user-images.githubusercontent.com/3665793/54483003-ac0dc580-4809-11e9-9b86-3439decf0428.png)

This PR addresses part of [this issue](https://github.com/evilsoft/crocks/issues/329) and adds the `unsetProp` function while also depreciating `dissoc`. The behavior for argument handling matches `unsetPath` in that:
* Only allows non-empty `String`s and positive `Integer`s for referencing keys/indices on a given `Object`/`Array`
* Will echo the provided target when it is not an `Object` or `Array`