### PR TITLE
add docs.crocks.dev hostname to docs

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.crocks.dev


### PR DESCRIPTION
I purchased the domain [crocks.dev](https://crocks.dev). It's currently pointed to Github's servers. This PR should (I think) let `docs.crocks.dev` point to the docs page.