### PR TITLE
Add `bichain` to remaining Sum Types

### DIFF
--- a/docs/src/pages/docs/crocks/Async.md
+++ b/docs/src/pages/docs/crocks/Async.md
@@ -18,8 +18,8 @@ that can be composed together.
 
 Depending on your needs, an `Async` can be constructed in a variety of ways. The
 typical closely resembles how a `Promise` is constructed with one major
-difference, the arguments used in the function that is passed to 
-the `Promise` constructor are reversed in an `Async` to match the order in 
+difference, the arguments used in the function that is passed to
+the `Promise` constructor are reversed in an `Async` to match the order in
 which `Async` is parameterized.
 
 There are many ways to represent asynchronous operations in JavaScript, and as
@@ -973,13 +973,13 @@ Async e a ~> ((e -> Async b c), (a -> Async b c)) -> Async b c
 ```
 
 Combining a sequential series of transformations that capture disjunction can be
-accomplished with `chain`. Along the same lines, `bichain` allows you to do this
-from both [`Rejected`](#rejected) and [`Resolved`](#resolved). `bichain` expects
-two unary, `Async` returning functions as its arguments. When invoked on 
-a [`Rejected`](#rejected) instance, `bichain` will use
-the [`Rejected`](#rejected) value and can return either a [`Rejected`](#rejected) or
-a [`Resolved`](#resolved). When called on a [`Resolved`](#resolved) instance, it
-will behave exactly as [`chain`](#chain) would.
+accomplished with [`chain`](#chain). Along the same lines, `bichain` allows you
+to do this from both [`Rejected`](#rejected) and [`Resolved`](#resolved). `bichain` expects
+two unary, `Async` returning functions as its arguments. When invoked on
+a [`Rejected`](#rejected) instance, `bichain` will use the left, or first, function
+that can return either a [`Rejected`](#rejected) or [`Resolved`](#resolved) instance.
+When called on a [`Resolved`](#resolved) instance, it will behave exactly
+as [`chain`](#chain) would with the right, or second function.
 
 <!-- eslint-disable no-console -->
 <!-- eslint-disable no-sequences -->
@@ -1139,10 +1139,10 @@ typeIso(Rejected('aaaaa'))
 Async e a ~> Async e a -> Async e a
 ```
 
-Used to provide the first settled result between two `Async`s. Just 
-pass `race` another `Async` and it will return new `Async`, that when forked, 
+Used to provide the first settled result between two `Async`s. Just
+pass `race` another `Async` and it will return new `Async`, that when forked,
 will run both `Async`s in parallel, returning the first of the two to settle.
-The result can either be rejected or resolved, based on the instance of the 
+The result can either be rejected or resolved, based on the instance of the
 first settled result.
 
 <!-- eslint-disable no-console -->

--- a/docs/src/pages/docs/crocks/Either.md
+++ b/docs/src/pages/docs/crocks/Either.md
@@ -940,6 +940,25 @@ incValue({ a: 44 })
 //=> Right { a: 44, value: 1 }
 ```
 
+#### bichain
+
+```haskell
+Either c a ~> ((c -> Either d b), (a -> Either d b)) -> Either d b
+```
+
+Combining a sequential series of transformations that capture disjunction can be
+accomplished with [`chain`](#chain). Along the same lines, `bichain` allows you
+to do this from both [`Left`](#left) and [`Right`](#right). `bichain` expects
+two unary, `Either` returning functions as its arguments. When invoked on
+a [`Left`](#left) instance, `bichain` will use
+the left, or first, function that can return either a [`Left`](#left) or
+a [`Right`](#right) instance. When called on a [`Right`](#right) instance, it
+will behave exactly as [`chain`](#chain) would with the right, or
+second, function.
+
+```javascript
+```
+
 #### swap
 
 ```haskell

