### PR TITLE
Add CNAME to docs on Publish

### DIFF
--- a/docs/src/CNAME
+++ b/docs/src/CNAME
@@ -1,0 +1,1 @@
+crocks.dev


### PR DESCRIPTION
## Stop playing the config game
![image](https://user-images.githubusercontent.com/3665793/61595552-81fc5380-abad-11e9-811a-ff9c087a09dc.png)

Took a few to find out how to get the CNAME to publish with the docs. Tracked it down and submitting this for the next release.