### PR TITLE
Expose a length property for curried functions

### DIFF
--- a/src/core/curry.js
+++ b/src/core/curry.js
@@ -43,6 +43,12 @@ function curry(fn) {
     value: true
   })
 
+  Object.defineProperty(curried, 'length', {
+    enumerable: false,
+    writable: false,
+    value: fn.length
+  })
+
   return curried
 }
 

--- a/src/core/curry.spec.js
+++ b/src/core/curry.spec.js
@@ -78,3 +78,11 @@ test('curry on a curried function', t => {
 
   t.end()
 })
+
+test('curried function with arity exposed', t => {
+  const fn = (a, b) => a + b
+  const curried = curry(fn)
+  t.equal(curried.length, fn.length, 'returns the same arity as its uncurried counterpart')
+
+  t.end()
+})


### PR DESCRIPTION
While working through a first-pass on what `Async.fromNode` might look like with its incoming parameter curried (see #478), I noticed that I was unable to check for a length on incoming curried functions.

With this change in place the code for allowing curried functions with `Async.fromNode` passes the tests.

What do you think about this change to `curry` where we expose the length on `curried` of the original `fn` that was passed in?