### PR TITLE
Fix Either constructor when called with object containing a circular reference

### DIFF
--- a/src/Either/Either.spec.js
+++ b/src/Either/Either.spec.js
@@ -25,6 +25,14 @@ const applyTo =
 const constant = x => () => x
 const identity = x => x
 
+const testCircularReference = (t, fn) => {
+  const objectWithCircularReference = {}
+  const ref = { objectWithCircularReference }
+  objectWithCircularReference.ref = ref
+
+  t.doesNotThrow(() => fn(objectWithCircularReference), 'does not throw when called with an object containing a circular reference')
+}
+
 const Either = require('.')
 
 test('Either', t => {
@@ -94,6 +102,8 @@ test('Either.Left', t => {
 
   t.equal(l.either(identity, constant('right')), 'value', 'creates an Either.Left')
 
+  testCircularReference(t, Either.Left)
+
   t.end()
 })
 
@@ -101,6 +111,8 @@ test('Either.Right', t => {
   const r = Either.Right('value')
 
   t.equal(r.either(constant('left'), identity), 'value', 'creates an Either.Right')
+
+  testCircularReference(t, Either.Right)
 
   t.end()
 })
@@ -844,6 +856,7 @@ test('Either of', t => {
   t.equal(Either.of, Either(0).of, 'Either.of is the same as the instance version')
   t.equal(Either.of(0).type(), 'Either', 'returns an Either')
   t.equal(Either.of(0).either(constant('left'), identity), 0, 'wraps the value into an Either.Right')
+  testCircularReference(t, Either.of)
 
   t.end()
 })

--- a/src/Either/index.js
+++ b/src/Either/index.js
@@ -63,12 +63,11 @@ function Either(u) {
   const of =
     _of
 
-  const inspect = constant(
+  const inspect = () =>
     either(
       l => `Left${_inspect(l)}`,
       r => `Right${_inspect(r)}`
     )
-  )
 
   function either(f, g) {
     if(!isFunction(f) || !isFunction(g)) {


### PR DESCRIPTION
Introduced in release 0.9.4 with commit https://github.com/evilsoft/crocks/commit/6bc5377cf4a47a927ff3fa407073d17aa3b0cdbe#diff-d70a7c87b679a4d796e121bd30e12fd1 the `inspect` function recursively stringifies objects which will blow the callstack when given an object containing a circular reference.

This bug is triggered when constructing an Either due to its `inspect` method being eagerly evaluated during construction.