### PR TITLE
Update CI to remove node-6 and add node-12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
+  - '12'
   - '10'
   - '8'
-  - '6'
 
 install:
   - npm install


### PR DESCRIPTION
## I guess ☝️
![image](https://user-images.githubusercontent.com/3665793/60696767-0c4d7380-9e9c-11e9-804e-992ba4181e57.png)

What it says on the tin. We only support the last three LTS versions. This drops 6 and adds 12.