### PR TITLE
Convert inline comments to block

### DIFF
--- a/CODINGSTANDARDS.md
+++ b/CODINGSTANDARDS.md
@@ -28,7 +28,7 @@ already has a header there is no need to update it.
 
 ### Main File Structure
 
-The following is an example of the normal structure of a core library file 
+The following is an example of the normal structure of a core library file
 using `find` as an example of this structure. It is also a good example of
 how each argument should be validated.
 
@@ -84,7 +84,7 @@ Bad:
 "Number is required for first argument"
 
 ```javascript
-// find :: Foldable f => ((a -> Boolean) | Pred) -> f a -> Maybe a
+/** find :: Foldable f => ((a -> Boolean) | Pred) -> f a -> Maybe a */
 function find(fn, foldable) {
   if(!isFunction(fn) && !isSameType(Pred, fn)) {
     throw new TypeError('find: First argument must be a Pred or predicate')
@@ -139,7 +139,7 @@ const { fromArray } = List
 #### Testing sections
 
 The spec file will contain one or many collections of tests grouped by subject
-matter. For example testing input validation for an argument. 
+matter. For example testing input validation for an argument.
 We also generally test with the following set of values to ensure there is
 proper protection. Remember, writing tests is about regression and protection
 from future changes.
@@ -181,11 +181,11 @@ the functions signature then a details description of the functions purpose and
 features using plain language. Any library function references should be linked
 
 > `crocks/combinators/composeB`
-> 
+>
 > ```haskell
 > composeB :: (b -> c) -> (a -> b) -> a -> c
 > ```
-> 
+>
 > Provides a means to describe a composition between two functions. it takes two
 > functions and a value. Given `composeB(f, g)`, which is read `f` after `g`, it
 > will return a function that will take value `a` and apply it to `g`, passing the
@@ -216,7 +216,7 @@ import isString from 'crocks/predicates/isString'
 When writing documentation examples start out with very simple usages to show
 how the functions works, followed by a more real-world scenario. Each function
 should also have a proper signature above it. When you invoke the function, it
-should also have the result of that invocation commented below. 
+should also have the result of that invocation commented below.
 
 ```javascript
 // yell :: String -> String

--- a/src/Async/asyncToPromise.js
+++ b/src/Async/asyncToPromise.js
@@ -15,8 +15,8 @@ const toPromise = m => {
   return m.toPromise()
 }
 
