### PR TITLE
Adding new `hasProps` predicate

### DIFF
--- a/docs/src/pages/docs/functions/predicate-functions.md
+++ b/docs/src/pages/docs/functions/predicate-functions.md
@@ -16,7 +16,7 @@ Below is a list of all the current predicates that are included with a
 description of their truth:
 
 * `hasProp :: (String | Integer) -> a -> Boolean`: an `Array` or `Object` that contains the provided index or key
-* `hasProps :: Array (String | Integer) -> a -> Boolean`: an `Array` or `Object` that contains the provided indexs or keys
+* `hasProps :: Foldable f => f (String | Integer) -> a -> Boolean`: an `Array` or `Object` that contains the provided indexs or keys
 * `hasPropPath :: [ String | Integer ] -> a -> Boolean`: an `Array` or `Object` that contains the provided index path
 * `isAlt :: a -> Boolean`: an ADT that provides `map` and `alt` methods
 * `isAlternative :: a -> Boolean`: an ADT that provides `alt`, `zero`, `map`, `ap`, `chain` and `of`methods

--- a/docs/src/pages/docs/functions/predicate-functions.md
+++ b/docs/src/pages/docs/functions/predicate-functions.md
@@ -2,7 +2,7 @@
 description: "Predicate Functions API"
 layout: "notopic"
 title: "Predicate Functions"
-functions: ["hasprop", "hasproppath", "isalt", "isalternative", "isapplicative", "isapply", "isarray", "isbifunctor", "isboolean", "iscategory", "ischain", "iscontravariant", "isDate", "isdefined", "isempty", "isextend", "isfalse", "isfalsy", "isfoldable", "isfunction", "isfunctor", "isinteger", "isiterable", "ismonad", "ismonoid", "isnil", "isnumber", "isobject", "isplus", "isprofunctor", "ispromise", "issame", "issametype", "issemigroup", "issemigroupoid", "issetoid", "isstring", "istraversable", "istrue", "istruthy", "patheq", "pathsatisfies", "propeq", "propsatisfies"]
+functions: ["hasprop", "hasprops", "hasproppath", "isalt", "isalternative", "isapplicative", "isapply", "isarray", "isbifunctor", "isboolean", "iscategory", "ischain", "iscontravariant", "isDate", "isdefined", "isempty", "isextend", "isfalse", "isfalsy", "isfoldable", "isfunction", "isfunctor", "isinteger", "isiterable", "ismonad", "ismonoid", "isnil", "isnumber", "isobject", "isplus", "isprofunctor", "ispromise", "issame", "issametype", "issemigroup", "issemigroupoid", "issetoid", "isstring", "istraversable", "istrue", "istruthy", "patheq", "pathsatisfies", "propeq", "propsatisfies"]
 weight: 40
 ---
 
@@ -16,6 +16,7 @@ Below is a list of all the current predicates that are included with a
 description of their truth:
 
 * `hasProp :: (String | Integer) -> a -> Boolean`: an `Array` or `Object` that contains the provided index or key
+* `hasProps :: Array (String | Integer) -> a -> Boolean`: an `Array` or `Object` that contains the provided indexs or keys
 * `hasPropPath :: [ String | Integer ] -> a -> Boolean`: an `Array` or `Object` that contains the provided index path
 * `isAlt :: a -> Boolean`: an ADT that provides `map` and `alt` methods
 * `isAlternative :: a -> Boolean`: an ADT that provides `alt`, `zero`, `map`, `ap`, `chain` and `of`methods

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -154,6 +154,7 @@ const valueOf = require('./pointfree/valueOf')
 
 // predicates
 const hasProp = require('./predicates/hasProp')
+const hasProps = require('./predicates/hasProps')
 const hasPropPath = require('./predicates/hasPropPath')
 const isAlt = require('./predicates/isAlt')
 const isAlternative = require('./predicates/isAlternative')
