### PR TITLE
Output result not correct

### DIFF
--- a/docs/src/pages/docs/crocks/Identity.md
+++ b/docs/src/pages/docs/crocks/Identity.md
@@ -334,6 +334,11 @@ import Identity from 'crocks/Identity'
 Identity(42)
   .valueOf()
 //=> 42
+
+Identity([10,20])
+  .concat(Identity([30,40]))
+  .valueOf()
+//=>[ 10, 20, 30, 40 ]
 ```
 
 </article>

--- a/docs/src/pages/docs/crocks/Identity.md
+++ b/docs/src/pages/docs/crocks/Identity.md
@@ -335,8 +335,8 @@ Identity(42)
   .valueOf()
 //=> 42
 
-Identity([10,20])
-  .concat(Identity([30,40]))
+Identity([ 10, 20 ])
+  .concat(Identity([ 30, 40 ]))
   .valueOf()
 //=>[ 10, 20, 30, 40 ]
 ```

--- a/docs/src/pages/docs/crocks/Identity.md
+++ b/docs/src/pages/docs/crocks/Identity.md
@@ -333,12 +333,7 @@ import Identity from 'crocks/Identity'
 
 Identity(42)
   .valueOf()
-//=> 33
-
-Identity(20)
-  .concat(Identity(22))
-  .valueOf()
-//=> 35
+//=> 42
 ```
 
 </article>


### PR DESCRIPTION
Identity(42)
  .valueOf()
//=> 42 (Must be 42) not 33

Remove following lines

Identity(20)
  .concat(Identity(22))
  .valueOf()
//=> 35

due to this error message. Throwing error "TypeError: Identity.concat: Both containers must contain Semigroups of the same type"