### PR TITLE
Adding `curry` to `pipe` and `compose`

### DIFF
--- a/src/helpers/compose.js
+++ b/src/helpers/compose.js
@@ -2,6 +2,7 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const isFunction = require('../core/isFunction')
+const curry = require('./curry')
 
 const err = 'compose: Functions required'
 
@@ -33,7 +34,7 @@ function compose(...args) {
   const tail =
     fns.slice(1).concat(x => x)
 
-  return tail.reduce(applyPipe, head)
+  return curry(tail.reduce(applyPipe, head))
 }
 
 module.exports = compose

--- a/src/helpers/compose.spec.js
+++ b/src/helpers/compose.spec.js
@@ -55,7 +55,7 @@ test('composed function', t => {
   const result = compose(second, first).apply(null, args)
 
   t.ok(first.calledBefore(second), 'right-most function is called first')
-  t.ok(first.calledWith.apply(first, args), 'right-most function applied with all arguments')
+  t.ok(first.calledWith.apply(first, args.slice(0, 1)), 'right-most function applied with only first argument')
   t.ok(second.calledWith('string'), 'second function receives result of the first function')
 
   t.equal(result, 'bling', 'returns the result of the left-most function')

--- a/src/helpers/pipe.js
+++ b/src/helpers/pipe.js
@@ -2,6 +2,7 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 const isFunction = require('../core/isFunction')
+const curry = require('./curry')
 
 const err = 'pipe: Functions required'
 
@@ -31,7 +32,7 @@ function pipe(...fns) {
   const tail =
     fns.slice(1).concat(x => x)
 
-  return tail.reduce(applyPipe, head)
+  return curry(tail.reduce(applyPipe, head))
 }
 
 module.exports = pipe

--- a/src/helpers/pipe.spec.js
+++ b/src/helpers/pipe.spec.js
@@ -53,7 +53,7 @@ test('pipe helper', t => {
   t.ok(isFunction(pipe(unit)), 'returns a function')
 
   t.ok(first.calledBefore(second), 'left-most function is called first')
-  t.ok(first.calledWith.apply(first, args), 'right-most function applied with all arguments')
+  t.ok(first.calledWith.apply(first, args.slice(0, 1)), 'right-most function applied with only first argument')
   t.ok(second.calledWith('string'), 'second function receives result of the first function')
 
   t.equal(result, 'bling', 'returns the result of the left-most function')


### PR DESCRIPTION
Nearly all of our functions export a curried function when complete except for our `compose` and `pipe` functions. If we `curry` the result then we get https://github.com/evilsoft/crocks/issues/338

If we do something like this we get the power of these functions as is, along with the expected behaviour of a few people in the order of argument application with non-unary invocation of the resultant composition

Also testing this implementation has it not appear to be a breaking change 
