### PR TITLE
Fix instance typos in error messages

### DIFF
--- a/src/List/maybeToList.js
+++ b/src/List/maybeToList.js
@@ -15,7 +15,7 @@ const applyTransform = maybe =>
   )
 
 const err =
-  'maybeToList: Argument must be a Maybe instanstace or a Maybe returning function'
+  'maybeToList: Argument must be a Maybe instance or a Maybe returning function'
 
 /** maybeToList :: Maybe a -> List a */
 /** maybeToList :: (a -> Maybe b) -> a -> List b */

--- a/src/List/maybeToList.spec.js
+++ b/src/List/maybeToList.spec.js
@@ -18,7 +18,7 @@ test('maybeToList transform', t => {
 
   t.ok(isFunction(maybeToList), 'is a function')
 
-  const err = /maybeToList: Argument must be a Maybe instanstace or a Maybe returning function/
+  const err = /maybeToList: Argument must be a Maybe instance or a Maybe returning function/
   t.throws(f(undefined), err, 'throws if first arg is undefined')
   t.throws(f(null), err, 'throws if first arg is null')
   t.throws(f(0), err, 'throws if first arg is a falsey number')
@@ -55,7 +55,7 @@ test('maybeToList with Maybe returning function', t => {
 
   const f = bindFunc(maybeToList(identity))
 
-  const err = /maybeToList: Argument must be a Maybe instanstace or a Maybe returning function/
+  const err = /maybeToList: Argument must be a Maybe instance or a Maybe returning function/
   t.throws(f(undefined), err, 'throws if function returns undefined')
   t.throws(f(null), err, 'throws if function returns null')
   t.throws(f(0), err, 'throws if function returns a falsey number')

--- a/src/Maybe/maybeToArray.js
+++ b/src/Maybe/maybeToArray.js
@@ -11,7 +11,7 @@ const applyTransform = maybe =>
   maybe.either(() => [], x => [ x ])
 
 const err =
-  'maybeToArray: Argument must be a Maybe instanstace or a Maybe returning function'
+  'maybeToArray: Argument must be a Maybe instance or a Maybe returning function'
 
 function maybeToArray(maybe) {
   if(isFunction(maybe)) {

--- a/src/Maybe/maybeToArray.spec.js
+++ b/src/Maybe/maybeToArray.spec.js
@@ -17,7 +17,7 @@ test('maybeToArray transform', t => {
 
   t.ok(isFunction(maybeToArray), 'is a function')
 
-  const err = /maybeToArray: Argument must be a Maybe instanstace or a Maybe returning function/
+  const err = /maybeToArray: Argument must be a Maybe instance or a Maybe returning function/
   t.throws(f(undefined), err, 'throws if second arg is undefined')
   t.throws(f(null), err, 'throws if second arg is null')
   t.throws(f(0), err, 'throws if second arg is a falsey number')
@@ -54,7 +54,7 @@ test('maybeToArray with Maybe returning function', t => {
 
   const f = bindFunc(maybeToArray(identity))
 
-  const err = /maybeToArray: Argument must be a Maybe instanstace or a Maybe returning function/
+  const err = /maybeToArray: Argument must be a Maybe instance or a Maybe returning function/
   t.throws(f(undefined), err, 'throws if function returns undefined')
   t.throws(f(null), err, 'throws if function returns null')
   t.throws(f(0), err, 'throws if function returns a falsey number')


### PR DESCRIPTION
Fix typos in error messages for `maybeToList` and `maybeToArray` functions