@@ -393,6 +394,7 @@ test('entry', t => {
 
   // predicates
   t.equal(crocks.hasProp, hasProp, 'provides the hasProp predicate')
+  t.equal(crocks.hasProps, hasProps, 'provides the hasProps predicate')
   t.equal(crocks.hasPropPath, hasPropPath, 'provides the hasPropPath predicate')
   t.equal(crocks.isAlt, isAlt, 'provides the isAlt predicate')
   t.equal(crocks.isAlternative, isAlternative, 'provides the isAlternative predicate')

--- a/src/predicates/hasProps.js
+++ b/src/predicates/hasProps.js
@@ -4,10 +4,10 @@
 const curry = require('../core/curry')
 const isDefined = require('../core/isDefined')
 const isEmpty = require('../core/isEmpty')
-const isString = require('../core/isString')
+const isFoldable = require('../core/isFoldable')
 const isInteger = require('../core/isInteger')
 const isNil = require('../core/isNil')
-const isFoldable = require('../core/isFoldable')
+const isString = require('../core/isString')
 
 // err :: String
 const err =

--- a/src/predicates/hasProps.js
+++ b/src/predicates/hasProps.js
@@ -1,0 +1,29 @@
+/** @license ISC License (c) copyright 2019 original and current authors */
+/** @author Dale Francis (dalefrancis88) */
+
+const curry = require('../core/curry')
+const isArray = require('../core/isArray')
+const isDefined = require('../core/isDefined')
+const isEmpty = require('../core/isEmpty')
+const isInteger = require('../core/isInteger')
+const isNil = require('../core/isNil')
+
+const isValid = keys =>
+  isArray(keys) && !isEmpty(keys) && keys.every(key => !isEmpty(key) || isInteger(key))
+
+// hasProps : Foldable (String | Integer) -> a -> Boolean
+function hasProps(keys, x) {
+  if(!isValid(keys)) {
+    throw new TypeError(
+      'hasProps: First argument must be an Array of Non-empty Strings or Integers'
+    )
+  }
+
+  if(isNil(x)) {
+    return false
+  }
+
+  return keys.every(key => isDefined(x[key]))
+}
+
+module.exports = curry(hasProps)

--- a/src/predicates/hasProps.js
+++ b/src/predicates/hasProps.js
@@ -30,7 +30,7 @@ const hasKey = obj => key => {
 const every = fn => (acc, x) =>
   (acc === null ? true : acc) && fn(x)
 
-// hasProps :: Foldable f -> a -> Boolean
+// hasProps :: Foldable f => f (String | Integer) -> a -> Boolean
 function hasProps(keys, x) {
   if(!isFoldable(keys)) {
     throw new TypeError(err)

--- a/src/predicates/hasProps.js
+++ b/src/predicates/hasProps.js
@@ -2,28 +2,50 @@
 /** @author Dale Francis (dalefrancis88) */
 
 const curry = require('../core/curry')
-const isArray = require('../core/isArray')
 const isDefined = require('../core/isDefined')
 const isEmpty = require('../core/isEmpty')
+const isString = require('../core/isString')
 const isInteger = require('../core/isInteger')
 const isNil = require('../core/isNil')
+const isFoldable = require('../core/isFoldable')
 
-const isValid = keys =>
-  isArray(keys) && !isEmpty(keys) && keys.every(key => !isEmpty(key) || isInteger(key))
+// err :: String
+const err =
+  'hasProps: First argument must be a Foldable of Non-empty Strings or Integers'
 
-// hasProps : Foldable (String | Integer) -> a -> Boolean
+// isKeyValid :: a -> Boolean
+const isKeyValid = key =>
+  isString(key) && !isEmpty(key) || isInteger(key)
+
+// hasKey :: a -> (String | Integer) -> Boolean
+const hasKey = obj => key => {
+  if(!isKeyValid(key)) {
+    throw new TypeError(err)
+  }
+
+  return isDefined(obj[key])
+}
+
+// every :: (a -> Boolean) -> ((Null | Boolean), a) -> Boolean
+const every = fn => (acc, x) =>
+  (acc === null ? true : acc) && fn(x)
+
+// hasProps :: Foldable f -> a -> Boolean
 function hasProps(keys, x) {
-  if(!isValid(keys)) {
-    throw new TypeError(
-      'hasProps: First argument must be an Array of Non-empty Strings or Integers'
-    )
+  if(!isFoldable(keys)) {
+    throw new TypeError(err)
   }
 
   if(isNil(x)) {
     return false
   }
 
-  return keys.every(key => isDefined(x[key]))
+  const result = keys.reduce(
+    every(hasKey(x)),
+    null
+  )
+
+  return result === null || result
 }
 
 module.exports = curry(hasProps)

--- a/src/predicates/hasProps.spec.js
+++ b/src/predicates/hasProps.spec.js
@@ -1,5 +1,6 @@
 const test = require('tape')
 const helpers = require('../test/helpers')
+const List = require('../core/List')
 
 const bindFunc = helpers.bindFunc
 
@@ -23,7 +24,7 @@ test('hasProps function', t => {
 test('hasProps errors', t => {
   const fn = bindFunc(hasProps)
 
-  const err = /hasProps: First argument must be an Array of Non-empty Strings or Integers/
+  const err = /^TypeError: hasProps: First argument must be a Foldable of Non-empty Strings or Integers/
 
   t.throws(fn(undefined, {}), err, 'throws with undefined in first argument')
   t.throws(fn(null, {}), err, 'throws with null in first argument')
@@ -31,7 +32,6 @@ test('hasProps errors', t => {
   t.throws(fn(false, {}), err, 'throws with false in first argument')
   t.throws(fn(true, {}), err, 'throws with true number in first argument')
   t.throws(fn({}, {}), err, 'throws with object in first argument')
-  t.throws(fn([], {}), err, 'throws with empty array in first argument')
   t.throws(fn(unit, {}), err, 'throws with function in first argument')
   t.throws(fn('', {}), err, 'throws with empty string in first argument')
   t.throws(fn(1.265, {}), err, 'throws with float in first argument')
@@ -48,6 +48,8 @@ test('hasProps object traversal', t => {
   t.equals(fn({ a: null, b: null }), true, 'returns true when keys exists on object with a null values')
   t.equals(fn({ a: NaN, b: NaN }), true, 'returns true when keys exists on object with a NaN values')
 
+  t.equals(hasProps([], {}), true, 'returns true when keys is an empty array')
+
   t.equals(fn({ c: 10 }), false, 'returns false when keys do not exist on object')
   t.equals(fn({ a: undefined, b: undefined }), false, 'returns false when keys exists on object with undefined values')
 
@@ -63,8 +65,38 @@ test('hasProps array traversal', t => {
   t.equals(fn([ 0, null, null ]), true, 'returns true when string index exists in array with null value')
   t.equals(fn([ 0, NaN, NaN ]), true, 'returns true when string index exists in array with NaN value')
 
+  t.equals(hasProps([], []), true, 'returns true when keys is an empty array')
+
   t.equals(fn([ 0 ]), false, 'returns false when index does not exist in array')
   t.equals(fn([ 0, undefined, undefined ]), false, 'returns false when index exists in array with undefined value')
+
+  t.end()
+})
+
+test('hasProps foldable keys', t => {
+  t.equal(hasProps(List('key'), { key: '123' }), true, 'returns true when Foldable structure is passed containing single string')
+  t.equal(hasProps(List(1), [ 2, 3 ]), true, 'returns true when Foldable structure is passed containing int')
+
+  t.equal(hasProps(List('key'), { notKey: '123' }), false, 'returns false when Foldable structure is passed containing single non-existant string')
+  t.equal(hasProps(List(1), [ 2 ]), false, 'returns false when Foldable structure is passed containing a non-existant index')
+
+  t.end()
+})
+
+test('hasProps foldable errors', t => {
+  const fn = value => bindFunc(hasProps)(List(value), { })
+
+  const err = /^TypeError: hasProps: First argument must be a Foldable of Non-empty Strings or Integers/
+
+  t.throws(fn(undefined), err, 'throws with undefined in first argument')
+  t.throws(fn(null), err, 'throws with null in first argument')
+  t.throws(fn(NaN), err, 'throws with NaN in first argument')
+  t.throws(fn(false), err, 'throws with false in first argument')
+  t.throws(fn(true), err, 'throws with true number in first argument')
+  t.throws(fn({}), err, 'throws with object in first argument')
+  t.throws(fn(unit), err, 'throws with function in first argument')
+  t.throws(fn(''), err, 'throws with empty string in first argument')
+  t.throws(fn(1.265), err, 'throws with float in first argument')
 
   t.end()
 })

--- a/src/predicates/hasProps.spec.js
+++ b/src/predicates/hasProps.spec.js
@@ -1,0 +1,70 @@
+const test = require('tape')
+const helpers = require('../test/helpers')
+
+const bindFunc = helpers.bindFunc
+
+const isFunction = require('../core/isFunction')
+const unit = require('../core/_unit')
+
+const hasProps = require('./hasProps')
+
+test('hasProps function', t => {
+  const fn = hasProps([ 'a' ])
+
+  t.ok(isFunction(hasProps), 'is a function')
+
+  t.equals(fn(undefined), false, 'returns false for undefined')
+  t.equals(fn(null), false, 'returns false for null')
+  t.equals(fn(NaN), false, 'returns false for NaN')
+
+  t.end()
+})
+
+test('hasProps errors', t => {
+  const fn = bindFunc(hasProps)
+
+  const err = /hasProps: First argument must be an Array of Non-empty Strings or Integers/
+
+  t.throws(fn(undefined, {}), err, 'throws with undefined in first argument')
+  t.throws(fn(null, {}), err, 'throws with null in first argument')
+  t.throws(fn(NaN, {}), err, 'throws with NaN in first argument')
+  t.throws(fn(false, {}), err, 'throws with false in first argument')
+  t.throws(fn(true, {}), err, 'throws with true number in first argument')
+  t.throws(fn({}, {}), err, 'throws with object in first argument')
+  t.throws(fn([], {}), err, 'throws with empty array in first argument')
+  t.throws(fn(unit, {}), err, 'throws with function in first argument')
+  t.throws(fn('', {}), err, 'throws with empty string in first argument')
+  t.throws(fn(1.265, {}), err, 'throws with float in first argument')
+  t.throws(fn('true', {}), err, 'throws with truthy string in first argument')
+  t.throws(fn(1, {}), err, 'throws with int in first argument')
+
+  t.end()
+})
+
+test('hasProps object traversal', t => {
+  const fn = hasProps([ 'a', 'b' ])
+
+  t.equals(fn({ a: 10, b: 20 }), true, 'returns true when keys exists on object')
+  t.equals(fn({ a: null, b: null }), true, 'returns true when keys exists on object with a null values')
+  t.equals(fn({ a: NaN, b: NaN }), true, 'returns true when keys exists on object with a NaN values')
+
+  t.equals(fn({ c: 10 }), false, 'returns false when keys do not exist on object')
+  t.equals(fn({ a: undefined, b: undefined }), false, 'returns false when keys exists on object with undefined values')
+
+  t.end()
+})
+
+test('hasProps array traversal', t => {
+  const fn = hasProps([ 1, 2 ])
+  const string = hasProps([ '1', '2' ])
+
+  t.equals(fn([ 10, 0, 20 ]), true, 'returns true when index exists in array')
+  t.equals(string([ 0, false, false ]), true, 'returns true when string index exists in array')
+  t.equals(fn([ 0, null, null ]), true, 'returns true when string index exists in array with null value')
+  t.equals(fn([ 0, NaN, NaN ]), true, 'returns true when string index exists in array with NaN value')
+
+  t.equals(fn([ 0 ]), false, 'returns false when index does not exist in array')
+  t.equals(fn([ 0, undefined, undefined ]), false, 'returns false when index exists in array with undefined value')
+
+  t.end()
+})

--- a/src/predicates/index.js
+++ b/src/predicates/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   hasProp: require('./hasProp'),
+  hasProps: require('./hasProps'),
   hasPropPath: require('./hasPropPath'),
   isAlt: require('./isAlt'),
   isAlternative: require('./isAlternative'),

--- a/src/predicates/index.spec.js
+++ b/src/predicates/index.spec.js
@@ -3,6 +3,7 @@ const test = require('tape')
 const index = require('.')
 
 const hasProp = require('./hasProp')
+const hasProps = require('./hasProps')
 const hasPropPath = require('./hasPropPath')
 const isAlt = require('./isAlt')
 const isAlternative = require('./isAlternative')
@@ -51,6 +52,7 @@ const propPathSatisfies = require('./propPathSatisfies')
 
 test('predicates entry', t => {
   t.equal(index.hasProp, hasProp, 'provides the hasProp predicate')
+  t.equal(index.hasProps, hasProps, 'provides the hasProps predicate')
   t.equal(index.hasPropPath, hasPropPath, 'provides the hasPropPath predicate')
   t.equal(index.isAlt, isAlt, 'provides the isAlt predicate')
   t.equal(index.isAlternative, isAlternative, 'provides the isAlternative predicate')


### PR DESCRIPTION
This will allow us to pass an array of keys instead of a single key to check the structure of an object.

Have some things to point out

1. Are we ok with the use of `every`? I'm not married to it and am happy to convert it to reduce
2. Right now it doesn't support taking either the Array or the single value, do we want to do that?
3. Is that the correct way to specify the expected values in an Array? I see that everywhere else we're using just Array but it'd be nice to be more specific in the signature