### PR TITLE
Update example in contramap on Arrow

### DIFF
--- a/docs/src/pages/docs/crocks/Arrow.md
+++ b/docs/src/pages/docs/crocks/Arrow.md
@@ -292,7 +292,7 @@ arrAdd10Value
 //=> 10
 
 arrAdd10Value
-  .runWith({ num: '23' })
+  .runWith({ num: 23 })
 //=> 10
 ```
 


### PR DESCRIPTION
In the docs the property num had the same type as the example above.
The change makes clear the contramap is not working on a different property either instead of the type