### PR TITLE
doc(either): update setPassed example in Left either function

### DIFF
--- a/docs/src/pages/docs/crocks/Either.md
+++ b/docs/src/pages/docs/crocks/Either.md
@@ -640,7 +640,7 @@ setPassed(Right({ a: 'awesome' }))
 //=> Right { a: "awesome", passed: true }
 
 setPassed(Left({ a: 'not so much' }))
-//=> Left { error: "not so much", passed: false }
+//=> Left { error: { a: "not so much" }, passed: false }
 
 // process :: a -> Either Object Object
 const process =


### PR DESCRIPTION
In case of a Left the object is added as the value of error instead of the value of the property 'a' transferred to 'error'