--- a/docs/src/pages/docs/crocks/Either.md
+++ b/docs/src/pages/docs/crocks/Either.md
@@ -957,6 +957,60 @@ will behave exactly as [`chain`](#chain) would with the right, or
 second, function.
 
 ```javascript
+import Either from 'crocks/Either'
+
+import bichain from 'crocks/pointfree/bichain'
+import compose from 'crocks/helpers/compose'
+import ifElse from 'crocks/logic/ifElse'
+import isNumber from 'crocks/predicates/isNumber'
+import isString from 'crocks/predicates/isString'
+import map from 'crocks/pointfree/map'
+
+const { Left, Right } = Either
+
+// swapEither :: Either a b -> Either b a
+const swapEither =
+  bichain(Right, Left)
+
+swapEither(Left('left'))
+//=> Right "left"
+
+swapEither(Right('right'))
+//=> Left "right"
+
+// length :: String -> Number
+const length = x =>
+  x.length
+
+// add10 :: Number -> Number
+const add10 = x =>
+  x + 10
+
+// safe :: (a -> Boolean) -> a -> Either c b
+const safe = pred =>
+  ifElse(pred, Right, Left)
+
+// stringLength :: a -> Either e Number
+const stringLength = compose(
+  map(length),
+  safe(isString)
+)
+
+// nested :: a -> Either c Number
+const nested = compose(
+  map(add10),
+  bichain(stringLength, Right),
+  safe(isNumber)
+)
+
+nested('cool')
+//=> Right 14
+
+nested(true)
+//=> Left true
+
+nested(13)
+//=> Right 23
 ```
 
 #### swap

--- a/docs/src/pages/docs/crocks/Maybe.md
+++ b/docs/src/pages/docs/crocks/Maybe.md
@@ -568,7 +568,7 @@ Maybe (a -> b) ~> Maybe a -> Maybe b
 ```
 
 Short for apply, `ap` is used to apply a `Maybe` instance containing a value
-to another `Maybe` instance that contains a function, resulting in 
+to another `Maybe` instance that contains a function, resulting in
 new `Maybe` instance with the result. `ap` requires that it is called on
 an `instance` that is either a `Nothing` or a `Just` that wraps a curried
 polyadic function.
@@ -872,6 +872,25 @@ shoutValue({ value: 49 })
 
 shoutValue({})
 //=> Just { shout: '' }
+```
+
+#### bichain
+
+```haskell
+Maybe a ~> ((() -> Maybe b), (a -> Maybe b)) -> Maybe b
+```
+
+Combining a sequential series of transformations that capture disjunction can be
+accomplished with [`chain`](#chain). Along the same lines, `bichain` allows you
+to do this from both [`Nothing`](#nothing) and [`Just`](#just). `bichain` expects
+two unary, `Either` returning functions as its arguments. When invoked on
+a [`Nothing`](#nothing) instance, `bichain` will use
+the left, or first, function that can return either a [`Nothing`](#nothing) or
+a [`Just`](#just) instance. When called on a [`Just`](#just) instance, it
+will behave exactly as [`chain`](#chain) would with the right, or
+second, function.
+
+```javascript
 ```
 
 #### option

--- a/docs/src/pages/docs/crocks/Maybe.md
+++ b/docs/src/pages/docs/crocks/Maybe.md
@@ -891,6 +891,24 @@ will behave exactly as [`chain`](#chain) would with the right, or
 second, function.
 
 ```javascript
+import Maybe from 'crocks/Maybe'
+
+import bichain from 'crocks/pointfree/bichain'
+import constant from 'crocks/combinators/constant'
+
+const { Nothing, Just } = Maybe
+
+// swapMaybe :: Maybe a -> Maybe b
+const swapMaybe = bichain(
+  constant(Just('nothing')),
+  Nothing
+)
+
+swapMaybe(Nothing())
+//=> Just Nothing
+
+swapMaybe(Just('just'))
+//=> Nothing
 ```
 
 #### option

--- a/docs/src/pages/docs/crocks/Result.md
+++ b/docs/src/pages/docs/crocks/Result.md
@@ -1054,6 +1054,25 @@ getDetails(false)
 //=> Ok { canDrink: false, age: 0 }
 ```
 
+#### bichain
+
+```haskell
+Result c a ~> ((c -> Result d b), (a -> Result d b)) -> Result d b
+```
+
+Combining a sequential series of transformations that capture disjunction can be
+accomplished with [`chain`](#chain). Along the same lines, `bichain` allows you
+to do this from both [`Err`](#err) and [`Ok`](#ok). `bichain` expects
+two unary, `Either` returning functions as its arguments. When invoked on
+an [`Err`](#err) instance, `bichain` will use
+the left, or first, function that can return either an [`Err`](#err) or
+an [`Ok`](#ok) instance. When called on an [`Ok`](#ok) instance, it
+will behave exactly as [`chain`](#chain) would with the right, or
+second, function.
+
+```javascript
+```
+
 #### swap
 
 ```haskell

--- a/docs/src/pages/docs/crocks/Result.md
+++ b/docs/src/pages/docs/crocks/Result.md
@@ -1071,6 +1071,95 @@ will behave exactly as [`chain`](#chain) would with the right, or
 second, function.
 
 ```javascript
+import Result from 'crocks/Result'
+
+import bichain from 'crocks/pointfree/bichain'
+import compose from 'crocks/helpers/compose'
+import composeK from 'crocks/helpers/composeK'
+import constant from 'crocks/combinators/constant'
+import equals from 'crocks/pointfree/equals'
+import getProp from 'crocks/Maybe/getProp'
+import isNumber from 'crocks/predicates/isNumber'
+import map from 'crocks/pointfree/map'
+import maybeToResult from 'crocks/Result/maybeToResult'
+import objOf from 'crocks/helpers/objOf'
+import safe from 'crocks/Maybe/safe'
+import substitution from 'crocks/combinators/substitution'
+import tryCatch from 'crocks/Result/tryCatch'
+
+const { Err, Ok } = Result
+
+// swapResult :: Result e a -> Result a e
+const swapResult =
+  bichain(Ok, Err)
+
+swapResult(Err('err'))
+//=> Ok "err"
+
+swapResult(Ok('ok'))
+//=> Err "ok"
+
+// Wrapped :: { value: Number }
+// wrapEven :: Number -> Wrapped
+function wrapEven(num) {
+  if(!isNumber(num)) {
+    throw new TypeError('wrapEven: Must be a Number')
+  }
+
+  if(num % 2) {
+    throw new Error('wrapEven: Nunber must be even')
+  }
+
+  return { value: num }
+}
+
+// increment :: Number -> Number
+const increment = x =>
+  x + 1
+
+const checkEvenError = composeK(
+  safe(equals('wrapEven: Nunber must be even')),
+  getProp('message')
+)
+
+// alwaysWrapInc :: Number -> () -> Wrapped
+const alwaysWrapInc = compose(
+  constant,
+  objOf('value'),
+  increment
+)
+
+// makeWrappedEven :: Number -> Error -> Maybe Wrapped
+const makeWrappedEven = orig => compose(
+  map(alwaysWrapInc(orig)),
+  checkEvenError
+)
+
+// resolveError :: Number -> Error -> Result Error Wrapped
+const resolveError = compose(
+  substitution(maybeToResult),
+  makeWrappedEven
+)
+
+// safeWrapEven :: Number -> Result Error Wrapped
+const safeWrapEven = num =>
+  tryCatch(wrapEven, num)
+    .bichain(resolveError(num), Ok)
+
+safeWrapEven(2)
+//=> Ok { value: 2 }
+
+safeWrapEven(42)
+//=> Ok { value: 42 }
+
+safeWrapEven(23)
+//=> Ok { value: 24 }
+
+safeWrapEven('92')
+//=> Err TypeError: wrapEven: Must be a Number
+
+safeWrapEven(null)
+//=> Err TypeError: wrapEven: Must be a Number
 ```
 
 #### swap

--- a/docs/src/pages/docs/crocks/index.md
+++ b/docs/src/pages/docs/crocks/index.md
@@ -20,17 +20,17 @@ names, but what they do from type to type may vary.
 | [`Arrow`][arrow] | [`id`][arrow-id] | [`both`][arrow-both], [`compose`][arrow-compose], [`contramap`][arrow-contra],[`first`][arrow-first], [`map`][arrow-map], [`promap`][arrow-promap], [`runWith`][arrow-runwith], [`second`][arrow-second] |
 | [`Async`][async] | [`Rejected`][async-rejected], [`Resolved`][async-resolved], [`all`][async-all], [`resolveAfter`][async-resolveAfter], [`rejectAfter`][async-rejectafter], [`fromNode`][async-fromnode], [`fromPromise`][async-frompromise], [`of`][async-of] | [`alt`][async-alt], [`ap`][async-ap], [`bichain`][async-bichain], [`bimap`][async-bimap], [`chain`][async-chain], [`coalesce`][async-coalesce], [`fork`][async-fork], [`map`][async-map], [`of`][async-of], [`race`][async-race], [`swap`][async-swap], [`toPromise`][async-topromise] |
 | [`Const`][const] | [`empty`][const-empty], [`of`][const-of] | [`ap`][const-ap], [`concat`][const-concat], [`empty`][const-empty], [`equals`][const-equals], [`map`][const-map], [`of`][const-of], [`valueOf`][const-valueof] |
-| [`Either`][either] | [`Left`][either-left], [`Right`][either-right], [`of`][either-of]| [`alt`][either-alt], [`ap`][either-ap], [`bimap`][either-bimap], [`chain`][either-chain], [`coalesce`][either-coalesce], [`concat`][either-concat], [`either`][either-either], [`equals`][either-equals], [`map`][either-map], [`of`][either-of], [`sequence`][either-sequence], [`swap`][either-swap], [`traverse`][either-traverse] |
+| [`Either`][either] | [`Left`][either-left], [`Right`][either-right], [`of`][either-of]| [`alt`][either-alt], [`ap`][either-ap], [`bichain`][either-bichain], [`bimap`][either-bimap], [`chain`][either-chain], [`coalesce`][either-coalesce], [`concat`][either-concat], [`either`][either-either], [`equals`][either-equals], [`map`][either-map], [`of`][either-of], [`sequence`][either-sequence], [`swap`][either-swap], [`traverse`][either-traverse] |
 | [`Equiv`][equiv] | [`empty`][equiv-empty] | [`concat`][equiv-concat], [`contramap`][equiv-contra], [`compareWith`][equiv-compare], [`valueOf`][equiv-value] |
 | [`Identity`][identity] | [`of`][identity-of] | [`ap`][identity-ap], [`chain`][identity-chain], [`concat`][identity-concat], [`equals`][identity-equals], [`map`][identity-map], [`of`][identity-of], [`sequence`][identity-sequence], [`traverse`][identity-traverse], [`valueOf`][identity-valueof] |
 | `IO` | `of` | `ap`, `chain`, `map`, `of`, `run` |
 | `List` |  `empty`, `fromArray`, `of` | `ap`, `chain`, `concat`, `cons`, `empty`, `equals`, `filter`, `fold`, `foldMap`, `head`, `init`, `last`, `map`, `of`, `reduce`, `reduceRight`, `reject`, `sequence`, `tail`, `toArray`, `traverse`, `valueOf` |
-| [`Maybe`][maybe] | [`Nothing`][maybe-nothing], [`Just`][maybe-just], [`of`][maybe-of], [`zero`][maybe-zero] | [`alt`][maybe-alt], [`ap`][maybe-ap], [`chain`][maybe-chain], [`coalesce`][maybe-coalesce], [`concat`][maybe-concat], [`equals`][maybe-equals], [`either`][maybe-either], [`map`][maybe-map], [`of`][maybe-of], [`option`][maybe-option], [`sequence`][maybe-sequence], [`traverse`][maybe-traverse], [`zero`][maybe-zero] |
+| [`Maybe`][maybe] | [`Nothing`][maybe-nothing], [`Just`][maybe-just], [`of`][maybe-of], [`zero`][maybe-zero] | [`alt`][maybe-alt], [`ap`][maybe-ap], [`bichain`][maybe-bichain], [`chain`][maybe-chain], [`coalesce`][maybe-coalesce], [`concat`][maybe-concat], [`equals`][maybe-equals], [`either`][maybe-either], [`map`][maybe-map], [`of`][maybe-of], [`option`][maybe-option], [`sequence`][maybe-sequence], [`traverse`][maybe-traverse], [`zero`][maybe-zero] |
 | [`Pair`][pair] | --- | [`ap`][pair-ap], [`bimap`][pair-bimap], [`chain`][pair-chain], [`concat`][pair-concat], [`equals`][pair-equals], [`extend`][pair-extend], [`fst`][pair-fst], [`map`][pair-map], [`merge`][pair-merge], [`sequence`][pair-sequence], [`snd`][pair-snd], [`swap`][pair-swap], [`traverse`][pair-traverse], [`toArray`][pair-toarray] |
 | [`Pred`][pred] * | [`empty`][pred-empty] | [`concat`][pred-concat], [`contramap`][pred-contra], [`runWith`][pred-run], [`valueOf`][pred-value] |
 | [`Reader`][reader] | [`ask`][reader-ask], [`of`][reader-of] | [`ap`][reader-ap], [`chain`][reader-chain], [`map`][reader-map], [`runWith`][reader-run] |
 | [`ReaderT`][readert] | [`ask`][readert-ask], [`lift`][readert-lift], [`liftFn`][readert-liftfn], [`of`][readert-of] | [`ap`][readert-ap], [`chain`][readert-chain], [`map`][readert-map], [`runWith`][readert-run] |
-| [`Result`][result] | [`Err`][result-err], [`Ok`][result-ok], [`of`][result-of]| [`alt`][result-alt], [`ap`][result-ap], [`bimap`][result-bimap], [`chain`][result-chain], [`coalesce`][result-coalesce], [`concat`][result-concat], [`either`][result-either], [`equals`][result-equals], [`map`][result-map], [`of`][result-of], [`sequence`][result-sequence], [`swap`][result-swap], [`traverse`][result-traverse] |
+| [`Result`][result] | [`Err`][result-err], [`Ok`][result-ok], [`of`][result-of]| [`alt`][result-alt], [`ap`][result-ap], [`bichain`][result-bichain], [`bimap`][result-bimap], [`chain`][result-chain], [`coalesce`][result-coalesce], [`concat`][result-concat], [`either`][result-either], [`equals`][result-equals], [`map`][result-map], [`of`][result-of], [`sequence`][result-sequence], [`swap`][result-swap], [`traverse`][result-traverse] |
 | `Star` | `id` | `both`, `compose`, `contramap`, `map`, `promap`, `runWith` |
 | [`State`][state] | [`get`][state-get], [`modify`][state-modify], [`of`][state-of], [`put`][state-put] | [`ap`][state-ap], [`chain`][state-chain], [`evalWith`][state-eval], [`execWith`][state-exec], [`map`][state-map], [`runWith`][state-run] |
 | [`Tuple`][tuple] | --- | [`concat`][tuple-concat], [`equals`][tuple-equals], [`map`][tuple-map], [`mapAll`][tuple-mapall], [`merge`][tuple-merge], [`project`][tuple-project], [`toArray`][tuple-toarray] |
@@ -86,6 +86,7 @@ names, but what they do from type to type may vary.
 [either-of]: Either.html#of
 [either-alt]: Either.html#alt
 [either-ap]: Either.html#ap
+[either-bichain]: Either.html#bichain
 [either-bimap]: Either.html#bimap
 [either-chain]: Either.html#chain
 [either-coalesce]: Either.html#coalesce
@@ -146,6 +147,7 @@ names, but what they do from type to type may vary.
 [maybe-zero]: Maybe.html#zero
 [maybe-alt]: Maybe.html#alt
 [maybe-ap]: Maybe.html#ap
+[maybe-bichain]: Maybe.html#bichain
 [maybe-chain]: Maybe.html#chain
 [maybe-coalesce]: Maybe.html#coalesce
 [maybe-concat]: Maybe.html#concat
@@ -181,6 +183,7 @@ names, but what they do from type to type may vary.
 [result-of]: Result.html#of
 [result-alt]: Result.html#alt
 [result-ap]: Result.html#ap
+[result-bichain]: Result.html#bichain
 [result-bimap]: Result.html#bimap
 [result-chain]: Result.html#chain
 [result-coalesce]: Result.html#coalesce

--- a/docs/src/pages/docs/crocks/index.md
+++ b/docs/src/pages/docs/crocks/index.md
@@ -18,7 +18,7 @@ names, but what they do from type to type may vary.
 | Crock | Constructor | Instance |
 |---|:---|:---|
 | [`Arrow`][arrow] | [`id`][arrow-id] | [`both`][arrow-both], [`compose`][arrow-compose], [`contramap`][arrow-contra],[`first`][arrow-first], [`map`][arrow-map], [`promap`][arrow-promap], [`runWith`][arrow-runwith], [`second`][arrow-second] |
-| [`Async`][async] | [`Rejected`][async-rejected], [`Resolved`][async-resolved], [`all`][async-all], [`resolveAfter`][async-resolveAfter], [`rejectAfter`][async-rejectafter], [`fromNode`][async-fromnode], [`fromPromise`][async-frompromise], [`of`][async-of] | [`alt`][async-alt], [`ap`][async-ap], [`bimap`][async-bimap], [`chain`][async-chain], [`coalesce`][async-coalesce], [`race`][async-race], [`fork`][async-fork], [`map`][async-map], [`of`][async-of], [`swap`][async-swap], [`toPromise`][async-topromise] |
+| [`Async`][async] | [`Rejected`][async-rejected], [`Resolved`][async-resolved], [`all`][async-all], [`resolveAfter`][async-resolveAfter], [`rejectAfter`][async-rejectafter], [`fromNode`][async-fromnode], [`fromPromise`][async-frompromise], [`of`][async-of] | [`alt`][async-alt], [`ap`][async-ap], [`bichain`][async-bichain], [`bimap`][async-bimap], [`chain`][async-chain], [`coalesce`][async-coalesce], [`fork`][async-fork], [`map`][async-map], [`of`][async-of], [`race`][async-race], [`swap`][async-swap], [`toPromise`][async-topromise] |
 | [`Const`][const] | [`empty`][const-empty], [`of`][const-of] | [`ap`][const-ap], [`concat`][const-concat], [`empty`][const-empty], [`equals`][const-equals], [`map`][const-map], [`of`][const-of], [`valueOf`][const-valueof] |
 | [`Either`][either] | [`Left`][either-left], [`Right`][either-right], [`of`][either-of]| [`alt`][either-alt], [`ap`][either-ap], [`bimap`][either-bimap], [`chain`][either-chain], [`coalesce`][either-coalesce], [`concat`][either-concat], [`either`][either-either], [`equals`][either-equals], [`map`][either-map], [`of`][either-of], [`sequence`][either-sequence], [`swap`][either-swap], [`traverse`][either-traverse] |
 | [`Equiv`][equiv] | [`empty`][equiv-empty] | [`concat`][equiv-concat], [`contramap`][equiv-contra], [`compareWith`][equiv-compare], [`valueOf`][equiv-value] |
@@ -64,6 +64,7 @@ names, but what they do from type to type may vary.
 [async-bimap]: Async.html#bimap
 [async-chain]: Async.html#chain
 [async-coalesce]: Async.html#coalesce
+[async-bichain]: Async.html#bichain
 [async-race]: Async.html#race
 [async-fork]: Async.html#fork
 [async-map]: Async.html#map

--- a/docs/src/pages/docs/functions/pointfree-functions.md
+++ b/docs/src/pages/docs/functions/pointfree-functions.md
@@ -2,7 +2,7 @@
 title: "Point-free Functions"
 description: "Point-free Functions API"
 layout: "notopic"
-functions: ["alt", "ap", "bimap", "both", "chain", "coalesce", "comparewith", "concat", "cons", "contramap", "either", "empty", "equals", "extend", "filter", "first", "fold", "foldmap", "head", "init", "last", "map", "merge", "option", "promap", "race", "reduce", "reduceright", "run", "runwith", "second", "sequence", "swap", "tail", "traverse", "valueof"]
+functions: ["alt", "ap", "bichain", "bimap", "both", "chain", "coalesce", "comparewith", "concat", "cons", "contramap", "either", "empty", "equals", "extend", "filter", "first", "fold", "foldmap", "head", "init", "last", "map", "merge", "option", "promap", "race", "reduce", "reduceright", "run", "runwith", "second", "sequence", "swap", "tail", "traverse", "valueof"]
 weight: 50
 ---
 
@@ -69,6 +69,7 @@ accepted Datatype):
 |---|:---|:---|
 | `alt` | `m a -> m a -> m a` | `crocks/pointfree` |
 | `ap` | `m a -> m (a -> b) -> m b` | `crocks/pointfree` |
+| `bichain` | `(a -> m c d) -> (b -> m c d) -> m a b -> m c d` | `crocks/pointfree` |
 | `bimap` | `(a -> c) -> (b -> d) -> m a b -> m c d` | `crocks/pointfree` |
 | `both` | `m (a -> b) -> m (Pair a a -> Pair b b)` | `crocks/pointfree` |
 | `chain` | `(a -> m b) -> m a -> m b` | `crocks/pointfree` |
@@ -118,6 +119,7 @@ accepted Datatype):
 |---|:---|
 | `alt` | [`Async`][async-alt], [`Either`][either-alt], [`Maybe`][maybe-alt], [`Result`][result-alt] |
 | `ap` | `Array`, [`Async`][async-ap], [`Const`][const-ap], [`Either`][either-ap], `Identity`, `IO`, `List`, [`Maybe`][maybe-ap], [`Pair`][pair-ap], [`Reader`][reader-ap], [`Result`][result-ap], [`State`][state-ap], `Unit`, `Writer` |
+| `bichain` | [`Async`][async-bichain], [`Either`][either-bichain], [`Maybe`][maybe-bichain], [`Result`][result-bichain] |
 | `bimap` | [`Async`][async-bimap], [`Either`][either-bimap], [`Pair`][pair-bimap], [`Result`][result-bimap] |
 | `both` | [`Arrow`][arrow-both], `Function`, `Star` |
 | `chain` | `Array`, [`Async`][async-chain], [`Const`][const-chain], [`Either`][either-chain], `Identity`, `IO`, `List`, [`Maybe`][maybe-chain], [`Pair`][pair-chain], [`Reader`][reader-chain], [`Result`][result-chain], [`State`][state-chain], `Unit`, `Writer` |
@@ -185,6 +187,7 @@ accepted Datatype):
 
 [async-alt]: ../crocks/Async.html#alt
 [async-ap]: ../crocks/Async.html#ap
+[async-bichain]: ../crocks/Async.html#bichain
 [async-bimap]: ../crocks/Async.html#bimap
 [async-chain]: ../crocks/Async.html#chain
 [async-coalesce]: ../crocks/Async.html#coalesce
@@ -206,6 +209,7 @@ accepted Datatype):
 
 [either-alt]: ../crocks/Either.html#alt
 [either-ap]: ../crocks/Either.html#ap
+[either-bichain]: ../crocks/Either.html#bichain
 [either-bimap]: ../crocks/Either.html#bimap
 [either-chain]: ../crocks/Either.html#chain
 [either-coalesce]: ../crocks/Either.html#coalesce
@@ -242,6 +246,7 @@ accepted Datatype):
 
 [maybe-alt]: ../crocks/Maybe.html#alt
 [maybe-ap]: ../crocks/Maybe.html#ap
+[maybe-bichain]: ../crocks/Maybe.html#bichain
 [maybe-chain]: ../crocks/Maybe.html#chain
 [maybe-coalesce]: ../crocks/Maybe.html#coalesce
 [maybe-concat]: ../crocks/Maybe.html#concat
@@ -294,6 +299,7 @@ accepted Datatype):
 
 [result-alt]: ../crocks/Result.html#alt
 [result-ap]: ../crocks/Result.html#ap
+[result-bichain]: ../crocks/Result.html#bichain
 [result-bimap]: ../crocks/Result.html#bimap
 [result-chain]: ../crocks/Result.html#chain
 [result-coalesce]: ../crocks/Result.html#coalesce

--- a/src/Async/Async.spec.js
+++ b/src/Async/Async.spec.js
@@ -1276,77 +1276,76 @@ test('Async chain properties (Monad)', t => {
 })
 
 test('Async bichain left errors', t => {
+  const { Rejected } = Async
   const bichain = bindFunc(Async(unit).bichain)
 
   const err = /Async.bichain: Both arguments must be Async returning functions/
-  t.throws(bichain(undefined, Async.of), err, 'throws with undefined')
-  t.throws(bichain(null, Async.of), err, 'throws with null')
-  t.throws(bichain(0, Async.of), err, 'throws with falsey number')
-  t.throws(bichain(1, Async.of), err, 'throws with truthy number')
-  t.throws(bichain('', Async.of), err, 'throws with falsey string')
-  t.throws(bichain('string', Async.of), err, 'throws with truthy string')
-  t.throws(bichain(false, Async.of), err, 'throws with false')
-  t.throws(bichain(true, Async.of), err, 'throws with true')
-  t.throws(bichain([], Async.of), err, 'throws with an array')
-  t.throws(bichain({}, Async.of), err, 'throws with an object')
+  t.throws(bichain(undefined, Rejected), err, 'throws with undefined on left')
+  t.throws(bichain(null, Rejected), err, 'throws with null on left')
+  t.throws(bichain(0, Rejected), err, 'throws with falsy number on left')
+  t.throws(bichain(1, Rejected), err, 'throws with truthy number on left')
+  t.throws(bichain('', Rejected), err, 'throws with falsy string on left')
+  t.throws(bichain('string', Rejected), err, 'throws with truthy string on left')
+  t.throws(bichain(false, Rejected), err, 'throws with false on left')
+  t.throws(bichain(true, Rejected), err, 'throws with true on left')
+  t.throws(bichain([], Rejected), err, 'throws with an array on left')
+  t.throws(bichain({}, Rejected), err, 'throws with an object on left')
 
-  const noAsync = /Async.bichain: Both arguments must be Async returning functions/
-  t.throws(Async.Rejected(3).bichain(unit, Async.of).fork.bind(null, unit, unit), noAsync, 'throws with a non-Async returning function')
+  const fn = () => Rejected(0)
+    .bichain(unit, Rejected)
+    .fork(unit, unit)
 
-  t.doesNotThrow(Async.Rejected(3).bichain(Async.of, Async.of).fork.bind(null, unit, unit), 'allows an Async returning function')
+  t.throws(fn, err, 'throws with a non-Async returning function')
 
   t.end()
 })
 
 test('Async bichain right errors', t => {
+  const { Resolved } = Async
   const bichain = bindFunc(Async(unit).bichain)
 
   const err = /Async.bichain: Both arguments must be Async returning functions/
 
-  t.throws(bichain(Async.Rejected, undefined), err, 'throws with undefined')
-  t.throws(bichain(Async.Rejected, null), err, 'throws with null')
-  t.throws(bichain(Async.Rejected, 0), err, 'throws with falsey number')
-  t.throws(bichain(Async.Rejected, 1), err, 'throws with truthy number')
-  t.throws(bichain(Async.Rejected, ''), err, 'throws with falsey string')
-  t.throws(bichain(Async.Rejected, 'string'), err, 'throws with truthy string')
-  t.throws(bichain(Async.Rejected, false), err, 'throws with false')
-  t.throws(bichain(Async.Rejected, true), err, 'throws with true')
-  t.throws(bichain(Async.Rejected, []), err, 'throws with an array')
-  t.throws(bichain(Async.Rejected, {}), err, 'throws with an object')
+  t.throws(bichain(Resolved, undefined), err, 'throws with undefined on right')
+  t.throws(bichain(Resolved, null), err, 'throws with null on right')
+  t.throws(bichain(Resolved, 0), err, 'throws with falsy number on right')
+  t.throws(bichain(Resolved, 1), err, 'throws with truthy number on right')
+  t.throws(bichain(Resolved, ''), err, 'throws with falsy string on right')
+  t.throws(bichain(Resolved, 'string'), err, 'throws with truthy string on right')
+  t.throws(bichain(Resolved, false), err, 'throws with false on right')
+  t.throws(bichain(Resolved, true), err, 'throws with true on right')
+  t.throws(bichain(Resolved, []), err, 'throws with an array on right')
+  t.throws(bichain(Resolved, {}), err, 'throws with an object on right')
 
-  t.throws(Async.of(3).bichain(Async.Rejected, unit).fork.bind(null, unit, unit), err, 'throws with a non-Async returning function')
+  const fn = () => Resolved(0)
+    .bichain(Resolved, unit)
+    .fork(unit, unit)
 
-  t.doesNotThrow(Async.of(3).bichain(Async.Rejected, Async.of).fork.bind(null, unit, unit), 'allows an Async returning function')
+  t.throws(fn, err, 'throws with a non-Async returning function')
 
   t.end()
 })
 
-test('Async bichain properties (Bichain)', t => {
-  t.ok(isFunction(Async(unit).bichain), 'provides a bichain function')
+test('Async bichain functionality', t => {
+  const { Rejected, Resolved } = Async
 
-  const aRej = sinon.spy()
-  const bRej = sinon.spy()
+  const left = x => Rejected(x + 1)
+  const right = x => Resolved(x + 1)
 
-  const fOfL = x => Async((rej) => rej(x + 2))
-  const gOfL = x => Async((rej) => rej(x + 10))
+  const ltr = sinon.spy()
+  const rtl = sinon.spy()
+  const rtr = sinon.spy()
+  const ltl = sinon.spy()
 
-  const aRes = sinon.spy()
-  const bRes = sinon.spy()
+  Rejected(0).bichain(right, left).fork(unit, ltr)
+  Resolved(0).bichain(right, left).fork(rtl, unit)
+  Resolved(0).bichain(left, right).fork(unit, rtr)
+  Rejected(0).bichain(left, right).fork(ltl, unit)
 
-  const fOfR = x => Async((_, res) => res(x * 2))
-  const gOfR = x => Async((_, res) => res(x * 10))
-
-  const x = 12
-  const y = 7
-
-  Async((rej) => rej(x)).bichain(fOfL, Async.of).bichain(gOfL, Async.of).fork(aRej, unit)
-  Async((rej) => rej(x)).bichain(y => fOfL(y).bichain(gOfL, Async.of), Async.of).fork(bRej, unit)
-
-  Async((rej) => rej(y)).bichain(Async.Rejected, fOfR).bichain(Async.Rejected, gOfR).fork(unit, aRes)
-  Async((rej) => rej(y)).bichain(Async.Rejected, y => fOfR(y).bichain(Async.Rejected, gOfR)).fork(unit, bRes)
-
-  t.same(aRej.args[0], bRej.args[0], 'left associativity')
-  t.same(aRes.args[0], bRes.args[0], 'right associativity')
+  t.equals(ltr.args[0][0], 1, 'moves from Rejected to Resolved')
+  t.equals(rtl.args[0][0], 1, 'moves from Resolved to Rejected')
+  t.equals(rtr.args[0][0], 1, 'moves from Resolved to Resolved')
+  t.equals(ltl.args[0][0], 1, 'moves from Rejected to Rejected')
 
   t.end()
 })

--- a/src/Either/Either.spec.js
+++ b/src/Either/Either.spec.js
@@ -7,6 +7,7 @@ const bindFunc = helpers.bindFunc
 
 const curry = require('../core/curry')
 const compose = curry(require('../core/compose'))
+const equals = require('../core/equals')
 const isArray = require('../core/isArray')
 const isFunction = require('../core/isFunction')
 const isObject = require('../core/isObject')
@@ -154,8 +155,8 @@ test('Either @@type', t => {
   t.equal(Right(0)['@@type'], Either['@@type'], 'static and instance versions are the same for Right')
   t.equal(Left(0)['@@type'], Either['@@type'], 'static and instance versions are the same for Left')
 
-  t.equal(Right(0)['@@type'], 'crocks/Either@3', 'returns crocks/Either@3 for Right')
-  t.equal(Left(0)['@@type'], 'crocks/Either@3', 'returns crocks/Either@3 for Left')
+  t.equal(Right(0)['@@type'], 'crocks/Either@4', 'returns crocks/Either@4 for Right')
+  t.equal(Left(0)['@@type'], 'crocks/Either@4', 'returns crocks/Either@4 for Left')
 
   t.end()
 })
@@ -263,6 +264,62 @@ test('Either coalesce', t => {
 
   t.ok(l.equals(Either.Right('was left')),'returns an Either.Right wrapping was left' )
   t.ok(r.equals(Either.Right('was right')),'returns an Either.Right wrapping was right' )
+
+  t.end()
+})
+
+test('Either bichain left errors', t => {
+  const { Left } = Either
+  const bichain = bindFunc(Left(0).bichain)
+
+  const err = /Either.bichain: Both arguments must be Either returning functions/
+  t.throws(bichain(undefined, Left), err, 'throws with undefined on left')
+  t.throws(bichain(null, Left), err, 'throws with null on left')
+  t.throws(bichain(0, Left), err, 'throws with falsy number on left')
+  t.throws(bichain(1, Left), err, 'throws with truthy number on left')
+  t.throws(bichain('', Left), err, 'throws with falsy string on left')
+  t.throws(bichain('string', Left), err, 'throws with truthy string on left')
+  t.throws(bichain(false, Left), err, 'throws with false on left')
+  t.throws(bichain(true, Left), err, 'throws with true on left')
+  t.throws(bichain([], Left), err, 'throws with an array on left')
+  t.throws(bichain({}, Left), err, 'throws with an object on left')
+
+  t.throws(bichain(unit, Left), err, 'throws with a non-Either returning function')
+
+  t.end()
+})
+
+test('Either bichain right errors', t => {
+  const { Right } = Either
+  const bichain = bindFunc(Right(0).bichain)
+
+  const err = /Either.bichain: Both arguments must be Either returning functions/
+  t.throws(bichain(Right, undefined), err, 'throws with undefined on left')
+  t.throws(bichain(Right, null), err, 'throws with null on left')
+  t.throws(bichain(Right, 0), err, 'throws with falsy number on left')
+  t.throws(bichain(Right, 1), err, 'throws with truthy number on left')
+  t.throws(bichain(Right, ''), err, 'throws with falsy string on left')
+  t.throws(bichain(Right, 'string'), err, 'throws with truthy string on left')
+  t.throws(bichain(Right, false), err, 'throws with false on left')
+  t.throws(bichain(Right, true), err, 'throws with true on left')
+  t.throws(bichain(Right, []), err, 'throws with an array on left')
+  t.throws(bichain(Right, {}), err, 'throws with an object on left')
+
+  t.throws(bichain(Right, unit), err, 'throws with a non-Either returning function')
+
+  t.end()
+})
+
+test('Either bichain functionality', t => {
+  const { Left, Right } = Either
+
+  const left = x => Left(x + 1)
+  const right = x => Right(x + 1)
+
+  t.ok(equals(Left(0).bichain(right, left), Right(1)), 'moves from Left to Right')
+  t.ok(equals(Right(0).bichain(right, left), Left(1)), 'moves from Right to Left')
+  t.ok(equals(Right(0).bichain(left, right), Right(1)), 'moves from Right to Right')
+  t.ok(equals(Left(0).bichain(left, right), Left(1)), 'moves from Left to Left')
 
   t.end()
 })

--- a/src/Either/index.js
+++ b/src/Either/index.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const VERSION = 3
+const VERSION = 4
 
 const _defineUnion = require('../core/defineUnion')
 const _equals = require('../core/equals')
@@ -110,6 +110,23 @@ function Either(u) {
     }
 
     return Either.Right(either(f, g))
+  }
+
+  function bichain(l, r) {
+    const bichainErr =
+      'Either.bichain: Both arguments must be Either returning functions'
+
+    if(!(isFunction(l) && isFunction(r))) {
+      throw new TypeError(bichainErr)
+    }
+
+    const m = either(l, r)
+
+    if(!isSameType(Either, m)) {
+      throw new TypeError(bichainErr)
+    }
+
+    return m
   }
 
   function map(method) {
@@ -228,8 +245,8 @@ function Either(u) {
 
   return {
     inspect, toString: inspect, either,
-    type, swap, coalesce, equals,
-    ap, of, sequence, traverse,
+    type, swap, coalesce, bichain,
+    equals, ap, of, sequence, traverse,
     alt: alt('alt'),
     bimap: bimap('bimap'),
     concat: concat('concat'),

--- a/src/Result/index.js
+++ b/src/Result/index.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const VERSION = 3
+const VERSION = 4
 
 const _defineUnion = require('../core/defineUnion')
 const _equals = require('../core/equals')
@@ -119,6 +119,23 @@ function Result(u) {
     }
 
     return Result.Ok(either(f, g))
+  }
+
+  function bichain(l, r) {
+    const bichainErr =
+      'Result.bichain: Both arguments must be Result returning functions'
+
+    if(!(isFunction(l) && isFunction(r))) {
+      throw new TypeError(bichainErr)
+    }
+
+    const m = either(l, r)
+
+    if(!isSameType(Result, m)) {
+      throw new TypeError(bichainErr)
+    }
+
+    return m
   }
 
   function map(method) {
@@ -239,7 +256,7 @@ function Result(u) {
 
   return {
     inspect, toString: inspect, equals,
-    type, either, swap, coalesce,
+    type, either, swap, coalesce, bichain,
     ap, of, sequence, traverse,
     alt: alt('alt'),
     bimap: bimap('bimap'),

--- a/src/core/Maybe.js
+++ b/src/core/Maybe.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-const VERSION = 3
+const VERSION = 4
 
 const _defineUnion = require('./defineUnion')
 const _equals = require('./equals')
@@ -115,6 +115,23 @@ function Maybe(u) {
     return Maybe.Just(either(f, g))
   }
 
+  function bichain(l, r) {
+    const bichainErr =
+      'Maybe.bichain: Both arguments must be Maybe returning functions'
+
+    if(!(isFunction(l) && isFunction(r))) {
+      throw new TypeError(bichainErr)
+    }
+
+    const m = either(l, r)
+
+    if(!isSameType(Maybe, m)) {
+      throw new TypeError(bichainErr)
+    }
+
+    return m
+  }
+
   function map(method) {
     return function(fn) {
       if(!isFunction(fn)) {
@@ -223,7 +240,7 @@ function Maybe(u) {
 
   return {
     inspect, toString: inspect, either,
-    option, type, equals, coalesce,
+    option, type, equals, bichain, coalesce,
     zero, ap, of, sequence,
     traverse,
     alt: alt('alt'),

--- a/src/core/isBichain.spec.js
+++ b/src/core/isBichain.spec.js
@@ -1,0 +1,33 @@
+const test = require('tape')
+const helpers = require('../test/helpers')
+
+const makeFake = helpers.makeFake
+
+const isFunction = require('./isFunction')
+
+const identity = x => x
+
+const isBichain = require('./isBichain')
+
+test('isBichain predicate function', t => {
+  const Fake = makeFake([ 'bichain' ])
+  const fake = Fake()
+
+  t.equal(isBichain(undefined), false, 'returns false for undefined')
+  t.equal(isBichain(null), false, 'returns false for null')
+  t.equal(isBichain(0), false, 'returns false for falsey number')
+  t.equal(isBichain(1), false, 'returns false for truthy number')
+  t.equal(isBichain(''), false, 'returns false for falsey string')
+  t.equal(isBichain('string'), false, 'returns false for truthy string')
+  t.equal(isBichain(false), false, 'returns false for false')
+  t.equal(isBichain(true), false, 'returns false for true')
+  t.equal(isBichain({}), false, 'returns false for an object')
+  t.equal(isBichain([]), false, 'returns false for an array')
+  t.equal(isBichain(identity), false, 'returns false for function')
+
+  t.equal(isBichain(Fake), true, 'returns true when Bifunctor Constructor is passed')
+  t.equal(isBichain(fake), true, 'returns true when Bifunctor is passed')
+
+  t.ok(isFunction(isBichain))
+  t.end()
+})

--- a/src/pointfree/bichain.js
+++ b/src/pointfree/bichain.js
@@ -2,20 +2,21 @@
 /** @author Dale Francis (dalefrancis88) */
 
 const curry = require('../core/curry')
-const isBichain = require('../core/isBichain')
 const isFunction = require('../core/isFunction')
 
 // bichain : bichain m => (e -> m c b) -> (a -> m c b) -> m e a -> m c b
 function bichain(f, g, m) {
   if(!isFunction(f) || !isFunction(g)) {
-    throw new TypeError('bichain: First two arguments must be Bichain returning functions')
+    throw new TypeError('bichain: First two arguments must be Sum Type returning functions')
   }
 
-  if(!isBichain(m)) {
-    throw new TypeError('bichain: Third argument must be a Bichain')
+  if(m && isFunction(m.bichain)) {
+    return m.bichain.call(m, f, g)
   }
 
-  return m.bichain.call(m, f, g)
+  throw new TypeError(
+    'bichain: Third argument must be a Sum Type'
+  )
 }
 
 module.exports = curry(bichain)

--- a/src/pointfree/bichain.spec.js
+++ b/src/pointfree/bichain.spec.js
@@ -21,7 +21,7 @@ test('bichain pointfree', t => {
 
   t.ok(isFunction(bichain), 'is a function')
 
-  const err = /TypeError: bichain: First two arguments must be Bichain returning functions/
+  const err = /^TypeError: bichain: First two arguments must be Sum Type returning functions$/
 
   t.throws(m(undefined, unit, f), err, 'throws if first arg is undefined')
   t.throws(m(null, unit, f), err, 'throws if first arg is null')
@@ -45,7 +45,7 @@ test('bichain pointfree', t => {
   t.throws(m(unit, [], f), err, 'throws if second arg is an array')
   t.throws(m(unit, {}, f), err, 'throws if second arg is an object')
 
-  const last = /bichain: Third argument must be a Bichain/
+  const last = /^TypeError: bichain: Third argument must be a Sum Type$/
   t.throws(m(unit, unit, undefined), last, 'throws if third arg is undefined')
   t.throws(m(unit, unit, null), last, 'throws if third arg is null')
   t.throws(m(unit, unit, 0), last, 'throws if third arg is a falsey number')


### PR DESCRIPTION
## 2 chains are better than 1
![image](https://user-images.githubusercontent.com/3665793/64493105-bf39a500-d230-11e9-8f54-57d9c3701e11.png)

This PR responds to [this issue][issue] and adds `bichain` to the remaining (3) Sum Types as it was already added on to `Async` on [this PR][pr]:
* `Either`
* `Maybe`
* `Result`

For each example in the documentation, we show both just a simple function to swap between "left"/"right" instances and a more in depth example. The exception to this is `Maybe`, which only shows the simple swap example. This is because, there is not really a solid use case that is not better implement with `alt`. Although, if anyone has any suggested, real-world use cases for the `Maybe` example, I am all :ear: 

[issue]: https://github.com/evilsoft/crocks/issues/393
[pr]: https://github.com/evilsoft/crocks/pull/394