### PR TITLE
Require Monoid Instance for Log Entry When Constructing A Writer

### DIFF
--- a/src/Pair/writerToPair.spec.js
+++ b/src/Pair/writerToPair.spec.js
@@ -39,7 +39,7 @@ test('writerToPair with Writer', t => {
   const value = 'something'
   const log = 'log'
 
-  const p = writerToPair(Writer(log, value))
+  const p = writerToPair(Writer(Last(log), value))
 
   t.ok(isSameType(Pair, p), 'returns a Pair')
 
@@ -54,7 +54,7 @@ test('writerToPair with Writer returning function', t => {
   const value = 'something'
   const log = 'log'
 
-  t.ok(isFunction(constant(writerToPair(Writer(log, value)))), 'returns a function')
+  t.ok(isFunction(constant(writerToPair(Writer(Last(log), value)))), 'returns a function')
 
   const f = bindFunc(writerToPair(identity))
 
@@ -71,7 +71,7 @@ test('writerToPair with Writer returning function', t => {
   t.throws(f({}), err, 'throws if function returns an object')
 
   const lift =
-    x => Writer(log, x)
+    x => Writer(Last(log), x)
 
   const p = writerToPair(lift, value)
 

--- a/src/Writer/Writer.spec.js
+++ b/src/Writer/Writer.spec.js
@@ -58,11 +58,11 @@ test('Writer', t => {
   t.ok(isFunction(Writer.type), 'provides a type function')
   t.ok(isString(Writer['@@type']), 'provides a @@type string')
 
-  const err = /^TypeError: Writer: Must be contructed with both a log entry and a value/
+  const err = /^TypeError: Writer\(Last\): Must be contructed with both a log entry and a value/
   t.throws(f(), err, 'throws with no parameters')
   t.throws(f(0), err, 'throws with one parameter')
 
-  const entryErr = /^TypeError: Writer: Log enrty must be an instance of Last/
+  const entryErr = /^TypeError: Writer\(Last\): Log enrty must be an instance of Last/
   t.throws(f(undefined, 0), entryErr, 'throws with undefined entry')
   t.throws(f(null, 0), entryErr, 'throws with null entry')
   t.throws(f(0, 0), entryErr, 'throws with falsy number entry')
@@ -200,7 +200,7 @@ test('Writer equals properties (Setoid)', t => {
 test('Writer map errors', t => {
   const map = bindFunc(Writer(Last(0), 0).map)
 
-  const err = /^TypeError: Writer.map: Function required/
+  const err = /^TypeError: Writer\(Last\).map: Function required/
   t.throws(map(undefined), err, 'throws with undefined')
   t.throws(map(null), err, 'throws with null')
   t.throws(map(0), err, 'throws with falsey number')
@@ -220,7 +220,7 @@ test('Writer map errors', t => {
 test('Writer map fantasy-land errors', t => {
   const map = bindFunc(Writer(Last(0), 0)[fl.map])
 
-  const err = /^TypeError: Writer.fantasy-land\/map: Function required/
+  const err = /^TypeError: Writer\(Last\).fantasy-land\/map: Function required/
   t.throws(map(undefined), err, 'throws with undefined')
   t.throws(map(null), err, 'throws with null')
   t.throws(map(0), err, 'throws with falsey number')
@@ -278,7 +278,7 @@ test('Writer ap errors', t => {
     x => Writer(Last(0), x).ap(Writer(Last(0), 0))
   )
 
-  const noFunc = /^TypeError: Writer.ap: Wrapped value must be a function/
+  const noFunc = /^TypeError: Writer\(Last\).ap: Wrapped value must be a function/
   t.throws(wrapAp(undefined), noFunc, 'throws when wrapped value is undefined')
   t.throws(wrapAp(null), noFunc, 'throws when wrapped value is null')
   t.throws(wrapAp(0), noFunc, 'throws when wrapped value is a falsey number')
@@ -290,7 +290,7 @@ test('Writer ap errors', t => {
   t.throws(wrapAp([]), noFunc, 'throws when wrapped value is an array')
   t.throws(wrapAp({}), noFunc, 'throws when wrapped value is an object')
 
-  const err = /^TypeError: Writer.ap: Writer required/
+  const err = /^TypeError: Writer\(Last\).ap: Writer required/
   t.throws(ap(undefined), err, 'throws with undefined')
   t.throws(ap(null), err, 'throws with null')
   t.throws(ap(0), err, 'throws with falsey number')
@@ -370,7 +370,7 @@ test('Writer chain errors', t => {
   const chain = bindFunc(m.chain)
   const fn = x => Writer(Last(0), x)
 
-  const err = /^TypeError: Writer.chain: Function required/
+  const err = /^TypeError: Writer\(Last\).chain: Function required/
   t.throws(chain(undefined), err, 'throws with undefined')
   t.throws(chain(null), err, 'throws with null')
   t.throws(chain(0), err, 'throws with falsey number')
@@ -382,7 +382,7 @@ test('Writer chain errors', t => {
   t.throws(chain([]), err, 'throws with an array')
   t.throws(chain({}), err, 'throws with an object')
 
-  const noWriter = /^TypeError: Writer.chain: Function must return a Writer/
+  const noWriter = /^TypeError: Writer\(Last\).chain: Function must return a Writer/
   t.throws(chain(unit), noWriter, 'throws with non-Writer returning function')
 
   t.doesNotThrow(chain(fn), 'allows a Writer returning function')
@@ -395,7 +395,7 @@ test('Writer chain fantasy-land errors', t => {
   const chain = bindFunc(m[fl.chain])
   const fn = x => Writer(Last(0), x)
 
-  const err = /^TypeError: Writer.fantasy-land\/chain: Function required/
+  const err = /^TypeError: Writer\(Last\).fantasy-land\/chain: Function required/
   t.throws(chain(undefined), err, 'throws with undefined')
   t.throws(chain(null), err, 'throws with null')
   t.throws(chain(0), err, 'throws with falsey number')
@@ -407,7 +407,7 @@ test('Writer chain fantasy-land errors', t => {
   t.throws(chain([]), err, 'throws with an array')
   t.throws(chain({}), err, 'throws with an object')
 
-  const noWriter = /^TypeError: Writer.fantasy-land\/chain: Function must return a Writer/
+  const noWriter = /^TypeError: Writer\(Last\).fantasy-land\/chain: Function must return a Writer/
   t.throws(chain(unit), noWriter, 'throws with non-Writer returning function')
 
   t.doesNotThrow(chain(fn), 'allows a Writer returning function')

--- a/src/Writer/Writer.spec.js
+++ b/src/Writer/Writer.spec.js
@@ -62,7 +62,7 @@ test('Writer', t => {
   t.throws(f(), err, 'throws with no parameters')
   t.throws(f(0), err, 'throws with one parameter')
 
-  const entryErr = /^TypeError: Writer\(Last\): Log enrty must be an instance of Last/
+  const entryErr = /^TypeError: Writer\(Last\): Log entry must be an instance of Last/
   t.throws(f(undefined, 0), entryErr, 'throws with undefined entry')
   t.throws(f(null, 0), entryErr, 'throws with null entry')
   t.throws(f(0, 0), entryErr, 'throws with falsy number entry')

--- a/src/Writer/Writer.spec.js
+++ b/src/Writer/Writer.spec.js
@@ -27,7 +27,7 @@ const Writer = _Writer(Last)
 test('Writer construction', t => {
   const w = bindFunc(_Writer)
 
-  const err = /Writer: Monoid required for construction/
+  const err = /^TypeError: Writer: Argument must be a Monoid Constructor/
   t.throws(w(undefined), err, 'throws with undefined')
   t.throws(w(null), err, 'throws with null')
   t.throws(w(0), err, 'throws with falsey number')
@@ -46,27 +46,39 @@ test('Writer construction', t => {
 })
 
 test('Writer', t => {
-  const w = Writer(0, 0)
+  const w = Writer(Last(0), 0)
   const f = bindFunc(Writer)
 
   t.ok(isFunction(Writer), 'is a function')
   t.ok(isObject(w), 'returns an object')
 
-  t.equals(Writer(0, 0).constructor, Writer, 'provides TypeRep on constructor')
+  t.equals(Writer(Last(0), 0).constructor, Writer, 'provides TypeRep on constructor')
 
   t.ok(isFunction(Writer.of), 'provides an of function')
   t.ok(isFunction(Writer.type), 'provides a type function')
   t.ok(isString(Writer['@@type']), 'provides a @@type string')
 
-  const err = /Writer: Log entry and a value required/
+  const err = /^TypeError: Writer: Must be contructed with both a log entry and a value/
   t.throws(f(), err, 'throws with no parameters')
   t.throws(f(0), err, 'throws with one parameter')
+
+  const entryErr = /^TypeError: Writer: Log enrty must be an instance of Last/
+  t.throws(f(undefined, 0), entryErr, 'throws with undefined entry')
+  t.throws(f(null, 0), entryErr, 'throws with null entry')
+  t.throws(f(0, 0), entryErr, 'throws with falsy number entry')
+  t.throws(f(1, 0), entryErr, 'throws with truthy number entry')
+  t.throws(f('', 0), entryErr, 'throws with falsy string entry')
+  t.throws(f('string', 0), entryErr, 'throws with truthy string entry')
+  t.throws(f(false, 0), entryErr, 'throws with false entry')
+  t.throws(f(true, 0), entryErr, 'throws with true entry')
+  t.throws(f([], 0), entryErr, 'throws with array entry')
+  t.throws(f({}, 0), entryErr, 'throws with object entry')
 
   t.end()
 })
 
 test('Writer fantasy-land api', t => {
-  const m = Writer(0, 0)
+  const m = Writer(Last(0), 0)
 
   t.ok(isFunction(Writer[fl.of]), 'provides of function on constructor')
 
@@ -91,7 +103,7 @@ test('Writer @@implements', t => {
 })
 
 test('Writer inspect', t => {
-  const m = Writer(0, 0)
+  const m = Writer(Last(0), 0)
 
   t.ok(isFunction(m.inspect), 'provides an inspect function')
   t.equal(m.inspect, m.toString, 'toString is the same function as inspect')
@@ -101,20 +113,20 @@ test('Writer inspect', t => {
 })
 
 test('Writer type', t => {
-  const m = Writer(0, 0)
+  const m = Writer(Last(0), 0)
 
   t.ok(isFunction(m.type), 'is a function')
   t.equal(Writer.type, m.type, 'static and instance versions are the same')
-  t.equal(m.type(), 'Writer( Last )', 'returns Writer with Monoid Type')
+  t.equal(m.type(), 'Writer(Last)', 'returns Writer with Monoid Type')
 
   t.end()
 })
 
 test('Writer @@type', t => {
-  const m = Writer(0, 0)
+  const m = Writer(Last(0), 0)
 
   t.equal(Writer['@@type'], m['@@type'], 'static and instance versions are the same')
-  t.equal(m['@@type'], 'crocks/Writer@2( crocks/Last@1 )', 'returns crocks/Writer@2 with Monoid Type')
+  t.equal(m['@@type'], 'crocks/Writer@3( crocks/Last@1 )', 'returns crocks/Writer@3 with Monoid Type')
 
   t.end()
 })
@@ -122,7 +134,7 @@ test('Writer @@type', t => {
 test('Writer read', t => {
   const x = 'some value'
   const l = 'some log'
-  const m = Writer(l, x)
+  const m = Writer(Last(l), x)
 
   t.ok(isFunction(m.read), 'is a function')
   t.ok(isSameType(Pair, m.read()), 'returns a Pair')
@@ -135,7 +147,7 @@ test('Writer read', t => {
 
 test('Writer valueOf', t => {
   const x = 34
-  const w = Writer(0, x)
+  const w = Writer(Last(0), x)
 
   t.ok(isFunction(w.valueOf), 'is a function')
   t.equal(w.valueOf(), x, 'provides wrapped value')
@@ -145,7 +157,7 @@ test('Writer valueOf', t => {
 
 test('Writer log', t => {
   const x = 'log entry'
-  const w = Writer(x, 0)
+  const w = Writer(Last(x), 0)
 
   t.ok(isFunction(w.log), 'is a function')
   t.equal(w.log().type(), 'Last', 'returns a monoid')
@@ -155,9 +167,9 @@ test('Writer log', t => {
 })
 
 test('Writer equals functionality', t => {
-  const a = Writer(23, 0)
-  const b = Writer(15, 0)
-  const c = Writer(23, 1)
+  const a = Writer(Last(23), 0)
+  const b = Writer(Last(15), 0)
+  const c = Writer(Last(23), 1)
 
   const value = 0
   const nonWriter = { type: 'Writer...Not' }
@@ -171,10 +183,10 @@ test('Writer equals functionality', t => {
 })
 
 test('Writer equals properties (Setoid)', t => {
-  const a = Writer('seg', 0)
-  const b = Writer(false, 0)
-  const c = Writer(null, 1)
-  const d = Writer(3, 0)
+  const a = Writer(Last('seg'), 0)
+  const b = Writer(Last(false), 0)
+  const c = Writer(Last(null), 1)
+  const d = Writer(Last(3), 0)
 
   t.ok(isFunction(a.equals), 'provides an equals function')
   t.equals(a.equals(a), true, 'reflexivity')
@@ -186,9 +198,9 @@ test('Writer equals properties (Setoid)', t => {
 })
 
 test('Writer map errors', t => {
-  const map = bindFunc(Writer(0, 0).map)
+  const map = bindFunc(Writer(Last(0), 0).map)
 
-  const err = /Writer.map: Function required/
+  const err = /^TypeError: Writer.map: Function required/
   t.throws(map(undefined), err, 'throws with undefined')
   t.throws(map(null), err, 'throws with null')
   t.throws(map(0), err, 'throws with falsey number')
@@ -206,9 +218,9 @@ test('Writer map errors', t => {
 })
 
 test('Writer map fantasy-land errors', t => {
-  const map = bindFunc(Writer(0, 0)[fl.map])
+  const map = bindFunc(Writer(Last(0), 0)[fl.map])
 
-  const err = /Writer.fantasy-land\/map: Function required/
+  const err = /^TypeError: Writer.fantasy-land\/map: Function required/
   t.throws(map(undefined), err, 'throws with undefined')
   t.throws(map(null), err, 'throws with null')
   t.throws(map(0), err, 'throws with falsey number')
@@ -230,9 +242,9 @@ test('Writer map functionality', t => {
   const x = 42
   const l = 'log'
 
-  const m = Writer(l, x).map(spy)
+  const m = Writer(Last(l), x).map(spy)
 
-  t.equal(m.type(), 'Writer( Last )', 'returns a Writer')
+  t.ok(isSameType(Writer, m), 'returns a Writer')
   t.equal(spy.called, true, 'calls mapping function')
   t.equal(m.valueOf(), x, 'returns the result of the map inside of new Writer, on value key')
   t.same(m.log().valueOf(), l, 'returns the result of the map inside of new Writer, on log key')
@@ -243,7 +255,7 @@ test('Writer map functionality', t => {
 })
 
 test('Writer map properties (Functor)', t => {
-  const m = Writer('blop', 49)
+  const m = Writer(Last('blop'), 49)
 
   const f = x => x + 54
   const g = x => x * 4
@@ -260,13 +272,13 @@ test('Writer ap errors', t => {
   const m = { type: () => 'Writer...Not' }
 
   const ap =
-    bindFunc(Writer(0, unit).ap)
+    bindFunc(Writer(Last(0), unit).ap)
 
   const wrapAp = bindFunc(
-    x => Writer(0, x).ap(Writer(0, 0))
+    x => Writer(Last(0), x).ap(Writer(Last(0), 0))
   )
 
-  const noFunc = /Writer.ap: Wrapped value must be a function/
+  const noFunc = /^TypeError: Writer.ap: Wrapped value must be a function/
   t.throws(wrapAp(undefined), noFunc, 'throws when wrapped value is undefined')
   t.throws(wrapAp(null), noFunc, 'throws when wrapped value is null')
   t.throws(wrapAp(0), noFunc, 'throws when wrapped value is a falsey number')
@@ -278,7 +290,7 @@ test('Writer ap errors', t => {
   t.throws(wrapAp([]), noFunc, 'throws when wrapped value is an array')
   t.throws(wrapAp({}), noFunc, 'throws when wrapped value is an object')
 
-  const err = /Writer.ap: Writer required/
+  const err = /^TypeError: Writer.ap: Writer required/
   t.throws(ap(undefined), err, 'throws with undefined')
   t.throws(ap(null), err, 'throws with null')
   t.throws(ap(0), err, 'throws with falsey number')
@@ -291,13 +303,13 @@ test('Writer ap errors', t => {
   t.throws(ap({}), err, 'throws with an object')
   t.throws(ap(m), err, 'throws with Non-Writer')
 
-  t.doesNotThrow(ap(Writer(0, 0)), 'allows a Writer')
+  t.doesNotThrow(ap(Writer(Last(0), 0)), 'allows a Writer')
 
   t.end()
 })
 
 test('Writer ap properties (Apply)', t => {
-  const m = Writer(0, identity)
+  const m = Writer(Last(0), identity)
 
   const a = m.map(compose).ap(m).ap(m)
   const b = m.ap(m.ap(m))
@@ -305,14 +317,18 @@ test('Writer ap properties (Apply)', t => {
   t.ok(isFunction(m.map), 'implements the Functor spec')
   t.ok(isFunction(m.ap), 'provides an ap function')
 
-  t.equal(a.ap(Writer(0, 3)).valueOf(), b.ap(Writer(0, 3)).valueOf(), 'composition')
+  t.equal(
+    a.ap(Writer(Last(0), 3)).valueOf(),
+    b.ap(Writer(Last(0), 3)).valueOf(),
+    'composition'
+  )
 
   t.end()
 })
 
 test('Writer ap functionality', t => {
-  const a = Writer(0, x => x + 2)
-  const b = Writer(1, 27)
+  const a = Writer(Last(0), x => x + 2)
+  const b = Writer(Last(1), 27)
 
   t.same(a.ap(b).log().valueOf(), 1, 'concats applied Writers log to inital log')
   t.equal(a.ap(b).valueOf(), 29, 'applys applied value to function')
@@ -323,9 +339,9 @@ test('Writer ap functionality', t => {
 test('Writer of', t => {
   const w = Writer.of(0)
 
-  t.equal(Writer.of, Writer(0, 0).of, 'Writer.of is the same as the instance version')
+  t.equal(Writer.of, Writer(Last(0), 0).of, 'Writer.of is the same as the instance version')
 
-  t.equal(w.type(), 'Writer( Last )', 'returns an Writer')
+  t.ok(isSameType(Writer, w), 'returns a Writer')
   t.equal(w.valueOf(), 0, 'wraps the value passed into a Writer')
   t.same(w.log().valueOf(), Last.empty().valueOf(), 'provides an empty Monoid as the log')
 
@@ -333,12 +349,12 @@ test('Writer of', t => {
 })
 
 test('Writer of properties (Applicative)', t => {
-  const m = Writer(0, identity)
+  const m = Writer(Last(0), identity)
 
   t.ok(isFunction(m.of), 'provides an of function')
   t.ok(isFunction(m.ap), 'implements the Apply spec')
 
-  t.equal(m.ap(Writer(0, 3)).valueOf(), 3, 'identity')
+  t.equal(m.ap(Writer(Last(0), 3)).valueOf(), 3, 'identity')
   t.equal(m.ap(Writer.of(3)).valueOf(), Writer.of(identity(3)).valueOf(), 'homomorphism')
 
   const a = x => m.ap(Writer.of(x))
@@ -350,11 +366,11 @@ test('Writer of properties (Applicative)', t => {
 })
 
 test('Writer chain errors', t => {
-  const m = Writer(0, 0)
+  const m = Writer(Last(0), 0)
   const chain = bindFunc(m.chain)
-  const fn = x => Writer(0, x)
+  const fn = x => Writer(Last(0), x)
 
-  const err = /Writer.chain: Function required/
+  const err = /^TypeError: Writer.chain: Function required/
   t.throws(chain(undefined), err, 'throws with undefined')
   t.throws(chain(null), err, 'throws with null')
   t.throws(chain(0), err, 'throws with falsey number')
@@ -366,7 +382,7 @@ test('Writer chain errors', t => {
   t.throws(chain([]), err, 'throws with an array')
   t.throws(chain({}), err, 'throws with an object')
 
-  const noWriter = /Writer.chain: Function must return a Writer/
+  const noWriter = /^TypeError: Writer.chain: Function must return a Writer/
   t.throws(chain(unit), noWriter, 'throws with non-Writer returning function')
 
   t.doesNotThrow(chain(fn), 'allows a Writer returning function')
@@ -375,11 +391,11 @@ test('Writer chain errors', t => {
 })
 
 test('Writer chain fantasy-land errors', t => {
-  const m = Writer(0, 0)
+  const m = Writer(Last(0), 0)
   const chain = bindFunc(m[fl.chain])
-  const fn = x => Writer(0, x)
+  const fn = x => Writer(Last(0), x)
 
-  const err = /Writer.fantasy-land\/chain: Function required/
+  const err = /^TypeError: Writer.fantasy-land\/chain: Function required/
   t.throws(chain(undefined), err, 'throws with undefined')
   t.throws(chain(null), err, 'throws with null')
   t.throws(chain(0), err, 'throws with falsey number')
@@ -391,7 +407,7 @@ test('Writer chain fantasy-land errors', t => {
   t.throws(chain([]), err, 'throws with an array')
   t.throws(chain({}), err, 'throws with an object')
 
-  const noWriter = /Writer.fantasy-land\/chain: Function must return a Writer/
+  const noWriter = /^TypeError: Writer.fantasy-land\/chain: Function must return a Writer/
   t.throws(chain(unit), noWriter, 'throws with non-Writer returning function')
 
   t.doesNotThrow(chain(fn), 'allows a Writer returning function')
@@ -400,8 +416,8 @@ test('Writer chain fantasy-land errors', t => {
 })
 
 test('Writer chain functionality', t => {
-  const m = Writer(0, 45)
-  const fn = x => Writer(1, x + 2)
+  const m = Writer(Last(0), 45)
+  const fn = x => Writer(Last(1), x + 2)
 
   t.same(m.chain(fn).log().valueOf(), 1, 'concats chained log to initial log')
   t.equal(m.chain(fn).valueOf(), 47, 'applys function to wrapped value')
@@ -410,14 +426,14 @@ test('Writer chain functionality', t => {
 })
 
 test('Writer chain properties (Chain)', t => {
-  t.ok(isFunction(Writer(0, 0).chain), 'provides a chain function')
-  t.ok(isFunction(Writer(0, 0).ap), 'implements the Apply spec')
+  t.ok(isFunction(Writer(Last(0), 0).chain), 'provides a chain function')
+  t.ok(isFunction(Writer(Last(0), 0).ap), 'implements the Apply spec')
 
-  const f = x => Writer(1, x + 2)
-  const g = x => Writer(2, x + 10)
+  const f = x => Writer(Last(1), x + 2)
+  const g = x => Writer(Last(2), x + 10)
 
-  const a = x => Writer(0, x).chain(f).chain(g)
-  const b = x => Writer(0, x).chain(y => f(y).chain(g))
+  const a = x => Writer(Last(0), x).chain(f).chain(g)
+  const b = x => Writer(Last(0), x).chain(y => f(y).chain(g))
 
   t.equal(a(10).valueOf(), b(10).valueOf(), 'assosiativity')
 
@@ -425,10 +441,10 @@ test('Writer chain properties (Chain)', t => {
 })
 
 test('Writer chain properties (Monad)', t => {
-  t.ok(isFunction(Writer(1, 0).chain), 'implements the Chain spec')
-  t.ok(isFunction(Writer(2, 0).of), 'implements the Applicative spec')
+  t.ok(isFunction(Writer(Last(1), 0).chain), 'implements the Chain spec')
+  t.ok(isFunction(Writer(Last(2), 0).of), 'implements the Applicative spec')
 
-  const f = x => Writer(0, x)
+  const f = x => Writer(Last(0), x)
 
   t.equal(Writer.of(3).chain(f).valueOf(), f(3).valueOf(), 'left identity')
   t.equal(f(3).chain(Writer.of).valueOf(), f(3).valueOf(), 'right identity')

--- a/src/Writer/index.js
+++ b/src/Writer/index.js
@@ -38,7 +38,7 @@ function _Writer(Monoid) {
     }
 
     if(!isSameType(Monoid, entry)) {
-      throw new TypeError(`${_type()}: Log enrty must be an instance of ${Monoid.type()}`)
+      throw new TypeError(`${_type()}: Log entry must be an instance of ${Monoid.type()}`)
     }
 
     const type =

--- a/src/Writer/index.js
+++ b/src/Writer/index.js
@@ -34,11 +34,11 @@ function _Writer(Monoid) {
 
   function Writer(entry, val) {
     if(arguments.length !== 2) {
-      throw new TypeError('Writer: Must be contructed with both a log entry and a value')
+      throw new TypeError(`${_type()}: Must be contructed with both a log entry and a value`)
     }
 
     if(!isSameType(Monoid, entry)) {
-      throw new TypeError(`Writer: Log enrty must be an instance of ${Monoid.type()}`)
+      throw new TypeError(`${_type()}: Log enrty must be an instance of ${Monoid.type()}`)
     }
 
     const type =
@@ -66,7 +66,7 @@ function _Writer(Monoid) {
     function map(method) {
       return function(fn) {
         if(!isFunction(fn)) {
-          throw new TypeError(`Writer.${method}: Function required`)
+          throw new TypeError(`${_type()}.${method}: Function required`)
         }
 
         return Writer(log(), fn(valueOf()))
@@ -75,11 +75,11 @@ function _Writer(Monoid) {
 
     function ap(m) {
       if(!isFunction(val)) {
-        throw new TypeError('Writer.ap: Wrapped value must be a function')
+        throw new TypeError(`${_type()}.ap: Wrapped value must be a function`)
       }
 
       if(!isSameType(Writer, m)) {
-        throw new TypeError('Writer.ap: Writer required')
+        throw new TypeError(`${_type()}.ap: Writer required`)
       }
 
       return Writer(
@@ -91,13 +91,13 @@ function _Writer(Monoid) {
     function chain(method) {
       return function(fn) {
         if(!isFunction(fn)) {
-          throw new TypeError(`Writer.${method}: Function required`)
+          throw new TypeError(`${_type()}.${method}: Function required`)
         }
 
         const w = fn(valueOf())
 
         if(!isSameType(Writer, w)) {
-          throw new TypeError(`Writer.${method}: Function must return a Writer`)
+          throw new TypeError(`${_type()}.${method}: Function must return a Writer`)
         }
 
         return Writer(log().concat(w.log()), w.valueOf())

--- a/src/Writer/index.js
+++ b/src/Writer/index.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const VERSION = 2
+const VERSION = 3
 
 const _equals = require('../core/equals')
 const _implements = require('../core/implements')
@@ -20,21 +20,25 @@ const constant = x => () => x
 
 function _Writer(Monoid) {
   if(!isMonoid(Monoid)) {
-    throw new TypeError('Writer: Monoid required for construction')
+    throw new TypeError('Writer: Argument must be a Monoid Constructor')
   }
 
-  const _of =
-    x => Writer(Monoid.empty().valueOf(), x)
+  const _of = x =>
+    Writer(Monoid.empty(), x)
 
   const _type =
-    constant(`${__type}( ${Monoid.type()} )`)
+    constant(`${__type}(${Monoid.type()})`)
 
   const typeString =
     `${_typeString}( ${Monoid['@@type']} )`
 
   function Writer(entry, val) {
     if(arguments.length !== 2) {
-      throw new TypeError('Writer: Log entry and a value required')
+      throw new TypeError('Writer: Must be contructed with both a log entry and a value')
+    }
+
+    if(!isSameType(Monoid, entry)) {
+      throw new TypeError(`Writer: Log enrty must be an instance of ${Monoid.type()}`)
     }
 
     const type =
@@ -50,8 +54,8 @@ function _Writer(Monoid) {
     const valueOf =
       constant(val)
 
-    const log =
-      constant(Monoid(entry))
+    const log = () =>
+      entry
 
     const inspect =
       constant(`Writer(${_inspect(log())}${_inspect(valueOf())} )`)
@@ -65,7 +69,7 @@ function _Writer(Monoid) {
           throw new TypeError(`Writer.${method}: Function required`)
         }
 
-        return Writer(log().valueOf(), fn(valueOf()))
+        return Writer(log(), fn(valueOf()))
       }
     }
 
@@ -79,7 +83,7 @@ function _Writer(Monoid) {
       }
 
       return Writer(
-        log().concat(m.log()).valueOf(),
+        log().concat(m.log()),
         val(m.valueOf())
       )
     }
@@ -96,7 +100,7 @@ function _Writer(Monoid) {
           throw new TypeError(`Writer.${method}: Function must return a Writer`)
         }
 
-        return Writer(log().concat(w.log()).valueOf(), w.valueOf())
+        return Writer(log().concat(w.log()), w.valueOf())
       }
     }
 


### PR DESCRIPTION
## Captains Log
![image](https://user-images.githubusercontent.com/3665793/61604688-6158eb80-abf7-11e9-9d41-51b3aa14bc58.png)

This PR is a direct answer to implementing the breaking change as defined in [this issue][issue]. Before this change we provided the value to be wrapped in the `Monoid` and the `Writer` would wrap it for us. This created issues when dealing with empty values on types like `Array` or other structure-ish type Monoids.

Going forward, each log entry will now have to provide an instance of the `Monoid`

```js
const MaxWriter =
  Writer(Max)

const oldWay =
  MaxWriter(34, 'string')

const newWay =
  MaxWriter(Max(34), 'string')
```

[issue]: https://github.com/evilsoft/crocks/issues/201