### PR TITLE
Remove `warning` option for uglifyjs to fix node 6 builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preversion": "npm run build",
     "postpublish": "npm run docs:deploy",
     "build:publish": "npm test && ./bin/publish",
-    "build:dist": "webpack && uglifyjs build/dist/crocks.js -c \"warnings=false\" -m -o build/dist/crocks.min.js",
+    "build:dist": "webpack && uglifyjs build/dist/crocks.js -m -o build/dist/crocks.min.js",
     "build": "doctoc && rimraf build && buble -i src -o build && npm run build:dist",
     "doctoc": "doctoc README.md",
     "docs:dev": "cd docs && npm start",


### PR DESCRIPTION
## Picard is Disappoint.
![image](https://user-images.githubusercontent.com/3665793/57201325-4d80e000-6f4c-11e9-8224-b46837ed9b1d.png)

Looks like when upgrading we broke the build stack for node 6 testing due to how uglifyjs handles unrecognized options. This is cause a build failure for the node 6 stacks. This PR should resolve the failed builds.