-// asyncToPromise :: m e a -> Promise a e
-// asyncToPromise :: (a -> m e b) -> a -> Promise b e
+/** asyncToPromise :: m e a -> Promise a e */
+/** asyncToPromise :: (a -> m e b) -> a -> Promise b e */
 function asyncToPromise(m) {
   return isFunction(m)
     ? x => toPromise(m(x))

--- a/src/Async/eitherToAsync.js
+++ b/src/Async/eitherToAsync.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = either =>
   either.either(Async.Rejected, Async.Resolved)
 
-// eitherToAsync : Either e a -> Async e a
-// eitherToAsync : (a -> Either e b) -> a -> Async e b
+/** eitherToAsync :: Either e a -> Async e a */
+/** eitherToAsync :: (a -> Either e b) -> a -> Async e b */
 function eitherToAsync(either) {
   if(isFunction(either)) {
     return function(x) {

--- a/src/Async/firstToAsync.js
+++ b/src/Async/firstToAsync.js
@@ -16,8 +16,8 @@ const applyTransform = (left, first) =>
     Async.Resolved
   )
 
-// firstToAsync : e -> First a -> Async e a
-// firstToAsync : e -> (a -> First b) -> a -> Async e b
+/** firstToAsync :: e -> First a -> Async e a */
+/** firstToAsync :: e -> (a -> First b) -> a -> Async e b */
 function firstToAsync(left, first) {
   if(isFunction(first)) {
     return function(x) {

--- a/src/Async/lastToAsync.js
+++ b/src/Async/lastToAsync.js
@@ -16,8 +16,8 @@ const applyTransform = (left, last) =>
     Async.Resolved
   )
 
-// lastToAsync : e -> Last a -> Async e a
-// lastToAsync : e -> (a -> Last b) -> a -> Async e b
+/** lastToAsync :: e -> Last a -> Async e a */
+/** lastToAsync :: e -> (a -> Last b) -> a -> Async e b */
 function lastToAsync(left, last) {
   if(isFunction(last)) {
     return function(x) {

--- a/src/Async/maybeToAsync.js
+++ b/src/Async/maybeToAsync.js
@@ -16,8 +16,8 @@ const applyTransform = (left, maybe) =>
     Async.Resolved
   )
 
-// maybeToAsync : e -> Maybe a -> Async e a
-// maybeToAsync : e -> (a -> Maybe b) -> a -> Async e b
+/** maybeToAsync :: e -> Maybe a -> Async e a */
+/** maybeToAsync :: e -> (a -> Maybe b) -> a -> Async e b */
 function maybeToAsync(left, maybe) {
   if(isFunction(maybe)) {
     return function(x) {

--- a/src/Async/resultToAsync.js
+++ b/src/Async/resultToAsync.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = either =>
   either.either(Async.Rejected, Async.Resolved)
 
-// resultToAsync : Result e a -> Async e a
-// resultToAsync : (a -> Result e b) -> a -> Async e b
+/** resultToAsync :: Result e a -> Async e a */
+/** resultToAsync :: (a -> Result e b) -> a -> Async e b */
 function resultToAsync(result) {
   if(isFunction(result)) {
     return function(x) {

--- a/src/Either/firstToEither.js
+++ b/src/Either/firstToEither.js
@@ -16,8 +16,8 @@ const applyTransform = (left, first) =>
     Either.Right
   )
 
-// firstToEither : c -> First a -> Either c a
-// firstToEither : c -> (a -> First b) -> a -> Either c b
+/** firstToEither :: c -> First a -> Either c a */
+/** firstToEither :: c -> (a -> First b) -> a -> Either c b */
 function firstToEither(left, first) {
   if(isFunction(first)) {
     return function(x) {

--- a/src/Either/lastToEither.js
+++ b/src/Either/lastToEither.js
@@ -16,8 +16,8 @@ const applyTransform = (left, last) =>
     Either.Right
   )
 
-// lastToEither : c -> Last a -> Either c a
-// lastToEither : c -> (a -> Last b) -> a -> Either c b
+/** lastToEither :: c -> Last a -> Either c a */
+/** lastToEither :: c -> (a -> Last b) -> a -> Either c b */
 function lastToEither(left, last) {
   if(isFunction(last)) {
     return function(x) {

--- a/src/Either/maybeToEither.js
+++ b/src/Either/maybeToEither.js
@@ -16,8 +16,8 @@ const applyTransform = (left, maybe) =>
     Either.Right
   )
 
-// maybeToEither : c -> Maybe a -> Either c a
-// maybeToEither : c -> (a -> Maybe b) -> a -> Either c b
+/** maybeToEither :: c -> Maybe a -> Either c a */
+/** maybeToEither :: c -> (a -> Maybe b) -> a -> Either c b */
 function maybeToEither(left, maybe) {
   if(isFunction(maybe)) {
     return function(x) {

--- a/src/Either/resultToEither.js
+++ b/src/Either/resultToEither.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = result =>
   result.either(Either.Left, Either.Right)
 
-// resultToEither : Result e a -> Either e a
-// resultToEither : (a -> Result e b) -> a -> Either e b
+/** resultToEither :: Result e a -> Either e a */
+/** resultToEither :: (a -> Result e b) -> a -> Either e b */
 function resultToEither(result) {
   if(isFunction(result)) {
     return function(x) {

--- a/src/First/eitherToFirst.js
+++ b/src/First/eitherToFirst.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = either =>
   either.either(First.empty, First)
 
-// eitherToFirst : Either b a -> First a
-// eitherToFirst : (a -> Either c b) -> a -> First b
+/** eitherToFirst :: Either b a -> First a */
+/** eitherToFirst :: (a -> Either c b) -> a -> First b */
 function eitherToFirst(either) {
   if(isFunction(either)) {
     return function(x) {

--- a/src/First/lastToFirst.js
+++ b/src/First/lastToFirst.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = last =>
   First(last.valueOf())
 
-// lastToFirst : Last a -> First a
-// lastToFirst : (a -> Last b) -> a -> First b
+/** lastToFirst :: Last a -> First a */
+/** lastToFirst :: (a -> Last b) -> a -> First b */
 function lastToFirst(last) {
   if(isFunction(last)) {
     return function(x) {

--- a/src/First/maybeToFirst.js
+++ b/src/First/maybeToFirst.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = maybe =>
   First(maybe)
 
-// maybeToFirst : Maybe a -> First a
-// maybeToFirst : (a -> Maybe b) -> a -> First b
+/** maybeToFirst :: Maybe a -> First a */
+/** maybeToFirst :: (a -> Maybe b) -> a -> First b */
 function maybeToFirst(maybe) {
   if(isFunction(maybe)) {
     return function(x) {

--- a/src/First/resultToFirst.js
+++ b/src/First/resultToFirst.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = result =>
   result.either(First.empty, First)
 
-// resultToFirst : Result b a -> First a
-// resultToFirst : (a -> Result c b) -> a -> First b
+/** resultToFirst :: Result b a -> First a */
+/** resultToFirst :: (a -> Result c b) -> a -> First b */
 function resultToFirst(result) {
   if(isFunction(result)) {
     return function(x) {

--- a/src/Last/eitherToLast.js
+++ b/src/Last/eitherToLast.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = either =>
   either.either(Last.empty, Last)
 
-// eitherToLast : Either b a -> Last a
-// eitherToLast : (a -> Either c b) -> a -> Last b
+/** eitherToLast :: Either b a -> Last a */
+/** eitherToLast :: (a -> Either c b) -> a -> Last b */
 function eitherToLast(either) {
   if(isFunction(either)) {
     return function(x) {

--- a/src/Last/firstToLast.js
+++ b/src/Last/firstToLast.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = first =>
   Last(first.valueOf())
 
-// firstToLast : First a -> Last a
-// firstToLast : (a -> First b) -> a -> Last b
+/** firstToLast :: First a -> Last a */
+/** firstToLast :: (a -> First b) -> a -> Last b */
 function firstToLast(first) {
   if(isFunction(first)) {
     return function(x) {

--- a/src/Last/maybeToLast.js
+++ b/src/Last/maybeToLast.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = maybe =>
   Last(maybe)
 
-// maybeToLast : Maybe a -> Last a
-// maybeToLast : (a -> Maybe b) -> a -> Last b
+/** maybeToLast :: Maybe a -> Last a */
+/** maybeToLast :: (a -> Maybe b) -> a -> Last b */
 function maybeToLast(maybe) {
   if(isFunction(maybe)) {
     return function(x) {

--- a/src/Last/resultToLast.js
+++ b/src/Last/resultToLast.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = result =>
   result.either(Last.empty, Last)
 
-// resultToLast : Result b a -> Last a
-// resultToLast : (a -> Result c b) -> a -> Last b
+/** resultToLast :: Result b a -> Last a */
+/** resultToLast :: (a -> Result c b) -> a -> Last b */
 function resultToLast(result) {
   if(isFunction(result)) {
     return function(x) {

--- a/src/List/arrayToList.js
+++ b/src/List/arrayToList.js
@@ -7,8 +7,8 @@ const curry = require('../core/curry')
 const isArray = require('../core/isArray')
 const isFunction = require('../core/isFunction')
 
-// arrayToList : [ a ] -> List a
-// arrayToList : (a -> [ b ]) -> a -> List b
+/** arrayToList :: [ a ] -> List a */
+/** arrayToList :: (a -> [ b ]) -> a -> List b */
 function arrayToList(array) {
   if(isArray(array)) {
     return List.fromArray(array)

--- a/src/List/listToArray.js
+++ b/src/List/listToArray.js
@@ -7,8 +7,8 @@ const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
 const isSameType = require('../core/isSameType')
 
-// listToArray : List a -> [ a ]
-// listToArray : (a -> List b) -> a -> [ b ]
+/** listToArray :: List a -> [ a ] */
+/** listToArray :: (a -> List b) -> a -> [ b ] */
 function listToArray(list) {
   if(isFunction(list)) {
     return function(x) {

--- a/src/List/maybeToList.js
+++ b/src/List/maybeToList.js
@@ -17,8 +17,8 @@ const applyTransform = maybe =>
 const err =
   'maybeToList: Argument must be a Maybe instanstace or a Maybe returning function'
 
-// maybeToList : Maybe a -> List a
-// maybeToList : (a -> Maybe b) -> a -> List b
+/** maybeToList :: Maybe a -> List a */
+/** maybeToList :: (a -> Maybe b) -> a -> List b */
 function maybeToList(maybe) {
   if(isFunction(maybe)) {
     return function(x) {

--- a/src/Maybe/eitherToMaybe.js
+++ b/src/Maybe/eitherToMaybe.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = either =>
   either.either(Maybe.Nothing, Maybe.Just)
 
-// eitherToMaybe : Either b a -> Maybe a
-// eitherToMaybe : (a -> Either c b) -> a -> Maybe b
+/** eitherToMaybe :: Either b a -> Maybe a */
+/** eitherToMaybe :: (a -> Either c b) -> a -> Maybe b */
 function eitherToMaybe(either) {
   if(isFunction(either)) {
     return function(x) {

--- a/src/Maybe/find.js
+++ b/src/Maybe/find.js
@@ -14,7 +14,7 @@ const { Just, Nothing } = require('.')
 const accumulator = fn => (acc, cur) =>
   !acc.found && predOrFunc(fn, cur) ? { found: true, value: cur } : acc
 
-// find :: Foldable f => ((a -> Boolean) | Pred) -> f a -> Maybe a
+/** find :: Foldable f => ((a -> Boolean) | Pred) -> f a -> Maybe a */
 function find(fn, foldable) {
   if(!isFunction(fn) && !isSameType(Pred, fn)) {
     throw new TypeError('find: First argument must be a Pred or predicate')

--- a/src/Maybe/firstToMaybe.js
+++ b/src/Maybe/firstToMaybe.js
@@ -10,8 +10,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = first =>
   first.valueOf()
 
-// firstToMaybe : First a -> Maybe a
-// firstToMaybe : (a -> First b) -> a -> Maybe b
+/** firstToMaybe :: First a -> Maybe a */
+/** firstToMaybe :: (a -> First b) -> a -> Maybe b */
 function firstToMaybe(first) {
   if(isFunction(first)) {
     return function(x) {

--- a/src/Maybe/lastToMaybe.js
+++ b/src/Maybe/lastToMaybe.js
@@ -10,8 +10,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = last =>
   last.valueOf()
 
-// lastToMaybe : Last a -> Maybe a
-// lastToMaybe : (a -> Last b) -> a -> Maybe b
+/** lastToMaybe :: Last a -> Maybe a */
+/** lastToMaybe :: (a -> Last b) -> a -> Maybe b */
 function lastToMaybe(last) {
   if(isFunction(last)) {
     return function(x) {

--- a/src/Maybe/resultToMaybe.js
+++ b/src/Maybe/resultToMaybe.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = result =>
   result.either(Maybe.Nothing, Maybe.Just)
 
-// resultToMaybe : Result b a -> Maybe a
-// resultToMaybe : (a -> Result c b) -> a -> Maybe b
+/** resultToMaybe :: Result b a -> Maybe a */
+/** resultToMaybe :: (a -> Result c b) -> a -> Maybe b */
 function resultToMaybe(result) {
   if(isFunction(result)) {
     return function(x) {

--- a/src/Maybe/safe.js
+++ b/src/Maybe/safe.js
@@ -7,7 +7,7 @@ const predOrFunc = require('../core/predOrFunc')
 const curry = require('../core/curry')
 const isPredOrFunc = require('../core/isPredOrFunc')
 
-// safe : ((a -> Boolean) | Pred) -> a -> Maybe a
+/** safe :: ((a -> Boolean) | Pred) -> a -> Maybe a */
 function safe(pred, x) {
   if(!isPredOrFunc(pred)) {
     throw new TypeError('safe: Pred or predicate function required for first argument')

--- a/src/Maybe/safeAfter.js
+++ b/src/Maybe/safeAfter.js
@@ -5,7 +5,7 @@ const isPredOrFunc = require('../core/isPredOrFunc')
 const isFunction = require('../core/isFunction')
 const predOrFunc = require('../core/predOrFunc')
 
-// safeAfter :: ((b -> Boolean) | Pred) -> (a -> b) -> a -> Maybe b
+/** safeAfter :: ((b -> Boolean) | Pred) -> (a -> b) -> a -> Maybe b */
 function safeAfter(pred, fn) {
   if(!isPredOrFunc(pred)) {
     throw new TypeError('safeAfter: Pred or predicate function required for first argument')

--- a/src/Maybe/safeLift.js
+++ b/src/Maybe/safeLift.js
@@ -10,7 +10,7 @@ const safe = require('./safe')
 const map =
   fn => m => m.map(fn)
 
-// safeLift : ((a -> Boolean) | Pred) -> (a -> b) -> a -> Maybe b
+/** safeLift :: ((a -> Boolean) | Pred) -> (a -> b) -> a -> Maybe b */
 function safeLift(pred, fn) {
   if(!isPredOrFunc(pred)) {
     throw new TypeError('safeLift: Pred or predicate function required for first argument')

--- a/src/Pair/branch.js
+++ b/src/Pair/branch.js
@@ -3,7 +3,7 @@
 
 const Pair = require('../core/Pair')
 
-// branch : a -> Pair a a
+/** branch :: a -> Pair a a */
 function branch(x) {
   return Pair(x, x)
 }

--- a/src/Pair/fanout.js
+++ b/src/Pair/fanout.js
@@ -16,7 +16,7 @@ const valid = (x, y) =>
     && isFunction(x.first)
     && isFunction(x.second)
 
-// fanout : m a b -> m a c -> m a (b, c)
+/** fanout :: m a b -> m a c -> m a (b, c) */
 function fanout(fst, snd) {
   if(isFunction(fst) && isFunction(snd)) {
     return x =>

--- a/src/Pair/toPairs.js
+++ b/src/Pair/toPairs.js
@@ -5,7 +5,7 @@ const List = require('../core/List')
 const Pair = require('../core/Pair')
 const isObject = require('../core/isObject')
 
-// toPairs : Object -> List (Pair String a)
+/** toPairs :: Object -> List (Pair String a) */
 function toPairs(obj) {
   if(!isObject(obj)) {
     throw new TypeError('toPairs: Object required for argument')

--- a/src/Pair/writerToPair.js
+++ b/src/Pair/writerToPair.js
@@ -10,8 +10,8 @@ const isWriter =
 const applyTransform = w =>
   w.read()
 
-// writerToPair : Monoid m => Writer m a -> Pair m a
-// writerToPair : Monoid m => (a -> Writer m a) -> Pair m b
+/** writerToPair :: Monoid m => Writer m a -> Pair m a */
+/** writerToPair :: Monoid m => (a -> Writer m a) -> Pair m b */
 function writerToPair(writer) {
   if(isFunction(writer)) {
     return function(x) {

--- a/src/Result/eitherToResult.js
+++ b/src/Result/eitherToResult.js
@@ -11,8 +11,8 @@ const isSameType = require('../core/isSameType')
 const applyTransform = either =>
   either.either(Result.Err, Result.Ok)
 
-// eitherToResult : Either e a -> Result e a
-// eitherToResult : (a -> Either e b) -> a -> Result e b
+/** eitherToResult :: Either e a -> Result e a */
+/** eitherToResult :: (a -> Either e b) -> a -> Result e b */
 function eitherToResult(either) {
   if(isFunction(either)) {
     return function(x) {

--- a/src/Result/firstToResult.js
+++ b/src/Result/firstToResult.js
@@ -16,8 +16,8 @@ const applyTransform = (left, first) =>
     Result.Ok
   )
 
-// firstToResult : c -> First a -> Result c a
-// firstToResult : c -> (a -> First b) -> a -> Result c b
+/** firstToResult :: c -> First a -> Result c a */
+/** firstToResult :: c -> (a -> First b) -> a -> Result c b */
 function firstToResult(left, first) {
   if(isFunction(first)) {
     return function(x) {

--- a/src/Result/lastToResult.js
+++ b/src/Result/lastToResult.js
@@ -16,8 +16,8 @@ const applyTransform = (left, last) =>
     Result.Ok
   )
 
-// lastToResult : c -> Last a -> Result c a
-// lastToResult : c -> (a -> Last b) -> a -> Result c b
+/** lastToResult :: c -> Last a -> Result c a */
+/** lastToResult :: c -> (a -> Last b) -> a -> Result c b */
 function lastToResult(left, last) {
   if(isFunction(last)) {
     return function(x) {

--- a/src/Result/maybeToResult.js
+++ b/src/Result/maybeToResult.js
@@ -16,8 +16,8 @@ const applyTransform = (left, maybe) =>
     Result.Ok
   )
 
-// maybeToResult : c -> Maybe a -> Result c a
-// maybeToResult : c -> (a -> Maybe b) -> a -> Result c b
+/** maybeToResult :: c -> Maybe a -> Result c a */
+/** maybeToResult :: c -> (a -> Maybe b) -> a -> Result c b */
 function maybeToResult(left, maybe) {
   if(isFunction(maybe)) {
     return function(x) {

--- a/src/Tuple/tupleToArray.js
+++ b/src/Tuple/tupleToArray.js
@@ -4,8 +4,8 @@
 const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
 
-// tupleToArray : Tuple a -> [ a ]
-// tupleToArray : (a -> Tuple b) -> a -> [ b ]
+/** tupleToArray :: Tuple a -> [ a ] */
+/** tupleToArray :: (a -> Tuple b) -> a -> [ b ] */
 function tupleToArray(tuple) {
   if(isFunction(tuple)) {
     return function(x) {

--- a/src/combinators/applyTo.js
+++ b/src/combinators/applyTo.js
@@ -5,7 +5,7 @@ const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
 
 // Application (Thrush)
-// applyTo :: a -> (a -> b) -> b
+/** applyTo :: a -> (a -> b) -> b */
 function applyTo(x, f) {
   if(!isFunction(f)) {
     throw new TypeError('applyTo: Function required for second argument')

--- a/src/combinators/compose2.js
+++ b/src/combinators/compose2.js
@@ -4,7 +4,7 @@
 const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
 
-// compose2 :: (c -> d -> e) -> (a -> c) -> (b -> d) -> a -> b -> e
+/** compose2 :: (c -> d -> e) -> (a -> c) -> (b -> d) -> a -> b -> e */
 function compose2(f, g, h, x, y) {
   if(!isFunction(f) || !isFunction(g) || !isFunction(h)) {
     throw new TypeError('compose2: First, second and third arguments must be functions')

--- a/src/combinators/composeB.js
+++ b/src/combinators/composeB.js
@@ -6,7 +6,7 @@ const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
 
 // Composition (Bluebird)
-// composeB :: (b -> c) -> (a -> b) -> a -> c
+/** composeB :: (b -> c) -> (a -> b) -> a -> c */
 function composeB(f, g) {
   if(!(isFunction(f) && isFunction(g))) {
     throw new TypeError(

--- a/src/combinators/constant.js
+++ b/src/combinators/constant.js
@@ -4,7 +4,7 @@
 const curry = require('../core/curry')
 
 // Constant (Kestrel)
-// constant : a -> b -> a
+/** constant :: a -> b -> a */
 const constant =
   x => () => x
 

--- a/src/combinators/identity.js
+++ b/src/combinators/identity.js
@@ -2,7 +2,7 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 // Identity (Idiot)
-// identity :: a -> a
+/** identity :: a -> a */
 const identity =
   x => x
 

--- a/src/combinators/psi.js
+++ b/src/combinators/psi.js
@@ -5,7 +5,7 @@ const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
 
 // PSI (P)
-// psi :: (b -> b -> c) -> (a -> b) -> a -> a -> c
+/** psi :: (b -> b -> c) -> (a -> b) -> a -> a -> c */
 function psi(f, g, x, y) {
   if(!isFunction(f) || !isFunction(g)) {
     throw new TypeError('psi: First and second arguments must be functions')

--- a/src/combinators/substitution.js
+++ b/src/combinators/substitution.js
@@ -5,7 +5,7 @@ const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
 
 // Substitution (Starling)
-// substitution : (a -> b -> c) -> (a -> b) -> a -> c
+/** substitution :: (a -> b -> c) -> (a -> b) -> a -> c */
 function substitution(f, g, x) {
   if(!(isFunction(f) && isFunction(g))) {
     throw new TypeError(

--- a/src/core/compose.js
+++ b/src/core/compose.js
@@ -2,7 +2,7 @@
 /** @author Ian Hofmann-Hicks (evil) */
 
 // Composition (Bluebird)
-// compose : (b -> c) -> (a -> b) -> a -> c
+/** compose :: (b -> c) -> (a -> b) -> a -> c */
 function compose(f, g) {
   return function(x) {
     return f(g(x))

--- a/src/core/curry.js
+++ b/src/core/curry.js
@@ -12,7 +12,7 @@ function applyCurry(fn, arg) {
   return fn.length > 1 ? fn.bind(null, arg) : fn.call(null, arg)
 }
 
-// curry : ((a, b, c) -> d) -> a -> b -> c -> d
+/** curry :: ((a, b, c) -> d) -> a -> b -> c -> d */
 function curry(fn) {
   if(fn[CURRY_SYMB]) {
     return fn

--- a/src/core/inspect.js
+++ b/src/core/inspect.js
@@ -14,7 +14,7 @@ function arrayInspect(xs) {
     : xs
 }
 
-// inspect : a -> String
+/** inspect :: a -> String */
 function inspect(x) {
   if(x && isFunction(x.inspect)) {
     return ` ${x.inspect()}`

--- a/src/core/isAlt.js
+++ b/src/core/isAlt.js
@@ -4,7 +4,7 @@
 const hasAlg = require('./hasAlg')
 const isFunctor = require('./isFunctor')
 
-// isAlt : a -> Boolean
+/** isAlt :: a -> Boolean */
 function isAlt(m) {
   return isFunctor(m)
     && hasAlg('alt', m)

--- a/src/core/isApplicative.js
+++ b/src/core/isApplicative.js
@@ -4,7 +4,7 @@
 const hasAlg = require('./hasAlg')
 const isApply = require('./isApply')
 
-// isApplicative : a -> Boolean
+/** isApplicative :: a -> Boolean */
 function isApplicative(m) {
   return isApply(m)
     && (hasAlg('of', m) || hasAlg('of', m.constructor))

--- a/src/core/isApply.js
+++ b/src/core/isApply.js
@@ -4,7 +4,7 @@
 const hasAlg = require('./hasAlg')
 const isFunctor = require('./isFunctor')
 
-// isApply : a -> Boolean
+/** isApply :: a -> Boolean */
 function isApply(m) {
   return isFunctor(m)
     && hasAlg('ap', m)

--- a/src/core/isBichain.js
+++ b/src/core/isBichain.js
@@ -3,7 +3,7 @@
 
 const hasAlg = require('./hasAlg')
 
-// isBichain : a -> Boolean
+/** isBichain :: a -> Boolean */
 function isBichain(m) {
   return hasAlg('bichain', m)
 }

--- a/src/core/isBifunctor.js
+++ b/src/core/isBifunctor.js
@@ -4,7 +4,7 @@
 const hasAlg = require('./hasAlg')
 const isFunctor = require('./isFunctor')
 
-// isBifunctor : a -> Boolean
+/** isBifunctor :: a -> Boolean */
 function isBifunctor(m) {
   return isFunctor(m)
     && hasAlg('bimap', m)

--- a/src/core/isChain.js
+++ b/src/core/isChain.js
@@ -4,7 +4,7 @@
 const hasAlg = require('./hasAlg')
 const isApply = require('./isApply')
 
-// isChain : a -> Boolean
+/** isChain :: a -> Boolean */
 function isChain(m) {
   return isApply(m)
     && hasAlg('chain', m)

--- a/src/core/isContravariant.js
+++ b/src/core/isContravariant.js
@@ -3,7 +3,7 @@
 
 const hasAlg = require('./hasAlg')
 
-// isContravariant : a -> Boolean
+/** isContravariant :: a -> Boolean */
 function isContravariant(m) {
   return !!m && hasAlg('contramap', m)
 }

--- a/src/core/isDate.js
+++ b/src/core/isDate.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2018 original and current authors */
 /** @author Dale Francis (dalefrancis88) */
 
-// isDate : a -> Boolean
+/** isDate :: a -> Boolean */
 function isDate(x) {
   return Object.prototype.toString.apply(x) === '[object Date]'
     && !isNaN(x.valueOf())

--- a/src/core/isExtend.js
+++ b/src/core/isExtend.js
@@ -4,7 +4,7 @@
 const hasAlg = require('./hasAlg')
 const isFunctor = require('./isFunctor')
 
-// isExtend : a -> Boolean
+/** isExtend :: a -> Boolean */
 function isExtend(m) {
   return isFunctor(m)
     && hasAlg('extend', m)

--- a/src/core/isFoldable.js
+++ b/src/core/isFoldable.js
@@ -3,7 +3,7 @@
 
 const hasAlg = require('./hasAlg')
 
-// isFoldable : a -> Boolean
+/** isFoldable :: a -> Boolean */
 function isFoldable(m) {
   return !!m
     && hasAlg('reduce', m)

--- a/src/core/isFunction.js
+++ b/src/core/isFunction.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-// isFunction : a -> Boolean
+/** isFunction :: a -> Boolean */
 function isFunction(fn) {
   return typeof fn === 'function'
 }

--- a/src/core/isFunctor.js
+++ b/src/core/isFunctor.js
@@ -3,7 +3,7 @@
 
 const hasAlg = require('./hasAlg')
 
-// isFunctor : a -> Boolean
+/** isFunctor :: a -> Boolean */
 function isFunctor(m) {
   return !!m && hasAlg('map', m)
 }

--- a/src/core/isInteger.js
+++ b/src/core/isInteger.js
@@ -3,7 +3,7 @@
 
 const isNumber = require('./isNumber')
 
-// isInteger : a -> Boolean
+/** isInteger :: a -> Boolean */
 function isInteger(x) {
   return isNumber(x)
     && isFinite(x)

--- a/src/core/isMonad.js
+++ b/src/core/isMonad.js
@@ -4,7 +4,7 @@
 const hasAlg = require('./hasAlg')
 const isApplicative = require('./isApplicative')
 
-// isMonad : a -> Boolean
+/** isMonad :: a -> Boolean */
 function isMonad(m) {
   return isApplicative(m)
     && hasAlg('chain', m)

--- a/src/core/isMonoid.js
+++ b/src/core/isMonoid.js
@@ -4,7 +4,7 @@
 const hasAlg = require('./hasAlg')
 const isSemigroup = require('./isSemigroup')
 
-// isMonoid :: a -> Boolean
+/** isMonoid :: a -> Boolean */
 function isMonoid(m) {
   return isSemigroup(m)
     && (hasAlg('empty', m) || hasAlg('empty', m.constructor))

--- a/src/core/isNil.js
+++ b/src/core/isNil.js
@@ -3,7 +3,7 @@
 
 /* eslint eqeqeq: "off" */
 
-// isNil : a -> Boolean
+/** isNil :: a -> Boolean */
 function isNil(x) {
   return x == null || x !== x
 }

--- a/src/core/isNumber.js
+++ b/src/core/isNumber.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-// isNumber : a -> Boolean
+/** isNumber :: a -> Boolean */
 function isNumber(x) {
   return typeof x === 'number'
     && !isNaN(x)

--- a/src/core/isObject.js
+++ b/src/core/isObject.js
@@ -3,7 +3,7 @@
 
 const toString = Object.prototype.toString
 
-// isObject : a -> Boolean
+/** isObject :: a -> Boolean */
 function isObject(x) {
   return !!x
     && toString.call(x) === '[object Object]'

--- a/src/core/isPlus.js
+++ b/src/core/isPlus.js
@@ -4,7 +4,7 @@
 const hasAlg = require('./hasAlg')
 const isAlt = require('./isAlt')
 
-// isPlus : a -> Boolean
+/** isPlus :: a -> Boolean */
 function isPlus(m) {
   return isAlt(m)
     && (hasAlg('zero', m) || hasAlg('zero', m.constructor))

--- a/src/core/isPredOrFunc.js
+++ b/src/core/isPredOrFunc.js
@@ -6,7 +6,7 @@ const Pred = require('./types').proxy('Pred')
 const isFunction = require('./isFunction')
 const isSameType = require('./isSameType')
 
-// isPredOrFunc :: ((a -> b) | pred) -> bool
+/** isPredOrFunc :: ((a -> b) | pred) -> bool */
 const isPredOrFunc = predOrFunc =>
   isFunction(predOrFunc) || isSameType(Pred, predOrFunc)
 

--- a/src/core/isProfunctor.js
+++ b/src/core/isProfunctor.js
@@ -5,7 +5,7 @@ const hasAlg = require('./hasAlg')
 const isContravariant = require('./isContravariant')
 const isFunctor = require('./isFunctor')
 
-// isProfunctor :: a -> Boolean
+/** isProfunctor :: a -> Boolean */
 function isProfunctor(m) {
   return isContravariant(m)
     && isFunctor(m)

--- a/src/core/isPromise.js
+++ b/src/core/isPromise.js
@@ -3,7 +3,7 @@
 
 const isFunction = require('./isFunction')
 
-// isPromise : a -> Boolean
+/** isPromise :: a -> Boolean */
 function isPromise(p) {
   return !!p
     && isFunction(p.then)

--- a/src/core/isSame.js
+++ b/src/core/isSame.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-// isSame : (a, b) -> Boolean
+/** isSame :: (a, b) -> Boolean */
 function isSame(x, y) {
   if(x === y) {
     return x !== 0 || 1 / x === 1 / y

--- a/src/core/isSameType.js
+++ b/src/core/isSameType.js
@@ -5,7 +5,7 @@ const curry = require('./curry')
 const isFunction = require('./isFunction')
 const type = require('./type')
 
-// isSameType :: Container m => (m, m) -> Boolean
+/** isSameType :: Container m => (m, m) -> Boolean */
 function isSameType(x, y) {
   const tX = type(x)
   const tY = type(y)

--- a/src/core/isSemigroup.js
+++ b/src/core/isSemigroup.js
@@ -4,7 +4,7 @@
 const isString = require('./isString')
 const hasAlg = require('./hasAlg')
 
-// isSemigroup : a -> Boolean
+/** isSemigroup :: a -> Boolean */
 function isSemigroup(m) {
   return isString(m)
     || !!m && hasAlg('concat', m)

--- a/src/core/isSemigroupoid.js
+++ b/src/core/isSemigroupoid.js
@@ -3,7 +3,7 @@
 
 const hasAlg = require('./hasAlg')
 
-// isSemigroupoid : a -> Boolean
+/** isSemigroupoid :: a -> Boolean */
 function isSemigroupoid(m) {
   return !!m && hasAlg('compose', m)
 }

--- a/src/core/isString.js
+++ b/src/core/isString.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2016 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-// isString : a -> Boolean
+/** isString :: a -> Boolean */
 function isString(x) {
   return typeof x === 'string'
 }

--- a/src/core/isSymbol.js
+++ b/src/core/isSymbol.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2018 original and current authors */
 /** @author Robert Pearce (rpearce) */
 
-// isSymbol : a -> Boolean
+/** isSymbol :: a -> Boolean */
 function isSymbol(x) {
   return typeof x === 'symbol'
 }

--- a/src/core/mconcatMap.js
+++ b/src/core/mconcatMap.js
@@ -6,7 +6,7 @@ const compose = require('./compose')
 const foldWith =
   m => (x, y) => x.concat(m(y))
 
-// mconcatMap :: Monoid M => M -> (b -> a) -> ([ b ] | List b) -> M a
+/** mconcatMap :: Monoid M => M -> (b -> a) -> ([ b ] | List b) -> M a */
 function mconcatMap(M, f, xs) {
   return xs.reduce(foldWith(compose(M, f)), M.empty())
 }

--- a/src/core/once.js
+++ b/src/core/once.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-// once : ((*) -> b) -> ((*) -> b)
+/** once :: ((*) -> b) -> ((*) -> b) */
 function once(fn) {
   var called, result
 

--- a/src/helpers/assign.js
+++ b/src/helpers/assign.js
@@ -5,7 +5,7 @@ const curry = require('../core/curry')
 const isObject = require('../core/isObject')
 const object = require('../core/object')
 
-// assign : Object -> Object -> Object
+/** assign :: Object -> Object -> Object */
 function assign(x, m) {
   if(!(isObject(x) && isObject(m))) {
     throw new TypeError('assign: Objects required for both arguments')

--- a/src/helpers/binary.js
+++ b/src/helpers/binary.js
@@ -4,7 +4,7 @@
 const curryN = require('../core/curryN')
 const isFunction = require('../core/isFunction')
 
-// binary : (* -> c) -> a -> b -> c
+/** binary :: (* -> c) -> a -> b -> c */
 function binary(fn) {
   if(!isFunction(fn)) {
     throw new TypeError('binary: Function required')

--- a/src/helpers/compose.js
+++ b/src/helpers/compose.js
@@ -14,7 +14,7 @@ function applyPipe(f, g) {
     g.call(null, f.apply(null, args))
 }
 
-// compose : ((y -> z), (x -> y), ..., (a -> b)) -> a -> z
+/** compose :: ((y -> z), (x -> y), ..., (a -> b)) -> a -> z */
 function compose(...args) {
   if(!arguments.length) {
     throw new TypeError(err)

--- a/src/helpers/composeK.js
+++ b/src/helpers/composeK.js
@@ -6,7 +6,7 @@ const isFunction = require('../core/isFunction')
 
 const err = 'composeK: Chain returning functions of the same type required'
 
-// composeK : Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> a -> m z
+/** composeK :: Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> a -> m z */
 function composeK(...args) {
   if(!arguments.length) {
     throw new TypeError(err)

--- a/src/helpers/composeS.js
+++ b/src/helpers/composeS.js
@@ -6,7 +6,7 @@ const isSemigroupoid = require('../core/isSemigroupoid')
 
 const err = 'composeS: Semigroupoids of the same type required'
 
-// composeS : Semigroupoid s => (s y z, s x y, ..., s a b) -> s a z
+/** composeS :: Semigroupoid s => (s y z, s x y, ..., s a b) -> s a z */
 function composeS(...args) {
   if(!arguments.length) {
     throw new TypeError(err)

--- a/src/helpers/curry.js
+++ b/src/helpers/curry.js
@@ -4,7 +4,7 @@
 const _curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
 
-// curry : ((a, b, c) -> d) -> a -> b -> c -> d
+/** curry :: ((a, b, c) -> d) -> a -> b -> c -> d */
 function curry(fn) {
   if(!isFunction(fn)) {
     throw new TypeError('curry: Function required')

--- a/src/helpers/defaultProps.js
+++ b/src/helpers/defaultProps.js
@@ -5,7 +5,7 @@ const curry = require('../core/curry')
 const isObject = require('../core/isObject')
 const object = require('../core/object')
 
-// defaultProps : Object -> Object -> Object
+/** defaultProps :: Object -> Object -> Object */
 function defaultProps(x, m) {
   if(!isObject(x) || !isObject(m)) {
     throw new TypeError('defaultProps: Objects required for both arguments')

--- a/src/helpers/defaultTo.js
+++ b/src/helpers/defaultTo.js
@@ -4,7 +4,7 @@
 const curry = require('../core/curry')
 const isNil = require('../core/isNil')
 
-// defaultTo : a -> b -> (a | b)
+/** defaultTo :: a -> b -> (a | b) */
 function defaultTo(def, val) {
   return isNil(val) ? def : val
 }

--- a/src/helpers/fromPairs.js
+++ b/src/helpers/fromPairs.js
@@ -24,7 +24,7 @@ function foldPairs(acc, pair) {
     : acc
 }
 
-// fromPairs : Foldable f => f (Pair String a) -> Object
+/** fromPairs :: Foldable f => f (Pair String a) -> Object */
 function fromPairs(xs) {
   if(!isFoldable(xs)) {
     throw new TypeError('fromPairs: Foldable of Pairs required for argument')

--- a/src/helpers/getPathOr.js
+++ b/src/helpers/getPathOr.js
@@ -47,7 +47,7 @@ function fn(name) {
   return curry(getPathOr)
 }
 
-// getPathOr :: a -> [ String | Integer ] -> b -> c
+/** getPathOr :: a -> [ String | Integer ] -> b -> c */
 const getPathOr =
   fn('getPathOr')
 

--- a/src/helpers/getPropOr.js
+++ b/src/helpers/getPropOr.js
@@ -28,7 +28,7 @@ function fn(name) {
   return curry(getPropOr)
 }
 
-// getPropOr : a -> (String | Integer) -> b -> c
+/** getPropOr :: a -> (String | Integer) -> b -> c */
 const getPropOr =
   fn('getPropOr')
 

--- a/src/helpers/liftA2.js
+++ b/src/helpers/liftA2.js
@@ -11,7 +11,7 @@ const isSameType = require('../core/isSameType')
 const map = array.map
 const ap = array.ap
 
-// liftA2 :: Applicative m => (a -> b -> c) -> m a -> m b -> m c
+/** liftA2 :: Applicative m => (a -> b -> c) -> m a -> m b -> m c */
 function liftA2(fn, x, y) {
   if(!isFunction(fn)) {
     throw new TypeError('liftA2: Function required for first argument')

--- a/src/helpers/liftA3.js
+++ b/src/helpers/liftA3.js
@@ -11,7 +11,7 @@ const isSameType = require('../core/isSameType')
 const map = array.map
 const ap = array.ap
 
-// liftA3 :: Applicative m => (a -> b -> c -> d) -> m a -> m b -> m c -> m d
+/** liftA3 :: Applicative m => (a -> b -> c -> d) -> m a -> m b -> m c -> m d */
 function liftA3(fn, x, y, z) {
   if(!isFunction(fn)) {
     throw new TypeError('liftA3: Function required for first argument')

--- a/src/helpers/mapProps.js
+++ b/src/helpers/mapProps.js
@@ -6,7 +6,7 @@ const isObject = require('../core/isObject')
 const isFunction = require('../core/isFunction')
 const isNil = require('../core/isNil')
 
-// applyMap :: ({ (* -> *) }, Object) -> (Object , String) -> Object
+/** applyMap :: ({ (* -> *) }, Object) -> (Object , String) -> Object */
 const applyMap = (fns, obj) =>
   function(acc, key) {
     if(isNil(fns[key])) {
@@ -28,7 +28,7 @@ const applyMap = (fns, obj) =>
     })
   }
 
-// mapProps :: { (* -> *) } -> Object -> Object
+/** mapProps :: { (* -> *) } -> Object -> Object */
 function mapProps(fns, obj) {
   if(!(isObject(fns) && isObject(obj))) {
     throw new TypeError('mapProps: Objects required for both arguments')

--- a/src/helpers/mconcat.js
+++ b/src/helpers/mconcat.js
@@ -8,7 +8,7 @@ const mconcatMap = require('../core/mconcatMap')
 
 const identity = x => x
 
-// mconcat : Monoid m => m -> ([ a ] | List a) -> m a
+/** mconcat :: Monoid m => m -> ([ a ] | List a) -> m a */
 function mconcat(m, xs) {
   if(!isMonoid(m)) {
     throw new TypeError(

--- a/src/helpers/mconcatMap.js
+++ b/src/helpers/mconcatMap.js
@@ -7,7 +7,7 @@ const isFoldable = require('../core/isFoldable')
 const isFunction = require('../core/isFunction')
 const isMonoid = require('../core/isMonoid')
 
-// mconcatMap : Monoid M => M -> (b -> a) -> ([ b ] | List b) -> M a
+/** mconcatMap :: Monoid M => M -> (b -> a) -> ([ b ] | List b) -> M a */
 function mconcatMap(m, f, xs) {
   if(!isMonoid(m)) {
     throw new TypeError(

--- a/src/helpers/mreduce.js
+++ b/src/helpers/mreduce.js
@@ -8,7 +8,7 @@ const mconcatMap = require('../core/mconcatMap')
 
 const identity = x => x
 
-// mreduce : Monoid M => M -> ([ a ] | List a) -> a
+/** mreduce :: Monoid M => M -> ([ a ] | List a) -> a */
 function mreduce(m, xs) {
   if(!isMonoid(m)) {
     throw new TypeError(

--- a/src/helpers/mreduceMap.js
+++ b/src/helpers/mreduceMap.js
@@ -7,7 +7,7 @@ const isFunction = require('../core/isFunction')
 const isMonoid = require('../core/isMonoid')
 const mconcatMap = require('../core/mconcatMap')
 
-// mreduceMap :: Monoid M => M -> (b -> a) -> ( [ b ] | List b ) -> a
+/** mreduceMap :: Monoid M => M -> (b -> a) -> ( [ b ] | List b ) -> a */
 function mreduceMap(m, f, xs) {
   if(!isMonoid(m)) {
     throw new TypeError(

--- a/src/helpers/nAry.js
+++ b/src/helpers/nAry.js
@@ -6,7 +6,7 @@ const curryN = require('../core/curryN')
 const isFunction = require('../core/isFunction')
 const isNumber = require('../core/isNumber')
 
-// nAry : Number -> (* -> a) -> * -> * -> a
+/** nAry :: Number -> (* -> a) -> * -> * -> a */
 function nAry(num, fn) {
   if(!isNumber(num)) {
     throw new TypeError('nAry: Number required for first argument')

--- a/src/helpers/objOf.js
+++ b/src/helpers/objOf.js
@@ -4,7 +4,7 @@
 const curry = require('../core/curry')
 const isString = require('../core/isString')
 
-// objOf : String -> a -> Object
+/** objOf :: String -> a -> Object */
 function objOf(key, value) {
   if(!(key && isString(key))) {
     throw new TypeError('objOf: Non-empty String required for first argument')

--- a/src/helpers/omit.js
+++ b/src/helpers/omit.js
@@ -13,7 +13,7 @@ function omitKeys(keys, obj) {
   }
 }
 
-// omit : [ String ] -> Object -> Object
+/** omit :: [ String ] -> Object -> Object */
 function omit(keys, obj) {
   if(!isFoldable(keys)) {
     throw new TypeError('omit: Foldable required for first argument')

--- a/src/helpers/once.js
+++ b/src/helpers/once.js
@@ -4,7 +4,7 @@
 const isFunction = require('../core/isFunction')
 const _once = require('../core/once')
 
-// once : ((*) -> b) -> ((*) -> b)
+/** once :: ((*) -> b) -> ((*) -> b) */
 function once(fn) {
   if(!isFunction(fn)) {
     throw new TypeError('once: Function required')

--- a/src/helpers/partial.js
+++ b/src/helpers/partial.js
@@ -4,7 +4,7 @@
 const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
 
-// partial : ((* -> c), *) -> * -> c
+/** partial :: ((* -> c), *) -> * -> c */
 function partial(...args) {
   const fn = args[0]
   const xs = args.slice(1)

--- a/src/helpers/pick.js
+++ b/src/helpers/pick.js
@@ -17,7 +17,7 @@ function pickKeys(obj) {
   }
 }
 
-// pick : ([ String ] | List String) -> Object -> Object
+/** pick :: ([ String ] | List String) -> Object -> Object */
 function pick(keys, obj) {
   if(!isFoldable(keys)) {
     throw new TypeError('pick: Foldable required for first argument')

--- a/src/helpers/pipe.js
+++ b/src/helpers/pipe.js
@@ -15,7 +15,7 @@ function applyPipe(f, g) {
   }
 }
 
-// pipe : ((a -> b), (b -> c), ..., (y -> z)) -> a -> z
+/** pipe :: ((a -> b), (b -> c), ..., (y -> z)) -> a -> z */
 function pipe(...fns) {
   if(!arguments.length) {
     throw new TypeError(err)

--- a/src/helpers/pipeP.js
+++ b/src/helpers/pipeP.js
@@ -22,7 +22,7 @@ function applyPipe(f, g) {
   }
 }
 
-// pipeP : Promise p => ((a -> p b), (b -> p c), ..., (y -> p z)) -> a -> p z
+/** pipeP :: Promise p => ((a -> p b), (b -> p c), ..., (y -> p z)) -> a -> p z */
 function pipeP(...fns) {
   if(!arguments.length) {
     throw new TypeError(err)

--- a/src/helpers/pipeS.js
+++ b/src/helpers/pipeS.js
@@ -6,7 +6,7 @@ const isSemigroupoid = require('../core/isSemigroupoid')
 
 const err = 'pipeS: Semigroupoids of the same type required'
 
-// pipeS : Semigroupoid s => (s a b, s b c, ..., s y z) -> s a z
+/** pipeS :: Semigroupoid s => (s a b, s b c, ..., s y z) -> s a z */
 function pipeS(...ms) {
   if(!arguments.length) {
     throw new TypeError(err)

--- a/src/helpers/setPath.js
+++ b/src/helpers/setPath.js
@@ -16,7 +16,7 @@ const isValid = x =>
 const pathErr =
   'setPath: Non-empty Array of non-empty Strings and/or Positive Integers required for first argument'
 
-// setPath :: [ String | Integer ] -> a -> (Object | Array) -> (Object | Array)
+/** setPath :: [ String | Integer ] -> a -> (Object | Array) -> (Object | Array) */
 function setPath(path, val, obj) {
   if(!isArray(path) || isEmpty(path)) {
     throw new TypeError(pathErr)

--- a/src/helpers/setProp.js
+++ b/src/helpers/setProp.js
@@ -40,7 +40,7 @@ function fn(name) {
   return curry(setProp)
 }
 
-// setProp :: (String | Integer) -> a -> (Object | Array) -> (Object | Array)
+/** setProp :: (String | Integer) -> a -> (Object | Array) -> (Object | Array) */
 const setProp =
   fn('setProp')
 

--- a/src/helpers/tap.js
+++ b/src/helpers/tap.js
@@ -7,7 +7,7 @@ const isFunction = require('../core/isFunction')
 
 const constant = x => () => x
 
-// tap : (a -> b) -> a -> a
+/** tap :: (a -> b) -> a -> a */
 function tap(fn, x) {
   if(!isFunction(fn)) {
     throw new TypeError(

--- a/src/helpers/unary.js
+++ b/src/helpers/unary.js
@@ -3,7 +3,7 @@
 
 const isFunction = require('../core/isFunction')
 
-// unary : (* -> b) -> a -> b
+/** unary :: (* -> b) -> a -> b */
 function unary(fn) {
   if(!isFunction(fn)) {
     throw new TypeError('unary: Function required')

--- a/src/helpers/unsetPath.js
+++ b/src/helpers/unsetPath.js
@@ -14,7 +14,7 @@ const object = require('../core/object')
 const pathError =
   'unsetPath: Non-empty Array of non-empty Strings and/or Positive Integers required for first argument'
 
-// unsetPath :: [ String | Integer ] -> a -> a
+/** unsetPath :: [ String | Integer ] -> a -> a */
 function unsetPath(path, obj) {
   if(!isArray(path) || isEmpty(path)) {
     throw new TypeError(pathError)

--- a/src/logic/and.js
+++ b/src/logic/and.js
@@ -5,7 +5,7 @@ const curry = require('../core/curry')
 const isPredOrFunc = require('../core/isPredOrFunc')
 const predOrFunc = require('../core/predOrFunc')
 
-// and : (a -> Boolean) | Pred -> (a -> Boolean) | Pred -> a -> Boolean
+/** and :: (a -> Boolean) | Pred -> (a -> Boolean) | Pred -> a -> Boolean */
 function and(f, g) {
   if(!(isPredOrFunc(f) && isPredOrFunc(g))) {
     throw new TypeError(

--- a/src/logic/ifElse.js
+++ b/src/logic/ifElse.js
@@ -6,7 +6,7 @@ const isFunction = require('../core/isFunction')
 const isPredOrFunc = require('../core/isPredOrFunc')
 const predOrFunc = require('../core/predOrFunc')
 
-// ifElse : (a -> Boolean) | Pred -> (a -> b) -> (a -> c) -> a -> (a | c)
+/** ifElse :: (a -> Boolean) | Pred -> (a -> b) -> (a -> c) -> a -> (a | c) */
 function ifElse(pred, f, g) {
   if(!isPredOrFunc(pred)) {
     throw new TypeError(

--- a/src/logic/implies.js
+++ b/src/logic/implies.js
@@ -5,7 +5,7 @@ const curry = require('../core/curry')
 const isPredOrFunc = require('../core/isPredOrFunc')
 const predOrFunc = require('../core/predOrFunc')
 
-// implies :: (a -> Boolean) | Pred -> (a -> Boolean) -> a -> Boolean
+/** implies :: (a -> Boolean) | Pred -> (a -> Boolean) -> a -> Boolean */
 function implies(p, q) {
   if(!(isPredOrFunc(p) && isPredOrFunc(q))) {
     throw new TypeError(

--- a/src/logic/not.js
+++ b/src/logic/not.js
@@ -5,7 +5,7 @@ const curry = require('../core/curry')
 const isPredOrFunc = require('../core/isPredOrFunc')
 const predOrFunc = require('../core/predOrFunc')
 
-// not : (a -> Boolean) | Pred -> a -> Boolean
+/** not :: (a -> Boolean) | Pred -> a -> Boolean */
 function not(pred, x) {
   if(!isPredOrFunc(pred)) {
     throw new TypeError(

--- a/src/logic/or.js
+++ b/src/logic/or.js
@@ -5,7 +5,7 @@ const curry = require('../core/curry')
 const isPredOrFunc = require('../core/isPredOrFunc')
 const predOrFunc = require('../core/predOrFunc')
 
-// or : (a -> Boolean) | Pred -> (a -> Boolean) | Pred -> a -> Boolean
+/** or :: (a -> Boolean) | Pred -> (a -> Boolean) | Pred -> a -> Boolean */
 function or(f, g) {
   if(!(isPredOrFunc(f) && isPredOrFunc(g))) {
     throw new TypeError(

--- a/src/logic/unless.js
+++ b/src/logic/unless.js
@@ -6,7 +6,7 @@ const isPredOrFunc = require('../core/isPredOrFunc')
 const isFunction = require('../core/isFunction')
 const predOrFunc = require('../core/predOrFunc')
 
-// unless : (a -> Boolean) | Pred -> (a -> b) -> a | b
+/** unless :: (a -> Boolean) | Pred -> (a -> b) -> a | b */
 function unless(pred, f) {
   if(!isPredOrFunc(pred)) {
     throw new TypeError(

--- a/src/logic/when.js
+++ b/src/logic/when.js
@@ -6,7 +6,7 @@ const predOrFunc = require('../core/predOrFunc')
 const isPredOrFunc = require('../core/isPredOrFunc')
 const isFunction = require('../core/isFunction')
 
-// when : (a -> Boolean) | Pred -> (a -> b) -> a -> b | a
+/** when :: (a -> Boolean) | Pred -> (a -> b) -> a -> b | a */
 function when(pred, f) {
   if(!isPredOrFunc(pred)) {
     throw new TypeError(

--- a/src/pointfree/alt.js
+++ b/src/pointfree/alt.js
@@ -6,7 +6,7 @@ const fl = require('../core/flNames')
 const isAlt = require('../core/isAlt')
 const isSameType = require('../core/isSameType')
 
-// alt : Alt m => m a -> m a -> m a
+/** alt :: Alt m => m a -> m a -> m a */
 function alt(m, x) {
   if(!(isAlt(m) && isSameType(m, x))) {
     throw new TypeError(

--- a/src/pointfree/ap.js
+++ b/src/pointfree/ap.js
@@ -7,7 +7,7 @@ const isApplicative = require('../core/isApplicative')
 const isArray = require('../core/isArray')
 const isSameType = require('../core/isSameType')
 
-// ap :: Applicative m => m a -> m (a -> b) ->  m b
+/** ap :: Applicative m => m a -> m (a -> b) ->  m b */
 function ap(m, x) {
   if(!((isApplicative(m) || isArray(m)) && isSameType(m, x))) {
     throw new TypeError('ap: Both arguments must be Applys of the same type')

--- a/src/pointfree/bichain.js
+++ b/src/pointfree/bichain.js
@@ -4,7 +4,7 @@
 const curry = require('../core/curry')
 const isFunction = require('../core/isFunction')
 
-// bichain : bichain m => (e -> m c b) -> (a -> m c b) -> m e a -> m c b
+/** bichain :: bichain m => (e -> m c b) -> (a -> m c b) -> m e a -> m c b */
 function bichain(f, g, m) {
   if(!isFunction(f) || !isFunction(g)) {
     throw new TypeError('bichain: First two arguments must be Sum Type returning functions')

--- a/src/pointfree/chain.js
+++ b/src/pointfree/chain.js
@@ -8,7 +8,7 @@ const isChain = require('../core/isChain')
 const isFunction = require('../core/isFunction')
 const fl = require('../core/flNames')
 
-// chain : Chain m => (a -> m b) -> m a -> m b
+/** chain :: Chain m => (a -> m b) -> m a -> m b */
 function chain(fn, m) {
   if(!isFunction(fn)) {
     throw new TypeError('chain: Chain returning function required for first argument')

--- a/src/pointfree/contramap.js
+++ b/src/pointfree/contramap.js
@@ -7,7 +7,7 @@ const isFunction = require('../core/isFunction')
 const isContravariant = require('../core/isContravariant')
 const fl = require('../core/flNames')
 
-// contramap : Functor f => (b -> a) -> f b -> f a
+/** contramap :: Functor f => (b -> a) -> f b -> f a */
 function contramap(fn, m) {
   if(!isFunction(fn)) {
     throw new TypeError(

--- a/src/pointfree/extend.js
+++ b/src/pointfree/extend.js
@@ -6,7 +6,7 @@ const fl = require('../core/flNames')
 const isExtend = require('../core/isExtend')
 const isFunction = require('../core/isFunction')
 
-// extend : Extend w => (w a -> b) -> w a -> w b
+/** extend :: Extend w => (w a -> b) -> w a -> w b */
 function extend(fn, m) {
   if(!isFunction(fn)) {
     throw new TypeError('extend: Function required for first argument')

--- a/src/pointfree/filter.js
+++ b/src/pointfree/filter.js
@@ -9,7 +9,7 @@ const isObject = require('../core/isObject')
 const object = require('../core/object')
 const predOrFunc = require('../core/predOrFunc')
 
-// filter : Filterable f => (a -> Boolean) -> f a -> f a
+/** filter :: Filterable f => (a -> Boolean) -> f a -> f a */
 function filter(pred, m) {
   if(!isPredOrFunc(pred)) {
     throw new TypeError('filter: Pred or predicate function required for first argument')

--- a/src/pointfree/fold.js
+++ b/src/pointfree/fold.js
@@ -6,7 +6,7 @@ const _array = require('../core/array')
 const isArray = require('../core/isArray')
 const isFunction = require('../core/isFunction')
 
-// fold : Foldable f, Semigroup s => f s -> s
+/** fold :: Foldable f, Semigroup s => f s -> s */
 function fold(m) {
   if(isArray(m)) {
     return _array.fold(m)

--- a/src/pointfree/foldMap.js
+++ b/src/pointfree/foldMap.js
@@ -7,7 +7,7 @@ const curry = require('../core/curry')
 const isArray = require('../core/isArray')
 const isFunction = require('../core/isFunction')
 
-// foldMap :: Foldable f, Semigroup s => (a -> s) -> f a -> s
+/** foldMap :: Foldable f, Semigroup s => (a -> s) -> f a -> s */
 function foldMap(fn, m) {
   if(!isFunction(fn)) {
     throw new TypeError(

--- a/src/pointfree/map.js
+++ b/src/pointfree/map.js
@@ -12,7 +12,7 @@ const array = require('../core/array')
 const object = require('../core/object')
 const fl = require('../core/flNames')
 
-// map : Functor f => (a -> b) -> f a -> f b
+/** map :: Functor f => (a -> b) -> f a -> f b */
 function map(fn, m) {
   if(!isFunction(fn)) {
     throw new TypeError('map: Function required for first argument')

--- a/src/pointfree/reject.js
+++ b/src/pointfree/reject.js
@@ -12,7 +12,7 @@ const predOrFunc = require('../core/predOrFunc')
 const not =
   fn => x => !fn(x)
 
-// reject : Foldable f => (a -> Boolean) -> f a -> f a
+/** reject :: Foldable f => (a -> Boolean) -> f a -> f a */
 function reject(pred, m) {
   if(!isPredOrFunc(pred)) {
     throw new TypeError(

--- a/src/predicates/hasProp.js
+++ b/src/predicates/hasProp.js
@@ -8,7 +8,7 @@ const isInteger = require('../core/isInteger')
 const isNil = require('../core/isNil')
 const isString = require('../core/isString')
 
-// hasProp : (String | Integer) -> a -> Boolean
+/** hasProp :: (String | Integer) -> a -> Boolean */
 function hasProp(key, x) {
   if(!(isString(key) && !isEmpty(key) || isInteger(key))) {
     throw new TypeError(

--- a/src/predicates/hasPropPath.js
+++ b/src/predicates/hasPropPath.js
@@ -9,7 +9,7 @@ const isInteger = require('../core/isInteger')
 const isNil = require('../core/isNil')
 const isString = require('../core/isString')
 
-// hasPropPath : [ String | Integer ] -> a -> Boolean
+/** hasPropPath :: [ String | Integer ] -> a -> Boolean */
 function hasPropPath(keys, target) {
   if(!isArray(keys)) {
     throw new TypeError(

--- a/src/predicates/hasProps.js
+++ b/src/predicates/hasProps.js
@@ -9,15 +9,15 @@ const isInteger = require('../core/isInteger')
 const isNil = require('../core/isNil')
 const isString = require('../core/isString')
 
-// err :: String
+/** err :: String */
 const err =
   'hasProps: First argument must be a Foldable of Non-empty Strings or Integers'
 
-// isKeyValid :: a -> Boolean
+/** isKeyValid :: a -> Boolean */
 const isKeyValid = key =>
   isString(key) && !isEmpty(key) || isInteger(key)
 
-// hasKey :: a -> (String | Integer) -> Boolean
+/** hasKey :: a -> (String | Integer) -> Boolean */
 const hasKey = obj => key => {
   if(!isKeyValid(key)) {
     throw new TypeError(err)
@@ -26,11 +26,11 @@ const hasKey = obj => key => {
   return isDefined(obj[key])
 }
 
-// every :: (a -> Boolean) -> ((Null | Boolean), a) -> Boolean
+/** every :: (a -> Boolean) -> ((Null | Boolean), a) -> Boolean */
 const every = fn => (acc, x) =>
   (acc === null ? true : acc) && fn(x)
 
-// hasProps :: Foldable f => f (String | Integer) -> a -> Boolean
+/** hasProps :: Foldable f => f (String | Integer) -> a -> Boolean */
 function hasProps(keys, x) {
   if(!isFoldable(keys)) {
     throw new TypeError(err)

--- a/src/predicates/isAlternative.js
+++ b/src/predicates/isAlternative.js
@@ -4,7 +4,7 @@
 const isApplicative = require('../core/isApplicative')
 const isPlus = require('../core/isPlus')
 
-// isAlternative : a -> Boolean
+/** isAlternative :: a -> Boolean */
 function isAlternative(m) {
   return isPlus(m)
     && isApplicative(m)

--- a/src/predicates/isBoolean.js
+++ b/src/predicates/isBoolean.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2017 original and current authors */
 /** @author Ian Hofmann-Hicks (evil) */
 
-// isBoolean : a -> Boolean
+/** isBoolean :: a -> Boolean */
 function isBoolean(x) {
   return typeof x === 'boolean'
 }

--- a/src/predicates/isCategory.js
+++ b/src/predicates/isCategory.js
@@ -4,7 +4,7 @@
 const hasAlg = require('../core/hasAlg')
 const isSemigroupoid = require('../core/isSemigroupoid')
 
-// isCategory : a -> Boolean
+/** isCategory :: a -> Boolean */
 function isCategory(m) {
   return isSemigroupoid(m)
     && (hasAlg('id', m) || hasAlg('id', m.constructor))

--- a/src/predicates/isFalse.js
+++ b/src/predicates/isFalse.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2019 original and current authors */
 /** @author Dale Francis (dalefrancis88) */
 
-// isFalse : a -> Boolean
+/** isFalse :: a -> Boolean */
 function isFalse(x) {
   return x === false
 }

--- a/src/predicates/isFalsy.js
+++ b/src/predicates/isFalsy.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2019 original and current authors */
 /** @author Dale Francis (dalefrancis88) */
 
-// isFalsy : a -> Boolean
+/** isFalsy :: a -> Boolean */
 function isFalsy(x) {
   return !x
 }

--- a/src/predicates/isSetoid.js
+++ b/src/predicates/isSetoid.js
@@ -3,7 +3,7 @@
 
 const hasAlg = require('../core/hasAlg')
 
-// isSetoid : a -> Boolean
+/** isSetoid :: a -> Boolean */
 function isSetoid(m) {
   return !!m
     && hasAlg('equals', m)

--- a/src/predicates/isTraversable.js
+++ b/src/predicates/isTraversable.js
@@ -4,7 +4,7 @@
 const hasAlg = require('../core/hasAlg')
 const isFunctor = require('../core/isFunctor')
 
-// isTraversable : a -> Boolean
+/** isTraversable :: a -> Boolean */
 function isTraversable(m) {
   return isFunctor(m)
     && hasAlg('traverse', m)

--- a/src/predicates/isTrue.js
+++ b/src/predicates/isTrue.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2019 original and current authors */
 /** @author Dale Francis (dalefrancis88) */
 
-// isTrue : a -> Boolean
+/** isTrue :: a -> Boolean */
 function isTrue(x) {
   return x === true
 }

--- a/src/predicates/isTruthy.js
+++ b/src/predicates/isTruthy.js
@@ -1,7 +1,7 @@
 /** @license ISC License (c) copyright 2019 original and current authors */
 /** @author Dale Francis (dalefrancis88) */
 
-// isTruthy : a -> Boolean
+/** isTruthy :: a -> Boolean */
 function isTruthy(x) {
   return !!x
 }

--- a/src/predicates/pathEq.js
+++ b/src/predicates/pathEq.js
@@ -15,7 +15,7 @@ const err = name =>
   `${name}: First argument must be an Array of non-empty Strings or Integers`
 
 function fn(name) {
-  // pathEq :: [ String | Number ] -> a -> Object -> Boolean
+  /** pathEq :: [ String | Number ] -> a -> Object -> Boolean */
   function pathEq(keys, value, target) {
     if(!isArray(keys)) {
       throw new TypeError(err(name))


### PR DESCRIPTION
This PR is the first step in #446 

It converts all currently present inline type signature comments to block format

This is an entirely mechanical transformation, using two regexps:

```vim
s/\/\/ ([^\s]+) : (.*)/\/** $1 :: $2 *\//g
s/\/\/ ([^\s]+) :: (.*)/\/** $1 :: $2 *\//g
```
